### PR TITLE
Conversion of MonoMacGameView to OpenTK equivalent.

### DIFF
--- a/Build/Projects/FrameworkReferences.definition
+++ b/Build/Projects/FrameworkReferences.definition
@@ -26,6 +26,9 @@
       <Binary
         Name="Tao.Sdl"
         Path="ThirdParty/GamepadConfig/Tao.Sdl.dll" />
+      <Binary
+        Name="OpenTK"
+        Path="ThirdParty/Dependencies/OpenTK.dll" />
     </Service>
   </Platform>
 

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -210,9 +210,7 @@
       <Platforms>Windows8,WindowsPhone,WindowsPhone81</Platforms>
     </Compile>
     <Compile Include="GameUpdateRequiredException.cs" />
-    <Compile Include="GameWindow.cs">
-		<ExcludePlatforms>MacOS</ExcludePlatforms>
-	</Compile>
+    <Compile Include="GameWindow.cs" />
     <Compile Include="IDrawable.cs" />
     <Compile Include="IGameComponent.cs" />
     <Compile Include="IGraphicsDeviceManager.cs" />
@@ -783,7 +781,10 @@
       <Platforms>PSMobile</Platforms>
     </Compile>
     <Compile Include="Input\GamePad.SDL.cs">
-      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,WindowsGL</Platforms>
+    </Compile>
+    <Compile Include="Input\GamePad.OpenTK.cs">
+      <Platforms>MacOS</Platforms>
     </Compile>
     <Compile Include="Input\GamePad.Web.cs">
       <Platforms>Web</Platforms>
@@ -1021,34 +1022,34 @@
 
     <!-- Common Desktop Platform -->
     <Compile Include="Desktop\Input\Axis.cs">
-      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,WindowsGL</Platforms>
     </Compile>
     <Compile Include="Desktop\Input\Capabilities.cs">
-      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,WindowsGL</Platforms>
     </Compile>
     <Compile Include="Desktop\Input\DPad.cs">
-      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,WindowsGL</Platforms>
     </Compile>
     <Compile Include="Desktop\Input\Input.cs">
-      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,WindowsGL</Platforms>
     </Compile>
     <Compile Include="Desktop\Input\Joystick.cs">
-      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,WindowsGL</Platforms>
     </Compile>
     <Compile Include="Desktop\Input\PadConfig.cs">
-      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,WindowsGL</Platforms>
     </Compile>
     <Compile Include="Desktop\Input\Settings.cs">
-      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,WindowsGL</Platforms>
     </Compile>
     <Compile Include="Desktop\Input\Stick.cs">
-      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,WindowsGL</Platforms>
     </Compile>
     <Compile Include="Desktop\OpenTKGamePlatform.cs">
-      <Platforms>Angle,Linux,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
     </Compile>
     <Compile Include="Desktop\OpenTKGameWindow.cs">
-      <Platforms>Angle,Linux,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
     </Compile>
 
 
@@ -1092,19 +1093,7 @@
 
 
     <!-- MacOS Platform -->
-    <Compile Include="MacOS\GameWindow.cs">
-      <Platforms>MacOS</Platforms>
-    </Compile>
-    <Compile Include="MacOS\KeyUtil.cs">
-      <Platforms>MacOS</Platforms>
-    </Compile>
-    <Compile Include="MacOS\MacGameNSWindow.cs">
-      <Platforms>MacOS</Platforms>
-    </Compile>
-    <Compile Include="MacOS\MacGamePlatform.cs">
-      <Platforms>MacOS</Platforms>
-    </Compile>
-    <Compile Include="MacOS\MacGamePlatform+Synchronous.cs">
+    <Compile Include="MacOS\Input\KeyboardUtil.cs">
       <Platforms>MacOS</Platforms>
     </Compile>
     <Compile Include="MacOS\Storage\StorageDeviceHelper.cs">

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -781,11 +781,13 @@
       <Platforms>PSMobile</Platforms>
     </Compile>
     <Compile Include="Input\GamePad.SDL.cs">
-      <Platforms>Angle,Linux,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
     </Compile>
+    <!--
     <Compile Include="Input\GamePad.OpenTK.cs">
       <Platforms>MacOS</Platforms>
     </Compile>
+    -->
     <Compile Include="Input\GamePad.Web.cs">
       <Platforms>Web</Platforms>
     </Compile>
@@ -1022,28 +1024,28 @@
 
     <!-- Common Desktop Platform -->
     <Compile Include="Desktop\Input\Axis.cs">
-      <Platforms>Angle,Linux,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
     </Compile>
     <Compile Include="Desktop\Input\Capabilities.cs">
-      <Platforms>Angle,Linux,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
     </Compile>
     <Compile Include="Desktop\Input\DPad.cs">
-      <Platforms>Angle,Linux,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
     </Compile>
     <Compile Include="Desktop\Input\Input.cs">
-      <Platforms>Angle,Linux,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
     </Compile>
     <Compile Include="Desktop\Input\Joystick.cs">
-      <Platforms>Angle,Linux,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
     </Compile>
     <Compile Include="Desktop\Input\PadConfig.cs">
-      <Platforms>Angle,Linux,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
     </Compile>
     <Compile Include="Desktop\Input\Settings.cs">
-      <Platforms>Angle,Linux,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
     </Compile>
     <Compile Include="Desktop\Input\Stick.cs">
-      <Platforms>Angle,Linux,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
     </Compile>
     <Compile Include="Desktop\OpenTKGamePlatform.cs">
       <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>

--- a/MonoGame.Framework/Content/ContentTypeReader.cs
+++ b/MonoGame.Framework/Content/ContentTypeReader.cs
@@ -143,6 +143,13 @@ namespace Microsoft.Xna.Framework.Content
 #else
 			    if (File.Exists(fileNamePlusExt))
 				    return fileNamePlusExt;
+
+				#if MONOMAC
+				// TODO: I think this logic would be safe for all platforms
+				if(File.Exists(Path.Combine(TitleContainer.Location, fileNamePlusExt)))
+					return fileNamePlusExt;
+				#endif
+
 #endif
             }
 			

--- a/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
@@ -306,11 +306,11 @@ namespace Microsoft.Xna.Framework
 
             GraphicsContext.ShareContexts = true;
 
-            window = new NativeWindow();
-            window.Closing += new EventHandler<CancelEventArgs>(OpenTkGameWindow_Closing);
-            window.Resize += OnResize;
-            window.KeyDown += new EventHandler<OpenTK.Input.KeyboardKeyEventArgs>(Keyboard_KeyDown);
-            window.KeyUp += new EventHandler<OpenTK.Input.KeyboardKeyEventArgs>(Keyboard_KeyUp);
+			window = new NativeWindow ();
+			window.Closing += new EventHandler<CancelEventArgs> (OpenTkGameWindow_Closing);
+			window.Resize += OnResize;
+			window.KeyDown += new EventHandler<OpenTK.Input.KeyboardKeyEventArgs> (Keyboard_KeyDown);
+			window.KeyUp += new EventHandler<OpenTK.Input.KeyboardKeyEventArgs> (Keyboard_KeyUp);
 #if LINUX
             window.WindowBorder = WindowBorder.Resizable;
 #endif
@@ -318,13 +318,16 @@ namespace Microsoft.Xna.Framework
             window.MouseEnter += OnMouseEnter;
             window.MouseLeave += OnMouseLeave;
 #endif
+			window.KeyPress += OnKeyPress;
 
-            window.KeyPress += OnKeyPress;
-
+#if MONOMAC
+			#warning DISABLED DURING MONOMAC OPENTK CONVERSION
+#else
             // Set the window icon.
             var assembly = Assembly.GetEntryAssembly();
             if(assembly != null)
                 window.Icon = Icon.ExtractAssociatedIcon(assembly.Location);
+#endif
             Title = MonoGame.Utilities.AssemblyHelper.GetDefaultWindowTitle();
 
             updateClientBounds = false;
@@ -338,7 +341,7 @@ namespace Microsoft.Xna.Framework
 
             // mouse
             // TODO review this when opentk 1.1 is released
-#if WINDOWS || LINUX || ANGLE
+#if WINDOWS || LINUX || ANGLE || MONOMAC
             Mouse.setWindows(this);
 #else
             Mouse.UpdateMouseInfo(window.Mouse);

--- a/MonoGame.Framework/GamePlatform.cs
+++ b/MonoGame.Framework/GamePlatform.cs
@@ -28,9 +28,7 @@ namespace Microsoft.Xna.Framework
         {
 #if IOS
             return new iOSGamePlatform(game);
-#elif MONOMAC
-            return new MacGamePlatform(game);
-#elif (WINDOWS && OPENGL) || LINUX || ANGLE
+#elif (WINDOWS && OPENGL) || LINUX || ANGLE || MONOMAC
             return new OpenTKGamePlatform(game);
 #elif ANDROID
             return new AndroidGamePlatform(game);
@@ -104,6 +102,10 @@ namespace Microsoft.Xna.Framework
                 }
             }
         }
+
+#if MONOMAC
+		public bool IsPlayingVideo { get; set; }
+#endif
 
 #if WINDOWS_STOREAPP && !WINDOWS_PHONE81
         private ApplicationViewState _viewState;

--- a/MonoGame.Framework/GameWindow.cs
+++ b/MonoGame.Framework/GameWindow.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Xna.Framework {
 		public event EventHandler<EventArgs> OrientationChanged;
 		public event EventHandler<EventArgs> ScreenDeviceNameChanged;
 
-#if WINDOWS || LINUX || ANGLE
+#if WINDOWS || LINUX || ANGLE || MONOMAC
 
         /// <summary>
 		/// Use this event to retrieve text for objects like textbox's.
@@ -139,7 +139,7 @@ namespace Microsoft.Xna.Framework {
 				ScreenDeviceNameChanged (this, EventArgs.Empty);
 		}
 
-#if WINDOWS || LINUX || ANGLE
+#if WINDOWS || LINUX || ANGLE || MONOMAC
 		protected void OnTextInput(object sender, TextInputEventArgs e)
 		{
 			if (TextInput != null)

--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
@@ -5,9 +5,7 @@
 using System;
 using System.Collections.Generic;
 #if OPENGL
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif GLES
+#if GLES
 using OpenTK.Graphics.ES20;
 #else
 using OpenTK.Graphics.OpenGL;

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.FramebufferHelper.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.FramebufferHelper.cs
@@ -9,12 +9,7 @@ using System.Text;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
-#if MONOMAC
-using MonoMac;
-using MonoMac.OpenGL;
-#endif
-
-#if (WINDOWS || LINUX) && !GLES
+#if (WINDOWS || LINUX || MONOMAC) && !GLES
 using OpenTK.Graphics.OpenGL;
 
 #endif
@@ -258,17 +253,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
             public bool SupportsBlitFramebuffer { get; private set; }
 
-#if MONOMAC
-			[DllImport(Constants.OpenGLLibrary, EntryPoint = "glRenderbufferStorageMultisampleEXT")]
-		    internal extern static void GLRenderbufferStorageMultisampleExt(All target, int samples, All internalformat, int width, int height);
-
-			[DllImport(Constants.OpenGLLibrary, EntryPoint = "glBlitFramebufferEXT")]
-			internal extern static void GLBlitFramebufferExt(int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, ClearBufferMask mask, BlitFramebufferFilter filter);
-
-			[DllImport(Constants.OpenGLLibrary, EntryPoint = "glGenerateMipmapEXT")]
-			internal extern static void GLGenerateMipmapExt(GenerateMipmapTarget target);
-#endif
-
             internal FramebufferHelper(GraphicsDevice graphicsDevice)
             {
                 this.SupportsBlitFramebuffer = true;
@@ -295,11 +279,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             internal virtual void RenderbufferStorageMultisample(int samples, int internalFormat, int width, int height)
             {
-#if !MONOMAC
                 GL.RenderbufferStorageMultisample(RenderbufferTarget.Renderbuffer, samples, (RenderbufferStorage)internalFormat, width, height);
-#else
-				GLRenderbufferStorageMultisampleExt(All.Renderbuffer, samples, (All)internalFormat, width, height);
-#endif
                 GraphicsExtensions.CheckGLError();
             }
 
@@ -351,11 +331,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             internal virtual void GenerateMipmap(int target)
             {
-#if !MONOMAC
                 GL.GenerateMipmap((GenerateMipmapTarget)target);
-#else
-				GLGenerateMipmapExt((GenerateMipmapTarget)target);
-#endif
                 GraphicsExtensions.CheckGLError();
 
             }
@@ -367,11 +343,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 GraphicsExtensions.CheckGLError();
                 GL.DrawBuffer(DrawBufferMode.ColorAttachment0 + iColorAttachment);
                 GraphicsExtensions.CheckGLError();
-#if !MONOMAC
                 GL.BlitFramebuffer(0, 0, width, height, 0, 0, width, height, ClearBufferMask.ColorBufferBit, BlitFramebufferFilter.Nearest);
-#else
-				GLBlitFramebufferExt(0, 0, width, height, 0, 0, width, height, ClearBufferMask.ColorBufferBit, BlitFramebufferFilter.Nearest);
-#endif
                 GraphicsExtensions.CheckGLError();
 
             }
@@ -394,7 +366,6 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
-#if !MONOMAC
         internal sealed class FramebufferHelperEXT : FramebufferHelper
         {
             internal FramebufferHelperEXT(GraphicsDevice graphicsDevice)
@@ -495,7 +466,6 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
             }
         }
-#endif
 #endif
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -7,12 +7,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-using GLPrimitiveType = MonoMac.OpenGL.BeginMode;
-#endif
-
-#if WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
 using GLPrimitiveType = OpenTK.Graphics.OpenGL.PrimitiveType;
@@ -44,7 +39,7 @@ namespace Microsoft.Xna.Framework.Graphics
 {
     public partial class GraphicsDevice
     {
-#if WINDOWS || LINUX || ANGLE
+#if WINDOWS || LINUX || ANGLE || MONOMAC
         internal IGraphicsContext Context { get; private set; }
 #endif
 
@@ -116,7 +111,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformSetup()
         {
-#if WINDOWS || LINUX || ANGLE
+#if WINDOWS || LINUX || ANGLE || MONOMAC
             GraphicsMode mode = GraphicsMode.Default;
             var wnd = (Game.Instance.Window as OpenTKGameWindow).Window.WindowInfo;
 
@@ -134,7 +129,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             if (Context == null || Context.IsDisposed)
             {
-                var color = PresentationParameters.BackBufferFormat.GetColorFormat();
+				var color = PresentationParameters.BackBufferFormat.GetColorFormat();
                 var depth =
                     PresentationParameters.DepthStencilFormat == DepthFormat.None ? 0 :
                     PresentationParameters.DepthStencilFormat == DepthFormat.Depth16 ? 16 :
@@ -265,7 +260,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 this.framebufferHelper = new FramebufferHelper(this);
             }
-            #if !(GLES || MONOMAC)
+            #if !GLES
             else if (GraphicsCapabilities.SupportsFramebufferObjectEXT)
             {
                 this.framebufferHelper = new FramebufferHelperEXT(this);
@@ -353,7 +348,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             GraphicsDevice.AddDisposeAction(() =>
                                             {
-#if WINDOWS || LINUX || ANGLE
+#if WINDOWS || LINUX || ANGLE || MONOMAC
                 Context.Dispose();
                 Context = null;
 
@@ -391,7 +386,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public void PlatformPresent()
         {
-#if WINDOWS || LINUX || ANGLE
+#if WINDOWS || LINUX || ANGLE || MONOMAC
             Context.SwapBuffers();
 #endif
             GraphicsExtensions.CheckGLError();

--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -2,9 +2,7 @@
 using System.Diagnostics;
 
 #if OPENGL
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
 #elif GLES
@@ -446,7 +444,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		}
 
-#if WINDOWS || LINUX || ANGLE
+#if WINDOWS || LINUX || ANGLE || MONOMAC
         /// <summary>
         /// Convert a <see cref="SurfaceFormat"/> to an OpenTK.Graphics.ColorFormat.
         /// This is used for setting up the backbuffer format of the OpenGL context.

--- a/MonoGame.Framework/Graphics/OcclusionQuery.cs
+++ b/MonoGame.Framework/Graphics/OcclusionQuery.cs
@@ -3,9 +3,7 @@ using System.Runtime.InteropServices;
 
 
 #if OPENGL
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics.OpenGL;
 #elif ANGLE // Review for iOS and Android, and change to GLES
 using OpenTK.Graphics.ES30;
@@ -77,11 +75,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		public bool IsComplete {
 			get {
 				int resultReady = 0;
-#if MONOMAC               
-				GetQueryObjectiv(glQueryId,
-				                 (int)GetQueryObjectParam.QueryResultAvailable,
-				                 out resultReady);
-#elif OPENGL
+#if OPENGL
                 GL.GetQueryObject(glQueryId, GetQueryObjectParam.QueryResultAvailable, out resultReady);
                 GraphicsExtensions.CheckGLError();
 #elif DIRECTX               
@@ -92,11 +86,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		public int PixelCount {
 			get {
 				int result = 0;
-#if MONOMAC
-				GetQueryObjectiv(glQueryId,
-				                 (int)GetQueryObjectParam.QueryResult,
-				                 out result);
-#elif OPENGL
+#if OPENGL
                 GL.GetQueryObject(glQueryId, GetQueryObjectParam.QueryResultAvailable, out result);
                 GraphicsExtensions.CheckGLError();
 #elif DIRECTX               
@@ -104,15 +94,6 @@ namespace Microsoft.Xna.Framework.Graphics
                 return result;
 			}
         }
-
-#if MONOMAC
-		//MonoMac doesn't export this. Grr.
-		const string OpenGLLibrary = "/System/Library/Frameworks/OpenGL.framework/OpenGL";
-
-		[System.Security.SuppressUnmanagedCodeSecurity()]
-		[DllImport(OpenGLLibrary, EntryPoint = "glGetQueryObjectiv", ExactSpelling = true)]
-		extern static unsafe void GetQueryObjectiv(int id, int pname, out int @params);
-#endif
     }
 }
 

--- a/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
@@ -2,9 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics.OpenGL;
 using System;
 using System.Collections.Generic;

--- a/MonoGame.Framework/Graphics/SamplerStateCollection.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/SamplerStateCollection.OpenGL.cs
@@ -4,9 +4,7 @@
 //
 // Author: Kenneth James Pouncey
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics.OpenGL;
 #elif GLES
 using OpenTK.Graphics.ES20;

--- a/MonoGame.Framework/Graphics/Shader/ConstantBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Shader/ConstantBuffer.OpenGL.cs
@@ -4,9 +4,7 @@
 
 using System;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics.OpenGL;
 #elif GLES
 using OpenTK.Graphics.ES20;

--- a/MonoGame.Framework/Graphics/Shader/Shader.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Shader/Shader.OpenGL.cs
@@ -5,9 +5,7 @@
 using System;
 using System.IO;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics.OpenGL;
 #elif GLES
 using System.Text;

--- a/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
+++ b/MonoGame.Framework/Graphics/Shader/ShaderProgramCache.cs
@@ -3,10 +3,7 @@
 using System;
 using System.Collections.Generic;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-using GetProgramParameterName = MonoMac.OpenGL.ProgramParameter;
-#elif WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics.OpenGL;
 #elif WINRT
 
@@ -69,11 +66,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 if (GL.IsProgram(pair.Value.Program))
                 {
-#if MONOMAC
-                    GL.DeleteProgram(pair.Value.Program, null);
-#else
                     GL.DeleteProgram(pair.Value.Program);
-#endif
                     GraphicsExtensions.CheckGLError();
                 }
             }
@@ -138,11 +131,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
                 GL.DetachShader(program, vertexShader.GetShaderHandle());
                 GL.DetachShader(program, pixelShader.GetShaderHandle());
-#if MONOMAC
-                GL.DeleteProgram(1, ref program);
-#else
                 GL.DeleteProgram(program);
-#endif
                 throw new InvalidOperationException("Unable to link effect program");
             }
 

--- a/MonoGame.Framework/Graphics/States/BlendState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/BlendState.OpenGL.cs
@@ -2,9 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics.OpenGL;
 #elif GLES
 using OpenTK.Graphics.ES20;

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.OpenGL.cs
@@ -2,10 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-#if MONOMAC
-using MonoMac.OpenGL;
-using GLStencilFunction = MonoMac.OpenGL.StencilFunction;
-#elif WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics.OpenGL;
 using GLStencilFunction = OpenTK.Graphics.OpenGL.StencilFunction;
 #elif GLES
@@ -89,11 +86,6 @@ namespace Microsoft.Xna.Framework.Graphics
                     var cullFaceModeBack = (All)CullFaceMode.Back;
                     var stencilFaceFront = (All)CullFaceMode.Front;
                     var stencilFaceBack = (All)CullFaceMode.Back;
-#elif MONOMAC
-                    var cullFaceModeFront = (Version20)CullFaceMode.Front;
-                    var cullFaceModeBack = (Version20)CullFaceMode.Back;
-                    var stencilFaceFront = StencilFace.Front;
-                    var stencilFaceBack = StencilFace.Back;
 #else
                     var cullFaceModeFront = StencilFace.Front;
                     var cullFaceModeBack = StencilFace.Back;

--- a/MonoGame.Framework/Graphics/States/RasterizerState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/RasterizerState.OpenGL.cs
@@ -4,9 +4,7 @@
 
 using System;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics.OpenGL;
 #elif GLES
 using OpenTK.Graphics.ES20;

--- a/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
@@ -5,9 +5,7 @@
 using System;
 using System.Diagnostics;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics.OpenGL;
 #elif GLES
 using OpenTK.Graphics.ES20;

--- a/MonoGame.Framework/Graphics/States/SamplerState.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.cs
@@ -3,9 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 #if OPENGL
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics.OpenGL;
 #elif GLES
 using OpenTK.Graphics.ES20;

--- a/MonoGame.Framework/Graphics/Texture.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture.OpenGL.cs
@@ -2,9 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics.OpenGL;
 #elif GLES
 using OpenTK.Graphics.ES20;

--- a/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
@@ -20,12 +20,8 @@ using MonoTouch.Foundation;
 #endif
 
 #if OPENGL
-#if MONOMAC
-using MonoMac.OpenGL;
-using GLPixelFormat = MonoMac.OpenGL.PixelFormat;
-#endif
 
-#if WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics.OpenGL;
 using GLPixelFormat = OpenTK.Graphics.OpenGL.PixelFormat;
 #endif

--- a/MonoGame.Framework/Graphics/Texture3D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture3D.OpenGL.cs
@@ -6,9 +6,7 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics.OpenGL;
 #endif
 

--- a/MonoGame.Framework/Graphics/TextureCollection.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.OpenGL.cs
@@ -2,9 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics.OpenGL;
 #elif GLES
 using OpenTK.Graphics.ES20;

--- a/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
@@ -4,9 +4,7 @@
 
 using System;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics.OpenGL;
 #elif GLES
 using OpenTK.Graphics.ES20;

--- a/MonoGame.Framework/Graphics/Vertices/IndexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/IndexBuffer.OpenGL.cs
@@ -8,15 +8,12 @@ using System.Linq;
 using System.Text;
 using System.Runtime.InteropServices;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#endif
 #if GLES
 using OpenTK.Graphics.ES20;
 using BufferTarget = OpenTK.Graphics.ES20.All;
 using BufferUsageHint = OpenTK.Graphics.ES20.All;
 #endif
-#if WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics.OpenGL;
 #endif
 

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
@@ -8,10 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Runtime.InteropServices;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#endif
-#if WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics.OpenGL;
 #endif
 #if GLES

--- a/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexDeclaration.OpenGL.cs
@@ -5,9 +5,7 @@
 using System;
 using System.Collections.Generic;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
 using OpenTK.Graphics.OpenGL;
 #else
 using OpenTK.Graphics.ES20;

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -6,9 +6,7 @@ using System;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input.Touch;
 
-#if MONOMAC
-using MonoMac.OpenGL;
-#elif GLES
+#if GLES
 using OpenTK.Graphics.ES20;
 #elif OPENGL
 using OpenTK.Graphics.OpenGL;
@@ -241,7 +239,7 @@ namespace Microsoft.Xna.Framework
 
             ((MonoGame.Framework.WinFormsGamePlatform)_game.Platform).ResetWindowBounds();
 
-#elif WINDOWS || LINUX
+#elif WINDOWS || LINUX || MONOMAC
             ((OpenTKGamePlatform)_game.Platform).ResetWindowBounds();
 
             //Set the swap interval based on if vsync is desired or not.
@@ -252,12 +250,12 @@ namespace Microsoft.Xna.Framework
             else
                 swapInterval = 0;
             _graphicsDevice.Context.SwapInterval = swapInterval;
-#elif MONOMAC
-            _graphicsDevice.PresentationParameters.IsFullScreen = _wantFullScreen;
-
-            // TODO: Implement multisampling (aka anti-alising) for all platforms!
-
-			_game.applyChanges(this);
+//#elif MONOMAC
+//            _graphicsDevice.PresentationParameters.IsFullScreen = _wantFullScreen;
+//
+//            // TODO: Implement multisampling (aka anti-alising) for all platforms!
+//
+//			_game.applyChanges(this);
 #else
 
 #if ANDROID

--- a/MonoGame.Framework/Input/GamePad.OpenTK.cs
+++ b/MonoGame.Framework/Input/GamePad.OpenTK.cs
@@ -1,0 +1,174 @@
+﻿#region License
+/*
+Microsoft Public License (Ms-PL)
+MonoGame - Copyright © 2009 The MonoGame Team
+
+All rights reserved.
+
+This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
+accept the license, do not use the software.
+
+1. Definitions
+The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
+U.S. copyright law.
+
+A "contribution" is the original software, or any additions or changes to the software.
+A "contributor" is any person that distributes its contribution under this license.
+"Licensed patents" are a contributor's patent claims that read directly on its contribution.
+
+2. Grant of Rights
+(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
+(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+
+3. Conditions and Limitations
+(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
+(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
+your patent license from such contributor to the software ends automatically.
+(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
+notices that are present in the software.
+(D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
+a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
+code form, you may only do so under a license that complies with this license.
+(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
+or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
+permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
+purpose and non-infringement.
+*/
+#endregion License
+using System;
+using OpenTK;
+
+namespace Microsoft.Xna.Framework.Input
+{
+    static partial class GamePad
+    {
+		static bool prepDone = false;
+
+		static void PrepSettings()
+        {
+			#if DEBUG
+			if (!prepDone)
+			{
+				try {
+					int count = 0;
+					for (int i = 0; i < 4; i++) 
+					{
+						if (OpenTK.Input.GamePad.GetState (i).IsConnected) 
+						{
+							count++;
+						}
+					}
+					Console.WriteLine("Number of joysticks: " + count);
+				} catch (Exception ex) {
+					Console.WriteLine("Unable to determine number of joysticks.");
+					Console.WriteLine(ex.Message);
+				}
+			}
+			#endif
+
+			prepDone = true;
+        }
+        
+        private static GamePadCapabilities PlatformGetCapabilities(int index)
+        {
+			PrepSettings ();
+
+			var capabilitiesTK = OpenTK.Input.GamePad.GetCapabilities (index);
+			if (capabilitiesTK.GamePadType == OpenTK.Input.GamePadType.Unknown) 
+			{
+				return new GamePadCapabilities ();
+			}
+
+            return new GamePadCapabilities()
+            {
+                IsConnected = true, // otherwise, GamePadType would have been Unknown
+				HasAButton = capabilitiesTK.HasAButton,
+				HasBButton = capabilitiesTK.HasBButton,
+				HasXButton = capabilitiesTK.HasXButton,
+				HasYButton = capabilitiesTK.HasYButton,
+				HasBackButton = capabilitiesTK.HasBackButton,
+				HasStartButton = capabilitiesTK.HasStartButton,
+				HasDPadDownButton = capabilitiesTK.HasDPadDownButton,
+				HasDPadLeftButton = capabilitiesTK.HasDPadLeftButton,
+				HasDPadRightButton = capabilitiesTK.HasDPadRightButton,
+				HasDPadUpButton = capabilitiesTK.HasDPadUpButton,
+				HasLeftShoulderButton = capabilitiesTK.HasLeftShoulderButton,
+				HasRightShoulderButton = capabilitiesTK.HasRightShoulderButton,
+				HasLeftStickButton = capabilitiesTK.HasLeftStickButton,
+				HasRightStickButton = capabilitiesTK.HasRightStickButton,
+				HasLeftTrigger = capabilitiesTK.HasLeftTrigger,
+				HasRightTrigger = capabilitiesTK.HasRightTrigger,
+				HasLeftXThumbStick = capabilitiesTK.HasLeftXThumbStick,
+				HasLeftYThumbStick = capabilitiesTK.HasLeftYThumbStick,
+				HasRightXThumbStick = capabilitiesTK.HasRightXThumbStick,
+				HasRightYThumbStick = capabilitiesTK.HasRightYThumbStick,
+				HasLeftVibrationMotor = capabilitiesTK.HasLeftVibrationMotor,
+				HasRightVibrationMotor = capabilitiesTK.HasRightVibrationMotor,
+				HasVoiceSupport = capabilitiesTK.HasVoiceSupport,
+				HasBigButton = capabilitiesTK.HasBigButton
+            };
+        }
+
+        private static GamePadState PlatformGetState(int index, GamePadDeadZone deadZoneMode)
+        {
+            PrepSettings();
+
+			var stateTK = OpenTK.Input.GamePad.GetState (index);
+
+			if (!stateTK.IsConnected) 
+			{
+				return GamePadState.Default;
+			}
+
+			const float DeadZoneSize = 0.27f;
+			var sticks = 
+				new GamePadThumbSticks (
+					new Vector2(stateTK.ThumbSticks.Left.X, stateTK.ThumbSticks.Left.Y),
+					new Vector2(stateTK.ThumbSticks.Right.X, stateTK.ThumbSticks.Right.Y)
+				);
+			sticks.ApplyDeadZone(deadZoneMode, DeadZoneSize);
+
+			var triggers =
+				new GamePadTriggers (
+					stateTK.Triggers.Left,
+					stateTK.Triggers.Right
+				);
+
+			Buttons buttonStates = 
+				(stateTK.Buttons.A == OpenTK.Input.ButtonState.Pressed ? Buttons.A : 0) |
+				(stateTK.Buttons.B == OpenTK.Input.ButtonState.Pressed ? Buttons.B : 0) |
+				(stateTK.Buttons.Back == OpenTK.Input.ButtonState.Pressed ? Buttons.Back : 0) |
+				(stateTK.Buttons.BigButton == OpenTK.Input.ButtonState.Pressed ? Buttons.BigButton : 0) |
+				(stateTK.Buttons.LeftShoulder == OpenTK.Input.ButtonState.Pressed ? Buttons.LeftShoulder : 0) |
+				(stateTK.Buttons.LeftStick == OpenTK.Input.ButtonState.Pressed ? Buttons.LeftStick : 0) |
+				(stateTK.Buttons.RightShoulder == OpenTK.Input.ButtonState.Pressed ? Buttons.RightShoulder : 0) |
+				(stateTK.Buttons.RightStick == OpenTK.Input.ButtonState.Pressed ? Buttons.RightStick : 0) |
+				(stateTK.Buttons.Start == OpenTK.Input.ButtonState.Pressed ? Buttons.Start : 0) |
+				(stateTK.Buttons.X == OpenTK.Input.ButtonState.Pressed ? Buttons.X : 0) |
+				(stateTK.Buttons.Y == OpenTK.Input.ButtonState.Pressed ? Buttons.Y : 0) |
+				0;
+			var buttons = new GamePadButtons(buttonStates);
+
+			var dpad = 
+				new GamePadDPad(
+					stateTK.DPad.IsUp ? ButtonState.Pressed : ButtonState.Released,
+					stateTK.DPad.IsDown ? ButtonState.Pressed : ButtonState.Released,
+					stateTK.DPad.IsLeft ? ButtonState.Pressed : ButtonState.Released,
+					stateTK.DPad.IsRight ? ButtonState.Pressed : ButtonState.Released
+				);
+
+			var result = new GamePadState(sticks, triggers, buttons, dpad);
+			result.PacketNumber = stateTK.PacketNumber;
+			return result;
+		}
+
+        private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor)
+        {
+			PrepSettings ();
+
+			return OpenTK.Input.GamePad.SetVibration (index, leftMotor, rightMotor);
+        }
+    }
+}

--- a/MonoGame.Framework/Input/Mouse.cs
+++ b/MonoGame.Framework/Input/Mouse.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Xna.Framework.Input
 
         private static readonly MouseState _defaultState = new MouseState();
 
-#if (WINDOWS && OPENGL) || LINUX || ANGLE
+#if (WINDOWS && OPENGL) || LINUX || ANGLE || MONOMAC
 
         static OpenTK.INativeWindow Window;
 
@@ -86,10 +86,6 @@ namespace Microsoft.Xna.Framework.Input
         {
             Window = window;
         }
-
-#elif MONOMAC
-        internal static GameWindow Window;
-        internal static float ScrollWheelValue;
 #endif
 
         /// <summary>
@@ -99,14 +95,12 @@ namespace Microsoft.Xna.Framework.Input
         { 
             get
             { 
-#if (WINDOWS && OPENGL) || LINUX || ANGLE
+#if (WINDOWS && OPENGL) || LINUX || ANGLE || MONOMAC
                 return Window.WindowInfo.Handle;
 #elif WINRT
                 return IntPtr.Zero; // WinRT platform does not create traditionally window, so returns IntPtr.Zero.
 #elif(WINDOWS && DIRECTX)
                 return Window.Handle; 
-#elif MONOMAC
-                return IntPtr.Zero;
 #else
                 return IntPtr.Zero;
 #endif
@@ -127,11 +121,7 @@ namespace Microsoft.Xna.Framework.Input
         /// <returns>Current state of the mouse.</returns>
         public static MouseState GetState(GameWindow window)
         {
-#if MONOMAC
-            //We need to maintain precision...
-            window.MouseState.ScrollWheelValue = (int)ScrollWheelValue;
-
-#elif (WINDOWS && OPENGL) || LINUX || ANGLE
+#if (WINDOWS && OPENGL) || LINUX || ANGLE || MONOMAC
 
             var state = OpenTK.Input.Mouse.GetCursorState();
             var pc = Window.PointToClient(new System.Drawing.Point(state.X, state.Y));
@@ -188,7 +178,7 @@ namespace Microsoft.Xna.Framework.Input
         {
             UpdateStatePosition(x, y);
 
-#if (WINDOWS && (OPENGL || DIRECTX)) || LINUX || ANGLE
+#if (WINDOWS && (OPENGL || DIRECTX)) || LINUX || ANGLE || MONOMAC
             // correcting the coordinate system
             // Only way to set the mouse position !!!
             var pt = Window.PointToScreen(new System.Drawing.Point(x, y));
@@ -196,30 +186,10 @@ namespace Microsoft.Xna.Framework.Input
             var pt = new System.Drawing.Point(0, 0);
 #endif
 
-#if (WINDOWS && OPENGL) || LINUX || ANGLE
+#if (WINDOWS && OPENGL) || LINUX || ANGLE || MONOMAC
             OpenTK.Input.Mouse.SetPosition(pt.X, pt.Y);
 #elif WINDOWS
             SetCursorPos(pt.X, pt.Y);
-#elif MONOMAC
-            var mousePt = NSEvent.CurrentMouseLocation;
-            NSScreen currentScreen = null;
-            foreach (var screen in NSScreen.Screens) {
-                if (screen.Frame.Contains(mousePt)) {
-                    currentScreen = screen;
-                    break;
-                }
-            }
-            
-            var point = new PointF(x, Window.ClientBounds.Height-y);
-            var windowPt = Window.ConvertPointToView(point, null);
-            var screenPt = Window.Window.ConvertBaseToScreen(windowPt);
-            var flippedPt = new PointF(screenPt.X, currentScreen.Frame.Size.Height-screenPt.Y);
-            flippedPt.Y += currentScreen.Frame.Location.Y;
-            
-            
-            CGSetLocalEventsSuppressionInterval(0.0);
-            CGWarpMouseCursorPosition(flippedPt);
-            CGSetLocalEventsSuppressionInterval(0.25);
 #endif
         }
 
@@ -253,13 +223,6 @@ namespace Microsoft.Xna.Framework.Input
             }
 
         }
-
-#elif MONOMAC
-        [DllImport (MonoMac.Constants.CoreGraphicsLibrary)]
-        extern static void CGWarpMouseCursorPosition(PointF newCursorPosition);
-        
-        [DllImport (MonoMac.Constants.CoreGraphicsLibrary)]
-        extern static void CGSetLocalEventsSuppressionInterval(double seconds);
 #endif
 
     }

--- a/MonoGame.Framework/MacOS/GamerServices/Guide.cs
+++ b/MonoGame.Framework/MacOS/GamerServices/Guide.cs
@@ -201,12 +201,16 @@ namespace Microsoft.Xna.Framework.GamerServices
 			if (isVisible)
 				return;
 			isVisible = true;
+
+			// --- New game window, new behavior? May no longer be needed. ---
+			#warning DISABLED DURING MONOMAC OPENTK CONVERSION
 			// We clear the key cache state here to prevent any extraneous keys from
 			// corrupting the key states from the time we call the method
 			// to the time it is actually shown.  This seems to be caused because
 			// we are interrupting the normal flow the game update logic.
-			Window.ClearKeyCacheState();
-			
+//			Window.ClearKeyCacheState();
+			// ---------------------------------------------------------------
+
 			MonoGameGamerServicesHelper.ShowSigninSheet();
 			
 			if (GamerServicesComponent.LocalNetworkGamer == null) {

--- a/MonoGame.Framework/MacOS/Input/KeyboardUtil.cs
+++ b/MonoGame.Framework/MacOS/Input/KeyboardUtil.cs
@@ -1,0 +1,421 @@
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Xna.Framework.Input
+{
+	internal static class KeyboardUtil
+	{
+		static Dictionary<OpenTK.Input.Key, Keys> _map;
+		
+		static KeyboardUtil ()
+		{
+			_map = new Dictionary<OpenTK.Input.Key, Keys> ();
+			var values = Enum.GetValues (typeof(OpenTK.Input.Key));
+			
+			foreach (OpenTK.Input.Key tkKey in values)
+				_map [tkKey] = _ToXna (tkKey);
+		}
+		
+		static Keys _ToXna (OpenTK.Input.Key key)
+		{
+			switch (key)
+			{
+				case OpenTK.Input.Key.A:
+					return Keys.A;
+	                    
+				case OpenTK.Input.Key.AltLeft:
+					return Keys.LeftAlt;
+	                    
+				case OpenTK.Input.Key.AltRight:
+					return Keys.RightAlt;
+	                    
+				case OpenTK.Input.Key.B:
+					return Keys.B;
+	                    
+				case OpenTK.Input.Key.Back:
+					return Keys.Back;
+	                    
+				case OpenTK.Input.Key.BackSlash:
+					return Keys.OemBackslash;
+	                    
+				case OpenTK.Input.Key.BracketLeft:
+					return Keys.OemOpenBrackets;
+	                    
+				case OpenTK.Input.Key.BracketRight:
+					return Keys.OemCloseBrackets;
+	                    
+				case OpenTK.Input.Key.C:
+					return Keys.C;
+	                    
+				case OpenTK.Input.Key.CapsLock:
+					return Keys.CapsLock;
+	                    
+				case OpenTK.Input.Key.Clear:
+					return Keys.OemClear;
+	                    
+				case OpenTK.Input.Key.Comma:
+					return Keys.OemComma;
+	                    
+				case OpenTK.Input.Key.ControlLeft:
+					return Keys.LeftControl;
+	                    
+				case OpenTK.Input.Key.ControlRight:
+					return Keys.RightControl;
+	                    
+				case OpenTK.Input.Key.D:
+					return Keys.D;
+	                    
+				case OpenTK.Input.Key.Delete:
+					return Keys.Delete;
+	                    
+				case OpenTK.Input.Key.Down:
+					return Keys.Down;
+	                    
+				case OpenTK.Input.Key.E:
+					return Keys.E;
+	                    
+				case OpenTK.Input.Key.End:
+					return Keys.End;
+	                    
+				case OpenTK.Input.Key.Enter:
+					return Keys.Enter;
+	                    
+				case OpenTK.Input.Key.Escape:
+					return Keys.Escape;
+	                    
+				case OpenTK.Input.Key.F:
+					return Keys.F;
+	                    
+				case OpenTK.Input.Key.F1:
+					return Keys.F1;
+	                    
+				case OpenTK.Input.Key.F10:
+					return Keys.F10;
+	                    
+				case OpenTK.Input.Key.F11:
+					return Keys.F11;
+	                    
+				case OpenTK.Input.Key.F12:
+					return Keys.F12;
+	                    
+				case OpenTK.Input.Key.F13:
+					return Keys.F13;
+	                    
+				case OpenTK.Input.Key.F14:
+					return Keys.F14;
+	                    
+				case OpenTK.Input.Key.F15:
+					return Keys.F15;
+	                    
+				case OpenTK.Input.Key.F16:
+					return Keys.F16;
+	                    
+				case OpenTK.Input.Key.F17:
+					return Keys.F17;
+	                    
+				case OpenTK.Input.Key.F18:
+					return Keys.F18;
+	                    
+				case OpenTK.Input.Key.F19:
+					return Keys.F19;
+	                    
+				case OpenTK.Input.Key.F2:
+					return Keys.F2;
+	                    
+				case OpenTK.Input.Key.F20:
+					return Keys.F20;
+	                    
+				case OpenTK.Input.Key.F21:
+					return Keys.F21;
+	                    
+				case OpenTK.Input.Key.F22:
+					return Keys.F22;
+	                    
+				case OpenTK.Input.Key.F23:
+					return Keys.F23;
+	                    
+				case OpenTK.Input.Key.F24:
+					return Keys.F24;
+	                    
+				case OpenTK.Input.Key.F25:
+					return Keys.None;
+	                    
+				case OpenTK.Input.Key.F26:
+					return Keys.None;
+	                    
+				case OpenTK.Input.Key.F27:
+					return Keys.None;
+	                    
+				case OpenTK.Input.Key.F28:
+					return Keys.None;
+	                    
+				case OpenTK.Input.Key.F29:
+					return Keys.None;
+	                    
+				case OpenTK.Input.Key.F3:
+					return Keys.F3;
+	                    
+				case OpenTK.Input.Key.F30:
+					return Keys.None;
+	                    
+				case OpenTK.Input.Key.F31:
+					return Keys.None;
+	                    
+				case OpenTK.Input.Key.F32:
+					return Keys.None;
+	                    
+				case OpenTK.Input.Key.F33:
+					return Keys.None;
+	                    
+				case OpenTK.Input.Key.F34:
+					return Keys.None;
+	                    
+				case OpenTK.Input.Key.F35:
+					return Keys.None;
+	                    
+				case OpenTK.Input.Key.F4:
+					return Keys.F4;
+	                    
+				case OpenTK.Input.Key.F5:
+					return Keys.F5;
+	                    
+				case OpenTK.Input.Key.F6:
+					return Keys.F6;
+	                    
+				case OpenTK.Input.Key.F7:
+					return Keys.F7;
+	                    
+				case OpenTK.Input.Key.F8:
+					return Keys.F8;
+	                    
+				case OpenTK.Input.Key.F9:
+					return Keys.F9;
+	                    
+				case OpenTK.Input.Key.G:
+					return Keys.G;
+	                    
+				case OpenTK.Input.Key.H:
+					return Keys.H;
+	                    
+				case OpenTK.Input.Key.Home:
+					return Keys.Home;
+	                    
+				case OpenTK.Input.Key.I:
+					return Keys.I;
+	                    
+				case OpenTK.Input.Key.Insert:
+					return Keys.Insert;
+	                    
+				case OpenTK.Input.Key.J:
+					return Keys.J;
+	                    
+				case OpenTK.Input.Key.K:
+					return Keys.K;
+	                    
+				case OpenTK.Input.Key.Keypad0:
+					return Keys.NumPad0;
+	                    
+				case OpenTK.Input.Key.Keypad1:
+					return Keys.NumPad1;
+	                    
+				case OpenTK.Input.Key.Keypad2:
+					return Keys.NumPad2;
+	                    
+				case OpenTK.Input.Key.Keypad3:
+					return Keys.NumPad3;
+	                    
+				case OpenTK.Input.Key.Keypad4:
+					return Keys.NumPad4;
+	                    
+				case OpenTK.Input.Key.Keypad5:
+					return Keys.NumPad5;
+	                    
+				case OpenTK.Input.Key.Keypad6:
+					return Keys.NumPad6;
+	                    
+				case OpenTK.Input.Key.Keypad7:
+					return Keys.NumPad7;
+	                    
+				case OpenTK.Input.Key.Keypad8:
+					return Keys.NumPad8;
+	                    
+				case OpenTK.Input.Key.Keypad9:
+					return Keys.NumPad9;
+	                    
+				case OpenTK.Input.Key.KeypadAdd:
+					return Keys.Add;
+	                    
+				case OpenTK.Input.Key.KeypadDecimal:
+					return Keys.Decimal;
+	                    
+				case OpenTK.Input.Key.KeypadDivide:
+					return Keys.Divide;
+	                    
+				case OpenTK.Input.Key.KeypadEnter:
+					return Keys.Enter;
+	                    
+				case OpenTK.Input.Key.KeypadMinus:
+					return Keys.OemMinus;
+	                    
+				case OpenTK.Input.Key.KeypadMultiply:
+					return Keys.Multiply;
+	                    
+				case OpenTK.Input.Key.L:
+					return Keys.L;
+	                    
+				case OpenTK.Input.Key.LShift:
+					return Keys.LeftShift;
+	                    
+				case OpenTK.Input.Key.LWin:
+					return Keys.LeftWindows;
+	                    
+				case OpenTK.Input.Key.Left:
+					return Keys.Left;
+	                    
+				case OpenTK.Input.Key.M:
+					return Keys.M;
+	                    
+				case OpenTK.Input.Key.Minus:
+					return Keys.OemMinus;
+	                    
+				case OpenTK.Input.Key.N:
+					return Keys.N;
+	                    
+				case OpenTK.Input.Key.NumLock:
+					return Keys.NumLock;
+	                    
+				case OpenTK.Input.Key.Number0:
+					return Keys.D0;
+	                    
+				case OpenTK.Input.Key.Number1:
+					return Keys.D1;
+	                    
+				case OpenTK.Input.Key.Number2:
+					return Keys.D2;
+	                    
+				case OpenTK.Input.Key.Number3:
+					return Keys.D3;
+	                    
+				case OpenTK.Input.Key.Number4:
+					return Keys.D4;
+	                    
+				case OpenTK.Input.Key.Number5:
+					return Keys.D5;
+	                    
+				case OpenTK.Input.Key.Number6:
+					return Keys.D6;
+	                    
+				case OpenTK.Input.Key.Number7:
+					return Keys.D7;
+	                    
+				case OpenTK.Input.Key.Number8:
+					return Keys.D8;
+	                    
+				case OpenTK.Input.Key.Number9:
+					return Keys.D9;
+	                    
+				case OpenTK.Input.Key.O:
+					return Keys.O;
+	                    
+				case OpenTK.Input.Key.P:
+					return Keys.P;
+	                    
+				case OpenTK.Input.Key.PageDown:
+					return Keys.PageDown;
+	                    
+				case OpenTK.Input.Key.PageUp:
+					return Keys.PageUp;
+	                    
+				case OpenTK.Input.Key.Pause:
+					return Keys.Pause;
+	                    
+				case OpenTK.Input.Key.Period:
+					return Keys.OemPeriod;
+	                    
+				case OpenTK.Input.Key.Plus:
+					return Keys.OemPlus;
+	                    
+				case OpenTK.Input.Key.PrintScreen:
+					return Keys.PrintScreen;
+	                    
+				case OpenTK.Input.Key.Q:
+					return Keys.Q;
+	                    
+				case OpenTK.Input.Key.Quote:
+					return Keys.OemQuotes;
+	                    
+				case OpenTK.Input.Key.R:
+					return Keys.R;
+	                    
+				case OpenTK.Input.Key.Right:
+					return Keys.Right;
+	                    
+				case OpenTK.Input.Key.RShift:
+					return Keys.RightShift;
+	                    
+				case OpenTK.Input.Key.RWin:
+					return Keys.RightWindows;
+	                    
+				case OpenTK.Input.Key.S:
+					return Keys.S;
+	                    
+				case OpenTK.Input.Key.ScrollLock:
+					return Keys.Scroll;
+	                    
+				case OpenTK.Input.Key.Semicolon:
+					return Keys.OemSemicolon;
+	                    
+				case OpenTK.Input.Key.Slash:
+					return Keys.OemQuestion;
+	                    
+				case OpenTK.Input.Key.Sleep:
+					return Keys.Sleep;
+	                    
+				case OpenTK.Input.Key.Space:
+					return Keys.Space;
+	                    
+				case OpenTK.Input.Key.T:
+					return Keys.T;
+	                    
+				case OpenTK.Input.Key.Tab:
+					return Keys.Tab;
+	                    
+				case OpenTK.Input.Key.Tilde:
+					return Keys.OemTilde;
+	                    
+				case OpenTK.Input.Key.U:
+					return Keys.U;
+	                    
+				case OpenTK.Input.Key.Unknown:
+					return Keys.None;
+	                    
+				case OpenTK.Input.Key.Up:
+					return Keys.Up;
+	                    
+				case OpenTK.Input.Key.V:
+					return Keys.V;
+	                    
+				case OpenTK.Input.Key.W:
+					return Keys.W;
+	                    
+				case OpenTK.Input.Key.X:
+					return Keys.X;
+				
+				case OpenTK.Input.Key.Y:
+					return Keys.Y;
+			
+				case OpenTK.Input.Key.Z:				
+					return Keys.Z;
+				
+				default:
+					return Keys.None;	                    
+			}	
+		}
+			
+		public static Keys ToXna (OpenTK.Input.Key key)
+		{
+			return _map [key];
+		}
+	}
+}
+

--- a/MonoGame.Framework/Media/VideoPlayer.MacOS.cs
+++ b/MonoGame.Framework/Media/VideoPlayer.MacOS.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Xna.Framework.Media
     public sealed partial class VideoPlayer : IDisposable
     {
         private Game _game;
-        private MacGamePlatform _platform;
+        private GamePlatform _platform;
 
         // TODO Needed to bind OpenGL to Quicktime private QTVisualContextRef  textureContext;
         // TODO Needed to grab frame as a texture private CVOpenGLTextureRef  currentFrame;
@@ -20,7 +20,7 @@ namespace Microsoft.Xna.Framework.Media
         private void PlatformInitialize()
         {
             _game = Game.Instance;
-            _platform = (MacGamePlatform)_game.Services.GetService(typeof(MacGamePlatform));
+            _platform = (GamePlatform)_game.Services.GetService(typeof(GamePlatform));
         }
 
         private Texture2D PlatformGetTexture()
@@ -59,7 +59,8 @@ namespace Microsoft.Xna.Framework.Media
 
             // TODO when Xamarin implement the relevant functions var theError = QTOpenGLTextureContextCreate( null, null, _game.Window.PixelFormat, _game.Window.OpenGLContext, out textureContext);
 
-            _game.Window.AddSubview(_currentVideo.MovieView);
+#warning DISABLED DURING MONOMAC OPENTK CONVERSION
+//            _game.Window.AddSubview(_currentVideo.MovieView);
 
             NSNotificationCenter.DefaultCenter.AddObserver(new NSString("QTMovieDidEndNotification"), (notification) =>
             {

--- a/MonoGame.Framework/Threading.cs
+++ b/MonoGame.Framework/Threading.cs
@@ -51,7 +51,7 @@ using OpenTK.Graphics.ES11;
 #else
 using OpenTK.Graphics.ES20;
 #endif
-#elif WINDOWS || LINUX || ANGLE
+#elif WINDOWS || LINUX || ANGLE || MONOMAC
 using OpenTK.Graphics;
 using OpenTK.Platform;
 using OpenTK;
@@ -76,7 +76,7 @@ namespace Microsoft.Xna.Framework
         //static Mutex actionsMutex = new Mutex();
 #elif IOS
         public static EAGLContext BackgroundContext;
-#elif WINDOWS || LINUX || ANGLE
+#elif WINDOWS || LINUX || ANGLE || MONOMAC
         public static IGraphicsContext BackgroundContext;
         public static IWindowInfo WindowInfo;
 #endif
@@ -191,7 +191,7 @@ namespace Microsoft.Xna.Framework
                 GL.Flush();
                 GraphicsExtensions.CheckGLError();
             }
-#elif WINDOWS || LINUX || ANGLE
+#elif WINDOWS || LINUX || ANGLE || MONOMAC
             lock (BackgroundContext)
             {
                 // Make the context current on this thread

--- a/MonoGame.Framework/TitleContainer.cs
+++ b/MonoGame.Framework/TitleContainer.cs
@@ -22,11 +22,11 @@ namespace Microsoft.Xna.Framework
     {
         static TitleContainer() 
         {
-#if WINDOWS || LINUX
+#if WINDOWS || LINUX || MONOMAC
             Location = AppDomain.CurrentDomain.BaseDirectory;
 #elif WINRT
             Location = Windows.ApplicationModel.Package.Current.InstalledLocation.Path;
-#elif IOS || MONOMAC
+#elif IOS
 			Location = NSBundle.MainBundle.ResourcePath;
 #elif PSM
 			Location = "/Application";
@@ -106,8 +106,8 @@ namespace Microsoft.Xna.Framework
             }
             return File.OpenRead(absolutePath);
 #else
-            var absolutePath = Path.Combine(Location, safeName);
-            return File.OpenRead(absolutePath);
+			var absolutePath = Path.Combine(Location, safeName);
+			return File.OpenRead(absolutePath);
 #endif
         }
 


### PR DESCRIPTION
OpenTK for `MONOMAC` platform. Now MacOS is a peer to `WINDOWS` and `LINUX` platforms. Common code for desktop platforms.

I think it's ready for review / testing. RE: #2154.

**NOTES:**

* OpenTK controller mappings can replace SDL on other desktop platforms. Didn't consider that in scope for this PR.
* Media / Video needs some love. I need to compare how the other desktop platforms interface to `GameWindow` and try to emulate.
* Three intentional `#warning DISABLED DURING MONOMAC OPENTK CONVERSION` messages were added.
 * One in `OpenTKGameWindow.cs` to bypass icon extraction from assembly
 * One in `MacOS/GamerServices/Guide.cs` for `Window.ClearKeyCacheState()` which may not be needed now that we're using a different game loop.
 * One in `Media/VideoPlayer.MacOS.cs` for `_game.Window.AddSubview(_currentVideo.MovieView);`. That's the one that need some love.