### PR TITLE
Set SamplerState.GraphicsDevice to null on reset

### DIFF
--- a/MonoGame.Framework/Graphics/SamplerStateCollection.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/SamplerStateCollection.OpenGL.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformClear()
         {
+            for (int i = 0; i < _samplers.Length; i++)
+                _samplers[i].GraphicsDevice = null;
         }
 
         private void PlatformDirty()

--- a/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
@@ -29,6 +29,16 @@ namespace Microsoft.Xna.Framework.Graphics
         private const TextureParameterName TextureParameterNameTextureMaxLevel = TextureParameterName.TextureMaxLevel;
 #endif
 
+        static partial void PlatformResetStates()
+        {
+            _anisotropicClamp.Value.GraphicsDevice = null;
+            _anisotropicWrap.Value.GraphicsDevice = null;
+            _linearClamp.Value.GraphicsDevice = null;
+            _linearWrap.Value.GraphicsDevice = null;
+            _pointClamp.Value.GraphicsDevice = null;
+            _pointWrap.Value.GraphicsDevice = null;
+        }
+
         internal void Activate(GraphicsDevice device, TextureTarget target, bool useMipmaps = false)
         {
             if (GraphicsDevice == null)

--- a/MonoGame.Framework/Graphics/States/SamplerState.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.cs
@@ -119,7 +119,10 @@ namespace Microsoft.Xna.Framework.Graphics
             _linearWrap.Reset();
             _pointClamp.Reset();
             _pointWrap.Reset();
+            PlatformResetStates();
         }
+
+        static partial void PlatformResetStates();
     }
 }
 


### PR DESCRIPTION
The predefined SamplerState are statically initialized on first access
and their GraphicsDevice property set when Activate() is called.
However, SamplerState.GraphicsDevice is never cleared when the
GraphicsDevice is disposed. This leads to an assertion when a
SamplerState is re-activated on a new GraphicsDevice.

This PR adds a static SamplerState.PlatformReset() method that is
invoked when a GraphicsDevice is disposed, allowing SamplerStates to be
re-initialized when activated on a new GraphicsDevice.