### PR TITLE
MacOS: use common OpenGL/AL codepath (1/2)

### DIFF
--- a/Build/Projects/FrameworkReferences.definition
+++ b/Build/Projects/FrameworkReferences.definition
@@ -23,6 +23,9 @@
     <Binary
       Name="Tao.Sdl"
       Path="ThirdParty/GamepadConfig/Tao.Sdl.dll" />
+    <Binary
+      Name="OpenTK"
+      Path="ThirdParty/Dependencies/OpenTK.dll" />
   </Platform>
 
   <Platform Type="Android">

--- a/MonoGame.Framework/Audio/OALSoundBuffer.cs
+++ b/MonoGame.Framework/Audio/OALSoundBuffer.cs
@@ -3,12 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-
-#if MONOMAC
-using MonoMac.OpenAL;
-#else
 using OpenTK.Audio.OpenAL;
-#endif
 
 namespace Microsoft.Xna.Framework.Audio
 {

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -4,12 +4,8 @@ using System.Linq;
 using System.IO;
 using System.Runtime.InteropServices;
 
-#if MONOMAC
-using MonoMac.OpenAL;
-#else
 using OpenTK.Audio.OpenAL;
 using OpenTK;
-#endif
 
 #if ANDROID
 using System.Globalization;

--- a/MonoGame.Framework/Audio/OpenALSupport.cs
+++ b/MonoGame.Framework/Audio/OpenALSupport.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using OpenTK.Audio.OpenAL;
 
 #if IOS
 using MonoTouch.UIKit;
@@ -7,19 +8,12 @@ using MonoTouch.Foundation;
 using MonoTouch.CoreFoundation;
 using MonoTouch.AudioToolbox;
 using MonoTouch.AudioUnit;
-
-using OpenTK.Audio.OpenAL;
-
 #elif MONOMAC
-
 using MonoMac.AppKit;
 using MonoMac.Foundation;
 using MonoMac.CoreFoundation;
 using MonoMac.AudioToolbox;
 using MonoMac.AudioUnit;
-
-using MonoMac.OpenAL;
-
 #endif
 
 namespace Microsoft.Xna.Framework.Audio

--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -4,21 +4,18 @@
 ﻿
 using System;
 using System.IO;
+using OpenTK.Audio.OpenAL;
 
 #if MONOMAC
 using MonoMac.AudioToolbox;
 using MonoMac.AudioUnit;
 using MonoMac.AVFoundation;
 using MonoMac.Foundation;
-using MonoMac.OpenAL;
-#elif OPENAL
-using OpenTK.Audio.OpenAL;
-#if IOS
+#elif IOS
 using MonoTouch.AudioToolbox;
 using MonoTouch.AudioUnit;
 using MonoTouch.AVFoundation;
 using MonoTouch.Foundation;
-#endif
 #endif
 
 namespace Microsoft.Xna.Framework.Audio

--- a/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
@@ -3,12 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-
-#if MONOMAC
-using MonoMac.OpenAL;
-#elif OPENAL
 using OpenTK.Audio.OpenAL;
-#endif
 
 namespace Microsoft.Xna.Framework.Audio
 {

--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
@@ -4,14 +4,10 @@
 
 using System;
 using System.Collections.Generic;
-#if OPENGL
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif GLES
+#if GLES
 using OpenTK.Graphics.ES20;
-#else
+#elif OPENGL
 using OpenTK.Graphics.OpenGL;
-#endif
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.FramebufferHelper.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.FramebufferHelper.cs
@@ -9,12 +9,7 @@ using System.Text;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
-#if MONOMAC
-using MonoMac;
-using MonoMac.OpenGL;
-#endif
-
-#if (WINDOWS || LINUX) && !GLES
+#if OPENGL && !GLES
 using OpenTK.Graphics.OpenGL;
 
 #endif
@@ -258,17 +253,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
             public bool SupportsBlitFramebuffer { get; private set; }
 
-#if MONOMAC
-			[DllImport(Constants.OpenGLLibrary, EntryPoint = "glRenderbufferStorageMultisampleEXT")]
-		    internal extern static void GLRenderbufferStorageMultisampleExt(All target, int samples, All internalformat, int width, int height);
-
-			[DllImport(Constants.OpenGLLibrary, EntryPoint = "glBlitFramebufferEXT")]
-			internal extern static void GLBlitFramebufferExt(int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, ClearBufferMask mask, BlitFramebufferFilter filter);
-
-			[DllImport(Constants.OpenGLLibrary, EntryPoint = "glGenerateMipmapEXT")]
-			internal extern static void GLGenerateMipmapExt(GenerateMipmapTarget target);
-#endif
-
             internal FramebufferHelper(GraphicsDevice graphicsDevice)
             {
                 this.SupportsBlitFramebuffer = true;
@@ -295,11 +279,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             internal virtual void RenderbufferStorageMultisample(int samples, int internalFormat, int width, int height)
             {
-#if !MONOMAC
                 GL.RenderbufferStorageMultisample(RenderbufferTarget.Renderbuffer, samples, (RenderbufferStorage)internalFormat, width, height);
-#else
-				GLRenderbufferStorageMultisampleExt(All.Renderbuffer, samples, (All)internalFormat, width, height);
-#endif
                 GraphicsExtensions.CheckGLError();
             }
 
@@ -351,11 +331,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             internal virtual void GenerateMipmap(int target)
             {
-#if !MONOMAC
                 GL.GenerateMipmap((GenerateMipmapTarget)target);
-#else
-				GLGenerateMipmapExt((GenerateMipmapTarget)target);
-#endif
                 GraphicsExtensions.CheckGLError();
 
             }
@@ -367,11 +343,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 GraphicsExtensions.CheckGLError();
                 GL.DrawBuffer(DrawBufferMode.ColorAttachment0 + iColorAttachment);
                 GraphicsExtensions.CheckGLError();
-#if !MONOMAC
                 GL.BlitFramebuffer(0, 0, width, height, 0, 0, width, height, ClearBufferMask.ColorBufferBit, BlitFramebufferFilter.Nearest);
-#else
-				GLBlitFramebufferExt(0, 0, width, height, 0, 0, width, height, ClearBufferMask.ColorBufferBit, BlitFramebufferFilter.Nearest);
-#endif
                 GraphicsExtensions.CheckGLError();
 
             }
@@ -394,7 +366,6 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
-#if !MONOMAC
         internal sealed class FramebufferHelperEXT : FramebufferHelper
         {
             internal FramebufferHelperEXT(GraphicsDevice graphicsDevice)
@@ -495,7 +466,6 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
             }
         }
-#endif
 #endif
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.FramebufferObject.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.FramebufferObject.cs
@@ -1,0 +1,113 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+#if GLES
+using OpenTK.Graphics.ES20;
+using FramebufferAttachment = OpenTK.Graphics.ES20.All;
+using FramebufferErrorCode = OpenTK.Graphics.ES20.All;
+using FramebufferTarget = OpenTK.Graphics.ES20.All;
+using RenderbufferTarget = OpenTK.Graphics.ES20.All;
+using TextureTarget = OpenTK.Graphics.ES20.All;
+#elif OPENGL
+using OpenTK.Graphics.OpenGL;
+#endif
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    // ARB_framebuffer_object implementation
+    partial class GraphicsDevice
+    {
+        internal class FramebufferObject
+        {
+            public virtual void Bind(FramebufferTarget target, int id)
+            {
+                GL.BindFramebuffer(target, id);
+                GraphicsExtensions.CheckGLError();
+            }
+
+            public virtual FramebufferErrorCode CheckStatus(FramebufferTarget target)
+            {
+                return (FramebufferErrorCode)GL.CheckFramebufferStatus(target);
+            }
+
+            public virtual void Delete(int id)
+            {
+                GL.DeleteFramebuffers(1, ref id);
+                GraphicsExtensions.CheckGLError();
+            }
+
+            public virtual int Generate()
+            {
+                int id = 0;
+#if IOS || ANDROID
+                GL.GenFramebuffers(1, ref id);
+#else
+                GL.GenFramebuffers(1, out id);
+#endif
+                GraphicsExtensions.CheckGLError();
+                return id;
+            }
+
+            public virtual void Renderbuffer(FramebufferTarget target, FramebufferAttachment attachment, RenderbufferTarget renderbufferTarget, int renderbuffer)
+            {
+                GL.FramebufferRenderbuffer(target, attachment, renderbufferTarget, renderbuffer);
+                GraphicsExtensions.CheckGLError();
+            }
+
+            public virtual void Texture2D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textureTarget, int texture, int level)
+            {
+                GL.FramebufferTexture2D(target, attachment, textureTarget, texture, level);
+                GraphicsExtensions.CheckGLError();
+            }
+        }
+
+#if !(GLES || MONOMAC)
+        // EXT_framebuffer_object implementation
+        internal sealed class FramebufferObjectEXT : FramebufferObject
+        {
+            public override void Bind(FramebufferTarget target, int id)
+            {
+                GL.Ext.BindFramebuffer(target, id);
+                GraphicsExtensions.CheckGLError();
+            }
+
+            public override FramebufferErrorCode CheckStatus(FramebufferTarget target)
+            {
+                return GL.Ext.CheckFramebufferStatus(target);
+            }
+
+            public override void Delete(int id)
+            {
+                GL.Ext.DeleteFramebuffers(1, ref id);
+                GraphicsExtensions.CheckGLError();
+            }
+
+            public override int Generate()
+            {
+                int id;
+                GL.Ext.GenFramebuffers(1, out id);
+                GraphicsExtensions.CheckGLError();
+                return id;
+            }
+
+            public override void Renderbuffer(FramebufferTarget target, FramebufferAttachment attachment, RenderbufferTarget renderbufferTarget, int renderbuffer)
+            {
+                GL.Ext.FramebufferRenderbuffer(target, attachment, renderbufferTarget, renderbuffer);
+                GraphicsExtensions.CheckGLError();
+            }
+
+            public override void Texture2D(FramebufferTarget target, FramebufferAttachment attachment, TextureTarget textureTarget, int texture, int level)
+            {
+                GL.Ext.FramebufferTexture2D(target, attachment, textureTarget, texture, level);
+                GraphicsExtensions.CheckGLError();
+            }
+        }
+#endif
+    }
+}

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.RenderbufferObject.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.RenderbufferObject.cs
@@ -1,0 +1,88 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+#if GLES
+using OpenTK.Graphics.ES20;
+using RenderbufferStorage = OpenTK.Graphics.ES20.All;
+using RenderbufferTarget = OpenTK.Graphics.ES20.All;
+#elif OPENGL
+using OpenTK.Graphics.OpenGL;
+#endif
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    // ARB_framebuffer_object implementation
+    partial class GraphicsDevice
+    {
+        internal class RenderbufferObject
+        {
+            public virtual void Bind(RenderbufferTarget target, int id)
+            {
+                GL.BindRenderbuffer(target, id);
+                GraphicsExtensions.CheckGLError();
+            }
+
+            public virtual void Delete(int id)
+            {
+                GL.DeleteRenderbuffers(1, ref id);
+                GraphicsExtensions.CheckGLError();
+            }
+
+            public virtual int Generate()
+            {
+                int id = 0;
+#if IOS || ANDROID
+                GL.GenRenderbuffers(1, ref id);
+#else
+                GL.GenRenderbuffers(1, out id);
+#endif
+                GraphicsExtensions.CheckGLError();
+                return id;
+            }
+
+            public virtual void Storage(RenderbufferTarget target, RenderbufferStorage internalFormat, int width, int height)
+            {
+                GL.RenderbufferStorage(target, internalFormat, width, height);
+                GraphicsExtensions.CheckGLError();
+            }
+        }
+
+#if !(GLES || MONOMAC)
+        // EXT_framebuffer_object implementation
+        internal sealed class RenderbufferObjectEXT : RenderbufferObject
+        {
+            public override void Bind(RenderbufferTarget target, int id)
+            {
+                GL.Ext.BindRenderbuffer(target, id);
+                GraphicsExtensions.CheckGLError();
+            }
+
+            public override void Delete(int id)
+            {
+                GL.Ext.DeleteRenderbuffers(1, ref id);
+                GraphicsExtensions.CheckGLError();
+            }
+
+            public override int Generate()
+            {
+                int id;
+                GL.Ext.GenRenderbuffers(1, out id);
+                GraphicsExtensions.CheckGLError();
+                return id;
+            }
+
+            public override void Storage(RenderbufferTarget target, RenderbufferStorage internalFormat, int width, int height)
+            {
+                GL.Ext.RenderbufferStorage(target, internalFormat, width, height);
+                GraphicsExtensions.CheckGLError();
+            }
+        }
+#endif
+    }
+}

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -42,6 +42,11 @@ namespace Microsoft.Xna.Framework.Graphics
 #if WINDOWS || LINUX || ANGLE
         internal IGraphicsContext Context { get; private set; }
 #endif
+#if MONOMAC
+        // In this case, the OpenGL context is constructed and managed by
+        // MonoMacGameView. We need to register that context with OpenTK.
+        IGraphicsContext Context { get; set; }
+#endif
 
 #if !GLES
         private DrawBuffersEnum[] _drawBuffers;
@@ -181,6 +186,13 @@ namespace Microsoft.Xna.Framework.Graphics
                 Threading.BackgroundContext.MakeCurrent(null);
             }
             Context.MakeCurrent(wnd);
+#elif MONOMAC
+            // Register the MonoMac OpenGL context with OpenTK.
+            // This will initialize the OpenTK GL bindings.
+            OpenTK.Toolkit.Init();
+            Context = new GraphicsContext(
+                OpenTK.ContextHandle.Zero, // use current context
+                null);
 #endif
 
             MaxTextureSlots = 16;

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -7,22 +7,12 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-using GLPrimitiveType = MonoMac.OpenGL.BeginMode;
-#endif
-
-#if WINDOWS || LINUX
-using OpenTK.Graphics;
-using OpenTK.Graphics.OpenGL;
-using GLPrimitiveType = OpenTK.Graphics.OpenGL.PrimitiveType;
-#endif
-
-#if ANGLE
-using OpenTK.Graphics;
-#endif
 
 #if GLES
+#if ANGLE
+using OpenTK.Graphics;
+using OpenTK.Graphics.ES20;
+#else
 using OpenTK.Graphics.ES20;
 using BeginMode = OpenTK.Graphics.ES20.All;
 using EnableCap = OpenTK.Graphics.ES20.All;
@@ -37,6 +27,11 @@ using FramebufferAttachment = OpenTK.Graphics.ES20.All;
 using RenderbufferTarget = OpenTK.Graphics.ES20.All;
 using RenderbufferStorage = OpenTK.Graphics.ES20.All;
 using GLPrimitiveType = OpenTK.Graphics.ES20.All;
+#endif
+#elif OPENGL
+using OpenTK.Graphics;
+using OpenTK.Graphics.OpenGL;
+using GLPrimitiveType = OpenTK.Graphics.OpenGL.PrimitiveType;
 #endif
 
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -272,7 +272,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 this.framebufferHelper = new FramebufferHelper(this);
             }
-            #if !(GLES || MONOMAC)
+            #if !GLES
             else if (GraphicsCapabilities.SupportsFramebufferObjectEXT)
             {
                 this.framebufferHelper = new FramebufferHelperEXT(this);

--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -1,16 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
 
-#if OPENGL
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
-using OpenTK.Graphics;
-using OpenTK.Graphics.OpenGL;
-#elif GLES
 #if ANGLE
 using OpenTK.Graphics;
-#endif
+#elif GLES
 using OpenTK.Graphics.ES20;
 using BlendEquationMode = OpenTK.Graphics.ES20.All;
 using BlendingFactorSrc = OpenTK.Graphics.ES20.All;
@@ -24,7 +17,9 @@ using ColorPointerType = OpenTK.Graphics.ES20.All;
 using NormalPointerType = OpenTK.Graphics.ES20.All;
 using TexCoordPointerType = OpenTK.Graphics.ES20.All;
 using GetPName = OpenTK.Graphics.ES20.All;
-#endif
+#elif OPENGL
+using OpenTK.Graphics;
+using OpenTK.Graphics.OpenGL;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics
@@ -167,7 +162,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 case VertexElementFormat.NormalizedShort4:
                     return VertexAttribPointerType.Short;
                 
-#if MONOMAC || WINDOWS || LINUX
+#if OPENGL && !GLES
                case VertexElementFormat.HalfVector2:
                     return VertexAttribPointerType.HalfFloat;
 
@@ -237,7 +232,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 case VertexElementFormat.NormalizedShort4:
                     return ColorPointerType.UnsignedShort;
 				
-#if MONOMAC
+#if OPENGL && !GLES
                 case VertexElementFormat.HalfVector2:
                     return ColorPointerType.HalfFloat;
 
@@ -283,7 +278,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 case VertexElementFormat.NormalizedShort4:
                     return NormalPointerType.Short;
 				
-#if MONOMAC
+#if OPENGL && !GLES
                 case VertexElementFormat.HalfVector2:
                     return NormalPointerType.HalfFloat;
 
@@ -329,7 +324,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 case VertexElementFormat.NormalizedShort4:
                     return TexCoordPointerType.Short;
 				
-#if MONOMAC
+#if OPENGL && !GLES
                 case VertexElementFormat.HalfVector2:
                     return TexCoordPointerType.HalfFloat;
 
@@ -382,11 +377,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			case Blend.InverseSourceAlpha:
 				return BlendingFactorSrc.OneMinusSrcAlpha;
 			case Blend.InverseSourceColor:
-#if MONOMAC || WINDOWS || LINUX
 				return (BlendingFactorSrc)All.OneMinusSrcColor;
-#else
-				return BlendingFactorSrc.OneMinusSrcColor;
-#endif
 			case Blend.One:
 				return BlendingFactorSrc.One;
 			case Blend.SourceAlpha:
@@ -394,11 +385,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			case Blend.SourceAlphaSaturation:
 				return BlendingFactorSrc.SrcAlphaSaturate;
 			case Blend.SourceColor:
-#if MONOMAC || WINDOWS || LINUX
 				return (BlendingFactorSrc)All.SrcColor;
-#else
-				return BlendingFactorSrc.SrcColor;
-#endif
 			case Blend.Zero:
 				return BlendingFactorSrc.Zero;
 			default:
@@ -421,11 +408,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			case Blend.InverseSourceAlpha:
 				return BlendingFactorDest.OneMinusSrcAlpha;
 			case Blend.InverseSourceColor:
-#if MONOMAC || WINDOWS
 				return (BlendingFactorDest)All.OneMinusSrcColor;
-#else
-				return BlendingFactorDest.OneMinusSrcColor;
-#endif
 			case Blend.One:
 				return BlendingFactorDest.One;
 			case Blend.SourceAlpha:
@@ -433,11 +416,7 @@ namespace Microsoft.Xna.Framework.Graphics
 //			case Blend.SourceAlphaSaturation:
 //				return BlendingFactorDest.SrcAlphaSaturate;
 			case Blend.SourceColor:
-#if MONOMAC || WINDOWS
 				return (BlendingFactorDest)All.SrcColor;
-#else
-				return BlendingFactorDest.SrcColor;
-#endif
 			case Blend.Zero:
 				return BlendingFactorDest.Zero;
 			default:

--- a/MonoGame.Framework/Graphics/OcclusionQuery.cs
+++ b/MonoGame.Framework/Graphics/OcclusionQuery.cs
@@ -3,12 +3,10 @@ using System.Runtime.InteropServices;
 
 
 #if OPENGL
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
-using OpenTK.Graphics.OpenGL;
-#elif ANGLE // Review for iOS and Android, and change to GLES
+#if ANGLE // Review for iOS and Android, and change to GLES
 using OpenTK.Graphics.ES30;
+#else
+using OpenTK.Graphics.OpenGL;
 #endif
 #endif
 
@@ -77,11 +75,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		public bool IsComplete {
 			get {
 				int resultReady = 0;
-#if MONOMAC               
-				GetQueryObjectiv(glQueryId,
-				                 (int)GetQueryObjectParam.QueryResultAvailable,
-				                 out resultReady);
-#elif OPENGL
+#if OPENGL
                 GL.GetQueryObject(glQueryId, GetQueryObjectParam.QueryResultAvailable, out resultReady);
                 GraphicsExtensions.CheckGLError();
 #elif DIRECTX               
@@ -92,11 +86,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		public int PixelCount {
 			get {
 				int result = 0;
-#if MONOMAC
-				GetQueryObjectiv(glQueryId,
-				                 (int)GetQueryObjectParam.QueryResult,
-				                 out result);
-#elif OPENGL
+#if OPENGL
                 GL.GetQueryObject(glQueryId, GetQueryObjectParam.QueryResultAvailable, out result);
                 GraphicsExtensions.CheckGLError();
 #elif DIRECTX               
@@ -104,15 +94,6 @@ namespace Microsoft.Xna.Framework.Graphics
                 return result;
 			}
         }
-
-#if MONOMAC
-		//MonoMac doesn't export this. Grr.
-		const string OpenGLLibrary = "/System/Library/Frameworks/OpenGL.framework/OpenGL";
-
-		[System.Security.SuppressUnmanagedCodeSecurity()]
-		[DllImport(OpenGLLibrary, EntryPoint = "glGetQueryObjectiv", ExactSpelling = true)]
-		extern static unsafe void GetQueryObjectiv(int id, int pname, out int @params);
-#endif
     }
 }
 

--- a/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
@@ -2,16 +2,14 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
-using OpenTK.Graphics.OpenGL;
-using System;
-using System.Collections.Generic;
-#elif GLES
+#if GLES
 using OpenTK.Graphics.ES20;
 using RenderbufferTarget = OpenTK.Graphics.ES20.All;
 using RenderbufferStorage = OpenTK.Graphics.ES20.All;
+#elif OPENGL
+using OpenTK.Graphics.OpenGL;
+using System;
+using System.Collections.Generic;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/SamplerStateCollection.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/SamplerStateCollection.OpenGL.cs
@@ -4,14 +4,12 @@
 //
 // Author: Kenneth James Pouncey
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
-using OpenTK.Graphics.OpenGL;
-#elif GLES
+#if GLES
 using OpenTK.Graphics.ES20;
 using TextureUnit = OpenTK.Graphics.ES20.All;
 using TextureTarget = OpenTK.Graphics.ES20.All;
+#elif OPENGL
+using OpenTK.Graphics.OpenGL;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/Shader/ConstantBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Shader/ConstantBuffer.OpenGL.cs
@@ -4,12 +4,10 @@
 
 using System;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
-using OpenTK.Graphics.OpenGL;
-#elif GLES
+#if GLES
 using OpenTK.Graphics.ES20;
+#elif OPENGL
+using OpenTK.Graphics.OpenGL;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/Shader/Shader.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Shader/Shader.OpenGL.cs
@@ -5,17 +5,15 @@
 using System;
 using System.IO;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
-using OpenTK.Graphics.OpenGL;
-#elif GLES
+#if GLES
 using System.Text;
 using OpenTK.Graphics.ES20;
 using ShaderType = OpenTK.Graphics.ES20.All;
 using ShaderParameter = OpenTK.Graphics.ES20.All;
 using TextureUnit = OpenTK.Graphics.ES20.All;
 using TextureTarget = OpenTK.Graphics.ES20.All;
+#elif OPENGL
+using OpenTK.Graphics.OpenGL;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
+++ b/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
@@ -3,20 +3,15 @@
 using System;
 using System.Collections.Generic;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-using GetProgramParameterName = MonoMac.OpenGL.ProgramParameter;
-#elif WINDOWS || LINUX
-using OpenTK.Graphics.OpenGL;
-#elif WINRT
-
-#else
+#if GLES
 using OpenTK.Graphics.ES20;
 #if IOS || ANDROID
 using ActiveUniformType = OpenTK.Graphics.ES20.All;
 using ShaderType = OpenTK.Graphics.ES20.All;
 using GetProgramParameterName = OpenTK.Graphics.ES20.All;
 #endif
+#else
+using OpenTK.Graphics.OpenGL;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics
@@ -69,11 +64,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 if (GL.IsProgram(pair.Value.Program))
                 {
-#if MONOMAC
-                    GL.DeleteProgram(pair.Value.Program, null);
-#else
                     GL.DeleteProgram(pair.Value.Program);
-#endif
                     GraphicsExtensions.CheckGLError();
                 }
             }
@@ -138,9 +129,6 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
                 GL.DetachShader(program, vertexShader.GetShaderHandle());
                 GL.DetachShader(program, pixelShader.GetShaderHandle());
-#if MONOMAC
-                GL.DeleteProgram(1, ref program);
-#else
                 GL.DeleteProgram(program);
 #endif
                 throw new InvalidOperationException("Unable to link effect program");
@@ -169,5 +157,3 @@ namespace Microsoft.Xna.Framework.Graphics
         }
     }
 }
-
-#endif // OPENGL

--- a/MonoGame.Framework/Graphics/States/BlendState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/BlendState.OpenGL.cs
@@ -2,16 +2,14 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
-using OpenTK.Graphics.OpenGL;
-#elif GLES
+#if GLES
 using OpenTK.Graphics.ES20;
 using EnableCap = OpenTK.Graphics.ES20.All;
 using BlendEquationMode = OpenTK.Graphics.ES20.All;
 using BlendingFactorSrc = OpenTK.Graphics.ES20.All;
 using BlendingFactorDest = OpenTK.Graphics.ES20.All;
+#elif OPENGL
+using OpenTK.Graphics.OpenGL;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.OpenGL.cs
@@ -2,18 +2,15 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-#if MONOMAC
-using MonoMac.OpenGL;
-using GLStencilFunction = MonoMac.OpenGL.StencilFunction;
-#elif WINDOWS || LINUX
-using OpenTK.Graphics.OpenGL;
-using GLStencilFunction = OpenTK.Graphics.OpenGL.StencilFunction;
-#elif GLES
+#if GLES
 using OpenTK.Graphics.ES20;
 using EnableCap = OpenTK.Graphics.ES20.All;
 using GLStencilFunction = OpenTK.Graphics.ES20.All;
 using StencilOp = OpenTK.Graphics.ES20.All;
 using DepthFunction = OpenTK.Graphics.ES20.All;
+#elif OPENGL
+using OpenTK.Graphics.OpenGL;
+using GLStencilFunction = OpenTK.Graphics.OpenGL.StencilFunction;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.OpenGL.cs
@@ -86,11 +86,6 @@ namespace Microsoft.Xna.Framework.Graphics
                     var cullFaceModeBack = (All)CullFaceMode.Back;
                     var stencilFaceFront = (All)CullFaceMode.Front;
                     var stencilFaceBack = (All)CullFaceMode.Back;
-#elif MONOMAC
-                    var cullFaceModeFront = (Version20)CullFaceMode.Front;
-                    var cullFaceModeBack = (Version20)CullFaceMode.Back;
-                    var stencilFaceFront = StencilFace.Front;
-                    var stencilFaceBack = StencilFace.Back;
 #else
                     var cullFaceModeFront = StencilFace.Front;
                     var cullFaceModeBack = StencilFace.Back;

--- a/MonoGame.Framework/Graphics/States/RasterizerState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/RasterizerState.OpenGL.cs
@@ -4,15 +4,13 @@
 
 using System;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
-using OpenTK.Graphics.OpenGL;
-#elif GLES
+#if GLES
 using OpenTK.Graphics.ES20;
 using EnableCap = OpenTK.Graphics.ES20.All;
 using FrontFaceDirection = OpenTK.Graphics.ES20.All;
 using CullFaceMode = OpenTK.Graphics.ES20.All;
+#elif OPENGL
+using OpenTK.Graphics.OpenGL;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics
@@ -54,12 +52,12 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
             }
 
-#if MONOMAC || WINDOWS || LINUX
+#if OPENGL && !GLES
 			if (FillMode == FillMode.Solid) 
 				GL.PolygonMode(MaterialFace.FrontAndBack, PolygonMode.Fill);
             else
 				GL.PolygonMode(MaterialFace.FrontAndBack, PolygonMode.Line);
-#else
+#elif OPENGL && GLES
             if (FillMode != FillMode.Solid)
                 throw new NotImplementedException();
 #endif

--- a/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
@@ -5,16 +5,14 @@
 using System;
 using System.Diagnostics;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
-using OpenTK.Graphics.OpenGL;
-#elif GLES
+#if GLES
 using OpenTK.Graphics.ES20;
 using TextureTarget = OpenTK.Graphics.ES20.All;
 using TextureMinFilter = OpenTK.Graphics.ES20.All;
 using TextureParameterName = OpenTK.Graphics.ES20.All;
 using GetPName = OpenTK.Graphics.ES20.All;
+#elif OPENGL
+using OpenTK.Graphics.OpenGL;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/States/SamplerState.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.cs
@@ -2,18 +2,14 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-#if OPENGL
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
-using OpenTK.Graphics.OpenGL;
-#elif GLES
+#if GLES
 using OpenTK.Graphics.ES20;
 using TextureTarget = OpenTK.Graphics.ES20.All;
 using TextureMinFilter = OpenTK.Graphics.ES20.All;
 using TextureParameterName = OpenTK.Graphics.ES20.All;
 using GetPName = OpenTK.Graphics.ES20.All;
-#endif
+#elif OPENGL
+using OpenTK.Graphics.OpenGL;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/Texture.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture.OpenGL.cs
@@ -2,17 +2,13 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
-using OpenTK.Graphics.OpenGL;
-#elif GLES
+#if GLES
 using OpenTK.Graphics.ES20;
 using PixelFormat = OpenTK.Graphics.ES20.All;
 using TextureTarget = OpenTK.Graphics.ES20.All;
 using TextureUnit = OpenTK.Graphics.ES20.All;
-using PixelInternalFormat = OpenTK.Graphics.ES20.All;
-using PixelType = OpenTK.Graphics.ES20.All;
+#elif OPENGL
+using OpenTK.Graphics.OpenGL;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/Texture.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture.OpenGL.cs
@@ -6,6 +6,7 @@
 using OpenTK.Graphics.ES20;
 using PixelFormat = OpenTK.Graphics.ES20.All;
 using PixelInternalFormat = OpenTK.Graphics.ES20.All;
+using PixelType = OpenTK.Graphics.ES20.All;
 using SamplerState = OpenTK.Graphics.ES20.All;
 using TextureTarget = OpenTK.Graphics.ES20.All;
 using TextureUnit = OpenTK.Graphics.ES20.All;

--- a/MonoGame.Framework/Graphics/Texture.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture.OpenGL.cs
@@ -5,6 +5,8 @@
 #if GLES
 using OpenTK.Graphics.ES20;
 using PixelFormat = OpenTK.Graphics.ES20.All;
+using PixelInternalFormat = OpenTK.Graphics.ES20.All;
+using SamplerState = OpenTK.Graphics.ES20.All;
 using TextureTarget = OpenTK.Graphics.ES20.All;
 using TextureUnit = OpenTK.Graphics.ES20.All;
 #elif OPENGL

--- a/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
@@ -20,15 +20,6 @@ using MonoTouch.Foundation;
 #endif
 
 #if OPENGL
-#if MONOMAC
-using MonoMac.OpenGL;
-using GLPixelFormat = MonoMac.OpenGL.PixelFormat;
-#endif
-
-#if WINDOWS || LINUX
-using OpenTK.Graphics.OpenGL;
-using GLPixelFormat = OpenTK.Graphics.OpenGL.PixelFormat;
-#endif
 
 #if GLES
 using OpenTK.Graphics.ES20;
@@ -40,6 +31,9 @@ using PixelInternalFormat = OpenTK.Graphics.ES20.All;
 using PixelType = OpenTK.Graphics.ES20.All;
 using PixelStoreParameter = OpenTK.Graphics.ES20.All;
 using ErrorCode = OpenTK.Graphics.ES20.All;
+#else
+using OpenTK.Graphics.OpenGL;
+using GLPixelFormat = OpenTK.Graphics.OpenGL.PixelFormat;
 #endif
 
 #if ANDROID

--- a/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
@@ -563,7 +563,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformSaveAsJpeg(Stream stream, int width, int height)
         {
-#if MONOMAC || WINDOWS
+#if WINDOWS || LINUX || MONOMAC || ANGLE
 			SaveAsImage(stream, width, height, ImageFormat.Jpeg);
 #else
             throw new NotImplementedException();
@@ -572,14 +572,14 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformSaveAsPng(Stream stream, int width, int height)
         {
-#if MONOMAC || WINDOWS
+#if WINDOWS || LINUX || MONOMAC || ANGLE
             SaveAsImage(stream, width, height, ImageFormat.Png);
 #else
             throw new NotImplementedException();
 #endif
         }
 
-#if MONOMAC || WINDOWS
+#if WINDOWS || LINUX || MONOMAC || ANGLE
 		private void SaveAsImage(Stream stream, int width, int height, ImageFormat format)
 		{
 			if (stream == null)

--- a/MonoGame.Framework/Graphics/Texture3D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture3D.OpenGL.cs
@@ -6,9 +6,9 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
+#if GLES
+using OpenTK.Graphics.ES20;
+#elif OPENGL
 using OpenTK.Graphics.OpenGL;
 #endif
 

--- a/MonoGame.Framework/Graphics/TextureCollection.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.OpenGL.cs
@@ -2,12 +2,12 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-#if OPENGL
-using OpenTK.Graphics.OpenGL;
-#elif GLES
+#if GLES
 using OpenTK.Graphics.ES20;
 using TextureUnit = OpenTK.Graphics.ES20.All;
 using TextureTarget = OpenTK.Graphics.ES20.All;
+#elif OPENGL
+using OpenTK.Graphics.OpenGL;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/TextureCollection.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.OpenGL.cs
@@ -2,9 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
+#if OPENGL
 using OpenTK.Graphics.OpenGL;
 #elif GLES
 using OpenTK.Graphics.ES20;

--- a/MonoGame.Framework/Graphics/TextureCollection.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.cs
@@ -1,4 +1,4 @@
-﻿// MonoGame - Copyright (C) The MonoGame Team
+// MonoGame - Copyright (C) The MonoGame Team
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
@@ -4,11 +4,7 @@
 
 using System;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
-using OpenTK.Graphics.OpenGL;
-#elif GLES
+#if GLES
 using OpenTK.Graphics.ES20;
 using PixelInternalFormat = OpenTK.Graphics.ES20.All;
 using PixelFormat = OpenTK.Graphics.ES20.All;
@@ -16,6 +12,8 @@ using PixelType = OpenTK.Graphics.ES20.All;
 using TextureTarget = OpenTK.Graphics.ES20.All;
 using TextureParameterName = OpenTK.Graphics.ES20.All;
 using TextureMinFilter = OpenTK.Graphics.ES20.All;
+#elif OPENGL
+using OpenTK.Graphics.OpenGL;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/Vertices/IndexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/IndexBuffer.OpenGL.cs
@@ -8,15 +8,11 @@ using System.Linq;
 using System.Text;
 using System.Runtime.InteropServices;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#endif
 #if GLES
 using OpenTK.Graphics.ES20;
 using BufferTarget = OpenTK.Graphics.ES20.All;
 using BufferUsageHint = OpenTK.Graphics.ES20.All;
-#endif
-#if WINDOWS || LINUX
+#elif OPENGL
 using OpenTK.Graphics.OpenGL;
 #endif
 

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
@@ -8,16 +8,12 @@ using System.Linq;
 using System.Text;
 using System.Runtime.InteropServices;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#endif
-#if WINDOWS || LINUX
-using OpenTK.Graphics.OpenGL;
-#endif
 #if GLES
 using OpenTK.Graphics.ES20;
 using BufferTarget = OpenTK.Graphics.ES20.All;
 using BufferUsageHint = OpenTK.Graphics.ES20.All;
+#elif OPENGL
+using OpenTK.Graphics.OpenGL;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.OpenGL.cs
@@ -5,13 +5,11 @@
 using System;
 using System.Collections.Generic;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
-using OpenTK.Graphics.OpenGL;
-#else
+#if GLES
 using OpenTK.Graphics.ES20;
 using VertexAttribPointerType = OpenTK.Graphics.ES20.All;
+#elif OPENGL
+using OpenTK.Graphics.OpenGL;
 #endif
 
 namespace Microsoft.Xna.Framework.Graphics

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -6,9 +6,7 @@ using System;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input.Touch;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif GLES
+#if GLES
 using OpenTK.Graphics.ES20;
 #elif OPENGL
 using OpenTK.Graphics.OpenGL;


### PR DESCRIPTION
This PR switches MacOS from MonoMac.OpenGL/AL to the corresponding OpenTK namespaces. This allows us to use a common codepath for the WinGL/Linux/MacOS platforms, which reduces the support burden (see comments in #2782.)

Changes:
- `MonoMac.OpenGL/AL` namespaces converted to `OpenTK.Graphics.OpenGL` and `OpenTK.Audio.OpenAL` respectively.
- `#if MONOMAC` regions regarding API differences between MonoMac and OpenTK are eliminated.
- `MacGamePlatform` and `GameWindow` are not affected - we are still using MonoMac for platform support.
- Unit tests remain unaffected (87/166 passing on my system.)

This PR does not introduce any functional differences and should be safe to apply as-is. I'll issue a separate PR for switching `MacGamePlatform` to `OpenTKGamePlatform`, as that is much more invasive change and should be reviewed separately.