### PR TITLE
Fixing issue #2236 in WindowsGL

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -139,9 +139,13 @@ namespace Microsoft.Xna.Framework
         }
 #endif
 
+        //IsActive is set to true here to avoid firing deactivated events early.
+        //The only other possible method for WindowsGL to fire instead of this one
+        //is StartRunLoop, which just throws a NotSupportedException.
         public override void RunLoop()
         {
             ResetWindowBounds(false);
+            IsActive = true;
             _view.Window.Run(0);
         }
 

--- a/MonoGame.Framework/GamePlatform.cs
+++ b/MonoGame.Framework/GamePlatform.cs
@@ -275,13 +275,11 @@ namespace Microsoft.Xna.Framework
 
         /// <summary>
         /// Gives derived classes an opportunity to do work before any
-        /// components are initialized.  Note that the base implementation sets
-        /// IsActive to true, so derived classes should either call the base
-        /// implementation or set IsActive to true by their own means.
+        /// components are initialized.  IsActive is set to true after initialization
+        /// (see OpenTKGamePlatform in RunLoop)
         /// </summary>
         public virtual void BeforeInitialize()
         {
-            IsActive = true;
             if (this.Game.GraphicsDevice == null) 
             {
                 var graphicsDeviceManager = Game.Services.GetService(typeof(IGraphicsDeviceManager)) as IGraphicsDeviceManager;			   


### PR DESCRIPTION
	GamePlatform.cs
	Line 284: Removed IsActive = true;

	OpenTKGamePlatform.cs
	Line 145: Runloop - added IsActive = true;

Fixes issue #2236 - Game Deactivate fired during startup.
Makes IsActive only get set to true after initialization when the game actually becomes active.

Signed-off-by: Daniel Shumway <shumway.danny@gmail.com>