### PR TITLE
Render faster if possible on fixed time step

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -473,12 +473,25 @@ namespace Microsoft.Xna.Framework
                 // NOTE: While sleep can be inaccurate in general it is 
                 // accurate enough for frame limiting purposes if some
                 // fluctuation is an acceptable result.
+                if (graphicsDeviceManager.SynchronizeWithVerticalRetrace)
+                {
+                    // NOTE: While sleep can be inaccurate in general it is 
+                    // accurate enough for frame limiting purposes if some
+                    // fluctuation is an acceptable result.
 #if WINRT
-                Task.Delay(sleepTime).Wait();
+                    Task.Delay(sleepTime).Wait();
 #else
-                System.Threading.Thread.Sleep(sleepTime);
+                    System.Threading.Thread.Sleep(sleepTime);
 #endif
-                goto RetryTick;
+                    goto RetryTick;
+                }
+                else
+                {
+                    // Draw until we have used up our time.
+                    DoDraw(_gameTime);
+
+                    goto RetryTick;
+                }
             }
 
             // Do not allow any update to take longer than our maximum.


### PR DESCRIPTION
Currently when MonoGame is using a fixed time step, it won't ever render faster than 60FPS, despite the GPUs capability to do so.

This modifies the tick so that if SynchronizeWithVerticalRetrace is off, it will continue to render frames until the time is used up (instead of sleeping).

This is useful for diagnosing whether rendering is responsible for causing slow frames by giving an accurate representation of how fast the current frame can be rendered.