### PR TITLE
Display orientation can be landscape or portrait on WP8

### DIFF
--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -184,8 +184,7 @@ namespace Microsoft.Xna.Framework
 
 #if WINDOWS_PHONE
             _graphicsDevice.GraphicsProfile = GraphicsProfile;
-            // Display orientation is always portrait on WP8
-            _graphicsDevice.PresentationParameters.DisplayOrientation = DisplayOrientation.Portrait;
+            _graphicsDevice.PresentationParameters.DisplayOrientation = _game.Window.CurrentOrientation;
 #elif WINDOWS_STOREAPP
 
             // TODO:  Does this need to occur here?


### PR DESCRIPTION
Both properties 
<code class='language-cs'>GraphicsDevice.PresentationParameters.DisplayOrientation</code> and
<code class='language-cs'>TouchPanel.DisplayOrientation</code> 
always return value <code class='language-cs'>Portrait</code> even if we are in landscape mode.

<code class='language-cs'>Window.CurrentOrientation</code> returns correct value.