### PR TITLE
Issue2612 bugfix

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
-
+using Microsoft.Xna.Framework.Utilities;
 using SharpDX;
 using SharpDX.Direct3D;
 
@@ -145,13 +145,15 @@ namespace Microsoft.Xna.Framework.Graphics
         private void UpdateDevice(Device device, DeviceContext context)
         {
             // TODO: Lost device logic!
-            SharpDX.Utilities.Dispose(ref _d3dDevice);
+
+            SharpDxDisposeHelper.SafeDispose(ref _d3dDevice);
             _d3dDevice = device;
 
-            SharpDX.Utilities.Dispose(ref _d3dContext);
+            // looks like this line solves lost device issues at least on windows phone 8.1
+            SharpDxDisposeHelper.SafeDispose(ref _d3dContext);
             _d3dContext = context;
 
-            SharpDX.Utilities.Dispose(ref _depthStencilView);
+            SharpDxDisposeHelper.SafeDispose(ref _depthStencilView);
 
             using (var dxgiDevice2 = device.QueryInterface<SharpDX.DXGI.Device2>())
             {

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -780,10 +780,10 @@ namespace Microsoft.Xna.Framework.Graphics
         private void PlatformDispose()
         {
             ClearLayouts();
-            SharpDX.Utilities.Dispose(ref _renderTargetView);
-            SharpDX.Utilities.Dispose(ref _depthStencilView);
-            SharpDX.Utilities.Dispose(ref _d3dDevice);
-            SharpDX.Utilities.Dispose(ref _d3dContext);
+            Utilities.SharpDxDisposeHelper.SafeDispose(ref _renderTargetView);
+            Utilities.SharpDxDisposeHelper.SafeDispose(ref _depthStencilView);
+            Utilities.SharpDxDisposeHelper.SafeDispose(ref _d3dDevice);
+            Utilities.SharpDxDisposeHelper.SafeDispose(ref _d3dContext);
 
 #if WINDOWS_STOREAPP
 

--- a/MonoGame.Framework/Graphics/RenderTarget2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.DirectX.cs
@@ -63,16 +63,16 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformGraphicsDeviceResetting()
         {
-            SharpDX.Utilities.Dispose(ref _renderTargetView);
-            SharpDX.Utilities.Dispose(ref _depthStencilView);
+            Utilities.SharpDxDisposeHelper.SafeDispose(ref _renderTargetView);
+            Utilities.SharpDxDisposeHelper.SafeDispose(ref _depthStencilView);
         }
 
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
-                SharpDX.Utilities.Dispose(ref _renderTargetView);
-                SharpDX.Utilities.Dispose(ref _depthStencilView);
+                Utilities.SharpDxDisposeHelper.SafeDispose(ref _renderTargetView);
+                Utilities.SharpDxDisposeHelper.SafeDispose(ref _depthStencilView);
             }
 
             base.Dispose(disposing);

--- a/MonoGame.Framework/Graphics/RenderTarget3D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget3D.DirectX.cs
@@ -51,8 +51,8 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (disposing)
             {
-                SharpDX.Utilities.Dispose(ref _renderTargetView);
-                SharpDX.Utilities.Dispose(ref _depthStencilView);
+                Utilities.SharpDxDisposeHelper.SafeDispose(ref _renderTargetView);
+                Utilities.SharpDxDisposeHelper.SafeDispose(ref _depthStencilView);
             }
 
             base.Dispose(disposing);

--- a/MonoGame.Framework/Graphics/RenderTargetCube.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Xna.Framework.Graphics
                         _renderTargetViews[i].Dispose();
 
                     _renderTargetViews = null;
-                    SharpDX.Utilities.Dispose(ref _depthStencilView);
+                    Utilities.SharpDxDisposeHelper.SafeDispose(ref _depthStencilView);
                 }
 #endif
             }

--- a/MonoGame.Framework/Graphics/Shader/ConstantBuffer.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Shader/ConstantBuffer.DirectX.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformClear()
         {
-            SharpDX.Utilities.Dispose(ref _cbuffer);
+            Utilities.SharpDxDisposeHelper.SafeDispose(ref _cbuffer);
             _dirty = true;
         }
 
@@ -53,7 +53,7 @@ namespace Microsoft.Xna.Framework.Graphics
         protected override void Dispose(bool disposing)
         {
             if (disposing)
-                SharpDX.Utilities.Dispose(ref _cbuffer);
+                Utilities.SharpDxDisposeHelper.SafeDispose(ref _cbuffer);
             base.Dispose(disposing);
         }
     }

--- a/MonoGame.Framework/Graphics/Shader/Shader.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Shader/Shader.DirectX.cs
@@ -54,16 +54,16 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformGraphicsDeviceResetting()
         {
-            SharpDX.Utilities.Dispose(ref _vertexShader);
-            SharpDX.Utilities.Dispose(ref _pixelShader);
+            Utilities.SharpDxDisposeHelper.SafeDispose(ref _vertexShader);
+            Utilities.SharpDxDisposeHelper.SafeDispose(ref _pixelShader);
         }
 
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
-                SharpDX.Utilities.Dispose(ref _vertexShader);
-                SharpDX.Utilities.Dispose(ref _pixelShader);
+                Utilities.SharpDxDisposeHelper.SafeDispose(ref _vertexShader);
+                Utilities.SharpDxDisposeHelper.SafeDispose(ref _pixelShader);
             }
 
             base.Dispose(disposing);

--- a/MonoGame.Framework/Graphics/States/BlendState.DirectX.cs
+++ b/MonoGame.Framework/Graphics/States/BlendState.DirectX.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         protected internal override void GraphicsDeviceResetting()
         {
-            SharpDX.Utilities.Dispose(ref _state);
+            Utilities.SharpDxDisposeHelper.SafeDispose(ref _state);
             base.GraphicsDeviceResetting();
         }
 
@@ -53,7 +53,7 @@ namespace Microsoft.Xna.Framework.Graphics
         protected override void Dispose(bool disposing)
         {
             if (disposing)
-                SharpDX.Utilities.Dispose(ref _state);
+                Utilities.SharpDxDisposeHelper.SafeDispose(ref _state);
             base.Dispose(disposing);
         }
     }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.DirectX.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.DirectX.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         protected internal override void GraphicsDeviceResetting()
         {
-            SharpDX.Utilities.Dispose(ref _state);
+            Utilities.SharpDxDisposeHelper.SafeDispose(ref _state);
             base.GraphicsDeviceResetting();
         }
 
@@ -142,7 +142,7 @@ namespace Microsoft.Xna.Framework.Graphics
         protected override void Dispose(bool disposing)
         {
             if (disposing)
-                SharpDX.Utilities.Dispose(ref _state);
+                Utilities.SharpDxDisposeHelper.SafeDispose(ref _state);
             base.Dispose(disposing);
         }
     }

--- a/MonoGame.Framework/Graphics/States/RasterizerState.DirectX.cs
+++ b/MonoGame.Framework/Graphics/States/RasterizerState.DirectX.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         protected internal override void GraphicsDeviceResetting()
         {
-            SharpDX.Utilities.Dispose(ref _state);
+            Utilities.SharpDxDisposeHelper.SafeDispose(ref _state);
             base.GraphicsDeviceResetting();
         }
 
@@ -78,7 +78,7 @@ namespace Microsoft.Xna.Framework.Graphics
         protected override void Dispose(bool disposing)
         {
             if (disposing)
-                SharpDX.Utilities.Dispose(ref _state);
+                Utilities.SharpDxDisposeHelper.SafeDispose(ref _state);
             base.Dispose(disposing);
         }
     }

--- a/MonoGame.Framework/Graphics/States/SamplerState.DirectX.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.DirectX.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         protected internal override void GraphicsDeviceResetting()
         {
-            SharpDX.Utilities.Dispose(ref _state);
+            Utilities.SharpDxDisposeHelper.SafeDispose(ref _state);
             base.GraphicsDeviceResetting();
         }
 
@@ -111,7 +111,7 @@ namespace Microsoft.Xna.Framework.Graphics
         protected override void Dispose(bool disposing)
         {
             if (disposing)
-                SharpDX.Utilities.Dispose(ref _state);
+                Utilities.SharpDxDisposeHelper.SafeDispose(ref _state);
             base.Dispose(disposing);
         }
     }

--- a/MonoGame.Framework/Graphics/Texture.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture.DirectX.cs
@@ -45,16 +45,16 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformGraphicsDeviceResetting()
         {
-            SharpDX.Utilities.Dispose(ref _resourceView);
-            SharpDX.Utilities.Dispose(ref _texture);
+            Utilities.SharpDxDisposeHelper.SafeDispose(ref _resourceView);
+            Utilities.SharpDxDisposeHelper.SafeDispose(ref _texture);
         }
 
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
-                SharpDX.Utilities.Dispose(ref _resourceView);
-                SharpDX.Utilities.Dispose(ref _texture);
+                Utilities.SharpDxDisposeHelper.SafeDispose(ref _resourceView);
+                Utilities.SharpDxDisposeHelper.SafeDispose(ref _texture);
             }
 
             base.Dispose(disposing);

--- a/MonoGame.Framework/Graphics/Vertices/IndexBuffer.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Vertices/IndexBuffer.DirectX.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformGraphicsDeviceResetting()
         {
-            SharpDX.Utilities.Dispose(ref _buffer);
+            Utilities.SharpDxDisposeHelper.SafeDispose(ref _buffer);
         }
 
         void GenerateIfRequired()
@@ -153,7 +153,7 @@ namespace Microsoft.Xna.Framework.Graphics
         protected override void Dispose(bool disposing)
         {
             if (disposing)
-                SharpDX.Utilities.Dispose(ref _buffer);
+                Utilities.SharpDxDisposeHelper.SafeDispose(ref _buffer);
 
             base.Dispose(disposing);
         }

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.DirectX.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private void PlatformGraphicsDeviceResetting()
         {
             _binding = new SharpDX.Direct3D11.VertexBufferBinding();
-            SharpDX.Utilities.Dispose(ref _buffer);
+            Utilities.SharpDxDisposeHelper.SafeDispose(ref _buffer);
         }
 
         void GenerateIfRequired()
@@ -161,7 +161,7 @@ namespace Microsoft.Xna.Framework.Graphics
         protected override void Dispose(bool disposing)
         {
             if (disposing)
-                SharpDX.Utilities.Dispose(ref _buffer);
+                Utilities.SharpDxDisposeHelper.SafeDispose(ref _buffer);
 
             base.Dispose(disposing);
         }

--- a/MonoGame.Framework/Utilities/SharpDxDisposeHelper.cs
+++ b/MonoGame.Framework/Utilities/SharpDxDisposeHelper.cs
@@ -1,15 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using SharpDX;
 
 namespace Microsoft.Xna.Framework.Utilities
 {
     public static class SharpDxDisposeHelper
     {
-        public static void SafeDispose<T>(ref T comObject) where T : CppObject
+        public static void SafeDispose<T>(ref T comObject) where T : SharpDX.CppObject
         {
             // seems like SharpDX.Utilities.Dispose is not such safe dispose
             // -> can throw NullReferenceException if NativePointer is nullptr

--- a/MonoGame.Framework/Utilities/SharpDxDisposeHelper.cs
+++ b/MonoGame.Framework/Utilities/SharpDxDisposeHelper.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SharpDX;
+
+namespace Microsoft.Xna.Framework.Utilities
+{
+    public static class SharpDxDisposeHelper
+    {
+        public static void SafeDispose<T>(ref T comObject) where T : CppObject
+        {
+            // seems like SharpDX.Utilities.Dispose is not such safe dispose
+            // -> can throw NullReferenceException if NativePointer is nullptr
+            // -> example: .Dispose(_d3dContext)
+            if (comObject != null && comObject.NativePointer != IntPtr.Zero)
+                SharpDX.Utilities.Dispose(ref comObject);
+
+            comObject = null;
+        }
+    }
+}

--- a/MonoGame.Framework/WindowsPhone/DrawingSurfaceUpdateHandler.cs
+++ b/MonoGame.Framework/WindowsPhone/DrawingSurfaceUpdateHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Windows;
 using System.Threading;
+using Microsoft.Xna.Framework.Utilities;
 using SharpDX;
 using SharpDX.Direct3D11;
 
@@ -108,7 +109,7 @@ namespace MonoGame.Framework.WindowsPhone
             {
                 _surfaceUpdateHandler.Disconnect();
                 _host = null;
-                SharpDX.Utilities.Dispose(ref _synchronizedTexture);
+                SharpDxDisposeHelper.SafeDispose(ref _synchronizedTexture);
                 _drawingSurfaceUpdateHandler.DisposeResources();
             }
 


### PR DESCRIPTION
https://github.com/mono/MonoGame/issues/2612

Looks like it fix crashes after restart (deacitvation/activation) on windows phone.

edit: To simulate crash debug on device (didn't test on emulator), set breakpoint in GraphicsDevice.DirectX.UpdateDevice(..,..), go back to home screen and back to game few times ( should crash after SharpDx.Dispose(ref _d3dContext) )