### PR TITLE
GraphicsDeviceManager.ApplyChanges changing window size.

### DIFF
--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -275,7 +275,7 @@ namespace Microsoft.Xna.Framework
             _graphicsDevice.CreateSizeDependentResources();
             _graphicsDevice.ApplyRenderTargets(null);
 
-            ((MonoGame.Framework.WinFormsGamePlatform)_game.Platform).ResetWindowBounds();
+            //((MonoGame.Framework.WinFormsGamePlatform)_game.Platform).ResetWindowBounds();
 
 #elif WINDOWS || LINUX
             ((OpenTKGamePlatform)_game.Platform).ResetWindowBounds();


### PR DESCRIPTION
GraphicsDeviceManager.ApplyChanges should not be triggering the window to resize, this is only a backbuffer resize operation.

In standard XNA one can hook into Window.OnClientBoundsChanged and initiate a backbuffer resize with GraphicsDeviceManager.ApplyChanges. But in MonoGame this triggers an infinite loop do to this line.
