### PR TITLE
added support for comparison samplers (DirectX only)

### DIFF
--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -280,7 +280,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 var desc = new SharpDX.Direct3D11.DepthStencilStateDescription();
 
                 desc.IsDepthEnabled = DepthBufferEnable;
-                desc.DepthComparison = SharpDXHelper.ToComparisson(DepthBufferFunction);
+                desc.DepthComparison = SharpDXHelper.ToComparison(DepthBufferFunction);
 
                 if (DepthBufferWriteEnable)
                     desc.DepthWriteMask = SharpDX.Direct3D11.DepthWriteMask.All;
@@ -293,20 +293,20 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 if (TwoSidedStencilMode)
                 {
-                    desc.BackFace.Comparison = SharpDXHelper.ToComparisson(CounterClockwiseStencilFunction);
+                    desc.BackFace.Comparison = SharpDXHelper.ToComparison(CounterClockwiseStencilFunction);
                     desc.BackFace.DepthFailOperation = GetStencilOp(CounterClockwiseStencilDepthBufferFail);
                     desc.BackFace.FailOperation = GetStencilOp(CounterClockwiseStencilFail);
                     desc.BackFace.PassOperation = GetStencilOp(CounterClockwiseStencilPass);
                 }
                 else
                 {   //use same settings as frontFace 
-                    desc.BackFace.Comparison = SharpDXHelper.ToComparisson(StencilFunction);
+                    desc.BackFace.Comparison = SharpDXHelper.ToComparison(StencilFunction);
                     desc.BackFace.DepthFailOperation = GetStencilOp(StencilDepthBufferFail);
                     desc.BackFace.FailOperation = GetStencilOp(StencilFail);
                     desc.BackFace.PassOperation = GetStencilOp(StencilPass);
                 }
 
-                desc.FrontFace.Comparison = SharpDXHelper.ToComparisson(StencilFunction);
+                desc.FrontFace.Comparison = SharpDXHelper.ToComparison(StencilFunction);
                 desc.FrontFace.DepthFailOperation = GetStencilOp(StencilDepthBufferFail);
                 desc.FrontFace.FailOperation = GetStencilOp(StencilFail);
                 desc.FrontFace.PassOperation = GetStencilOp(StencilPass);

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -280,7 +280,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 var desc = new SharpDX.Direct3D11.DepthStencilStateDescription();
 
                 desc.IsDepthEnabled = DepthBufferEnable;
-                desc.DepthComparison = GetComparison(DepthBufferFunction);
+                desc.DepthComparison = SharpDXHelper.ToComparisson(DepthBufferFunction);
 
                 if (DepthBufferWriteEnable)
                     desc.DepthWriteMask = SharpDX.Direct3D11.DepthWriteMask.All;
@@ -293,20 +293,20 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 if (TwoSidedStencilMode)
                 {
-                    desc.BackFace.Comparison = GetComparison(CounterClockwiseStencilFunction);
+                    desc.BackFace.Comparison = SharpDXHelper.ToComparisson(CounterClockwiseStencilFunction);
                     desc.BackFace.DepthFailOperation = GetStencilOp(CounterClockwiseStencilDepthBufferFail);
                     desc.BackFace.FailOperation = GetStencilOp(CounterClockwiseStencilFail);
                     desc.BackFace.PassOperation = GetStencilOp(CounterClockwiseStencilPass);
                 }
                 else
                 {   //use same settings as frontFace 
-                    desc.BackFace.Comparison = GetComparison(StencilFunction);
+                    desc.BackFace.Comparison = SharpDXHelper.ToComparisson(StencilFunction);
                     desc.BackFace.DepthFailOperation = GetStencilOp(StencilDepthBufferFail);
                     desc.BackFace.FailOperation = GetStencilOp(StencilFail);
                     desc.BackFace.PassOperation = GetStencilOp(StencilPass);
                 }
 
-                desc.FrontFace.Comparison = GetComparison(StencilFunction);
+                desc.FrontFace.Comparison = SharpDXHelper.ToComparisson(StencilFunction);
                 desc.FrontFace.DepthFailOperation = GetStencilOp(StencilDepthBufferFail);
                 desc.FrontFace.FailOperation = GetStencilOp(StencilFail);
                 desc.FrontFace.PassOperation = GetStencilOp(StencilPass);
@@ -329,39 +329,6 @@ namespace Microsoft.Xna.Framework.Graphics
             _default.Reset();
             _depthRead.Reset();
             _none.Reset();
-        }
-
-        static private SharpDX.Direct3D11.Comparison GetComparison( CompareFunction compare)
-        {
-            switch (compare)
-            {
-                case CompareFunction.Always:
-                    return SharpDX.Direct3D11.Comparison.Always;
-
-                case CompareFunction.Equal:
-                    return SharpDX.Direct3D11.Comparison.Equal;
-
-                case CompareFunction.Greater:
-                    return SharpDX.Direct3D11.Comparison.Greater;
-
-                case CompareFunction.GreaterEqual:
-                    return SharpDX.Direct3D11.Comparison.GreaterEqual;
-
-                case CompareFunction.Less:
-                    return SharpDX.Direct3D11.Comparison.Less;
-
-                case CompareFunction.LessEqual:
-                    return SharpDX.Direct3D11.Comparison.LessEqual;
-
-                case CompareFunction.Never:
-                    return SharpDX.Direct3D11.Comparison.Never;
-
-                case CompareFunction.NotEqual:
-                    return SharpDX.Direct3D11.Comparison.NotEqual;
-
-                default:
-                    throw new ArgumentException("Invalid comparison!");
-            }
         }
 
         static private SharpDX.Direct3D11.StencilOperation GetStencilOp(StencilOperation op)

--- a/MonoGame.Framework/Graphics/States/SamplerState.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 // To support feature level 9.1 these must 
                 // be set to these exact values.
                 desc.MaximumLod = float.MaxValue;
-                desc.ComparisonFunction = SharpDXHelper.ToComparisson(CompareFunction);
+                desc.ComparisonFunction = SharpDXHelper.ToComparison(CompareFunction);
 
                 // Create the state.
                 _state = new SharpDX.Direct3D11.SamplerState(GraphicsDevice._d3dDevice, desc);
@@ -234,9 +234,9 @@ namespace Microsoft.Xna.Framework.Graphics
             return _state;
         }
 
-        private static SharpDX.Direct3D11.Filter GetFilter(TextureFilter filter, bool comparisson = false)
+        private static SharpDX.Direct3D11.Filter GetFilter(TextureFilter filter, bool comparison)
         {
-            if (comparisson)
+            if (comparison)
             {
                 switch (filter)
                 {

--- a/MonoGame.Framework/Graphics/States/SamplerState.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.cs
@@ -165,6 +165,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		public int MaxAnisotropy { get; set; }
 		public int MaxMipLevel { get; set; }
 		public float MipMapLevelOfDetailBias { get; set; }
+        public CompareFunction CompareFunction { get; set; }
 
         public SamplerState()
         {
@@ -175,6 +176,7 @@ namespace Microsoft.Xna.Framework.Graphics
             this.MaxAnisotropy = 4;
             this.MaxMipLevel = 0;
             this.MipMapLevelOfDetailBias = 0.0f;
+            this.CompareFunction = Graphics.CompareFunction.Never;
         }
     
 #if DIRECTX
@@ -210,7 +212,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 desc.AddressV = GetAddressMode(AddressV);
                 desc.AddressW = GetAddressMode(AddressW);
 
-                desc.Filter = GetFilter(Filter);
+                desc.Filter = GetFilter(Filter, CompareFunction != Graphics.CompareFunction.Never);
                 desc.MaximumAnisotropy = MaxAnisotropy;
                 desc.MipLodBias = MipMapLevelOfDetailBias;
 
@@ -221,7 +223,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 // To support feature level 9.1 these must 
                 // be set to these exact values.
                 desc.MaximumLod = float.MaxValue;
-                desc.ComparisonFunction = SharpDX.Direct3D11.Comparison.Never;
+                desc.ComparisonFunction = SharpDXHelper.ToComparisson(CompareFunction);
 
                 // Create the state.
                 _state = new SharpDX.Direct3D11.SamplerState(GraphicsDevice._d3dDevice, desc);
@@ -232,39 +234,76 @@ namespace Microsoft.Xna.Framework.Graphics
             return _state;
         }
 
-        private static SharpDX.Direct3D11.Filter GetFilter(TextureFilter filter)
+        private static SharpDX.Direct3D11.Filter GetFilter(TextureFilter filter, bool comparisson = false)
         {
-            switch (filter)
+            if (comparisson)
             {
-                case TextureFilter.Anisotropic:
-                    return SharpDX.Direct3D11.Filter.Anisotropic;
+                switch (filter)
+                {
+                    case TextureFilter.Anisotropic:
+                        return SharpDX.Direct3D11.Filter.ComparisonAnisotropic;
 
-                case TextureFilter.Linear:
-                    return SharpDX.Direct3D11.Filter.MinMagMipLinear;
+                    case TextureFilter.Linear:
+                        return SharpDX.Direct3D11.Filter.ComparisonMinMagMipLinear;
 
-                case TextureFilter.LinearMipPoint:
-                    return SharpDX.Direct3D11.Filter.MinMagLinearMipPoint;
+                    case TextureFilter.LinearMipPoint:
+                        return SharpDX.Direct3D11.Filter.ComparisonMinMagLinearMipPoint;
 
-                case TextureFilter.MinLinearMagPointMipLinear:
-                    return SharpDX.Direct3D11.Filter.MinLinearMagPointMipLinear;
+                    case TextureFilter.MinLinearMagPointMipLinear:
+                        return SharpDX.Direct3D11.Filter.ComparisonMinLinearMagPointMipLinear;
 
-                case TextureFilter.MinLinearMagPointMipPoint:
-                    return SharpDX.Direct3D11.Filter.MinLinearMagMipPoint;
+                    case TextureFilter.MinLinearMagPointMipPoint:
+                        return SharpDX.Direct3D11.Filter.ComparisonMinLinearMagMipPoint;
 
-                case TextureFilter.MinPointMagLinearMipLinear:
-                    return SharpDX.Direct3D11.Filter.MinPointMagMipLinear;
+                    case TextureFilter.MinPointMagLinearMipLinear:
+                        return SharpDX.Direct3D11.Filter.ComparisonMinPointMagMipLinear;
 
-                case TextureFilter.MinPointMagLinearMipPoint:
-                    return SharpDX.Direct3D11.Filter.MinPointMagLinearMipPoint;
+                    case TextureFilter.MinPointMagLinearMipPoint:
+                        return SharpDX.Direct3D11.Filter.ComparisonMinPointMagLinearMipPoint;
 
-                case TextureFilter.Point:
-                    return SharpDX.Direct3D11.Filter.MinMagMipPoint;
+                    case TextureFilter.Point:
+                        return SharpDX.Direct3D11.Filter.ComparisonMinMagMipPoint;
 
-                case TextureFilter.PointMipLinear:
-                    return SharpDX.Direct3D11.Filter.MinMagPointMipLinear;
+                    case TextureFilter.PointMipLinear:
+                        return SharpDX.Direct3D11.Filter.ComparisonMinMagPointMipLinear;
+                    default:
+                        throw new ArgumentException("Invalid texture filter!");
+                }
+            }
+            else
+            {
+                switch (filter)
+                {
+                    case TextureFilter.Anisotropic:
+                        return SharpDX.Direct3D11.Filter.Anisotropic;
 
-                default:
-                    throw new ArgumentException("Invalid texture filter!");
+                    case TextureFilter.Linear:
+                        return SharpDX.Direct3D11.Filter.MinMagMipLinear;
+
+                    case TextureFilter.LinearMipPoint:
+                        return SharpDX.Direct3D11.Filter.MinMagLinearMipPoint;
+
+                    case TextureFilter.MinLinearMagPointMipLinear:
+                        return SharpDX.Direct3D11.Filter.MinLinearMagPointMipLinear;
+
+                    case TextureFilter.MinLinearMagPointMipPoint:
+                        return SharpDX.Direct3D11.Filter.MinLinearMagMipPoint;
+
+                    case TextureFilter.MinPointMagLinearMipLinear:
+                        return SharpDX.Direct3D11.Filter.MinPointMagMipLinear;
+
+                    case TextureFilter.MinPointMagLinearMipPoint:
+                        return SharpDX.Direct3D11.Filter.MinPointMagLinearMipPoint;
+
+                    case TextureFilter.Point:
+                        return SharpDX.Direct3D11.Filter.MinMagMipPoint;
+
+                    case TextureFilter.PointMipLinear:
+                        return SharpDX.Direct3D11.Filter.MinMagPointMipLinear;
+
+                    default:
+                        throw new ArgumentException("Invalid texture filter!");
+                }
             }
         }
 

--- a/MonoGame.Framework/Windows8/SharpDXHelper.cs
+++ b/MonoGame.Framework/Windows8/SharpDXHelper.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Xna.Framework
             };
         }
 
-        static public SharpDX.Direct3D11.Comparison ToComparisson(CompareFunction compare)
+        static public SharpDX.Direct3D11.Comparison ToComparison(CompareFunction compare)
         {
             switch (compare)
             {

--- a/MonoGame.Framework/Windows8/SharpDXHelper.cs
+++ b/MonoGame.Framework/Windows8/SharpDXHelper.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using System;
+
 namespace Microsoft.Xna.Framework
 {
     using Microsoft.Xna.Framework.Graphics;
@@ -195,6 +196,39 @@ namespace Microsoft.Xna.Framework
                 OrientFront = new SharpDX.Vector3(forward.X, forward.Y, forward.Z),
                 OrientTop = new SharpDX.Vector3(up.X, up.Y, up.Z),                
             };
+        }
+
+        static public SharpDX.Direct3D11.Comparison ToComparisson(CompareFunction compare)
+        {
+            switch (compare)
+            {
+                case CompareFunction.Always:
+                    return SharpDX.Direct3D11.Comparison.Always;
+
+                case CompareFunction.Equal:
+                    return SharpDX.Direct3D11.Comparison.Equal;
+
+                case CompareFunction.Greater:
+                    return SharpDX.Direct3D11.Comparison.Greater;
+
+                case CompareFunction.GreaterEqual:
+                    return SharpDX.Direct3D11.Comparison.GreaterEqual;
+
+                case CompareFunction.Less:
+                    return SharpDX.Direct3D11.Comparison.Less;
+
+                case CompareFunction.LessEqual:
+                    return SharpDX.Direct3D11.Comparison.LessEqual;
+
+                case CompareFunction.Never:
+                    return SharpDX.Direct3D11.Comparison.Never;
+
+                case CompareFunction.NotEqual:
+                    return SharpDX.Direct3D11.Comparison.NotEqual;
+
+                default:
+                    throw new ArgumentException("Invalid comparison!");
+            }
         }
     }
 }


### PR DESCRIPTION
Comparison samplers allows to use SampleCmp methods in HLSL. For example, this feature can be really useful when implementing shadow mapping.

Also moved ToComparisson method to SharpDXHelper, so it might be reused in several places.