### PR TITLE
Fullscreen enabling for WindowsDX

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -635,8 +635,6 @@ namespace Microsoft.Xna.Framework
 
 #if !(WINDOWS && DIRECTX)
 
-            // FIXME : FULLSCREEN
-
             if (GraphicsDevice.PresentationParameters.IsFullScreen)
                 Platform.EnterFullScreen();
             else

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -634,6 +634,9 @@ namespace Microsoft.Xna.Framework
 			Platform.BeginScreenDeviceChange(GraphicsDevice.PresentationParameters.IsFullScreen);
 
 #if !(WINDOWS && DIRECTX)
+
+            // FIXME : FULLSCREEN
+
             if (GraphicsDevice.PresentationParameters.IsFullScreen)
                 Platform.EnterFullScreen();
             else

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -632,11 +632,13 @@ namespace Microsoft.Xna.Framework
         internal void applyChanges(GraphicsDeviceManager manager)
         {
 			Platform.BeginScreenDeviceChange(GraphicsDevice.PresentationParameters.IsFullScreen);
+
+#if !(WINDOWS && DIRECTX)
             if (GraphicsDevice.PresentationParameters.IsFullScreen)
                 Platform.EnterFullScreen();
             else
                 Platform.ExitFullScreen();
-
+#endif
             var viewport = new Viewport(0, 0,
 			                            GraphicsDevice.PresentationParameters.BackBufferWidth,
 			                            GraphicsDevice.PresentationParameters.BackBufferHeight);

--- a/MonoGame.Framework/GamePlatform.cs
+++ b/MonoGame.Framework/GamePlatform.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Xna.Framework
         protected TimeSpan _inactiveSleepTime = TimeSpan.FromMilliseconds(20.0);
         protected bool _needsToResetElapsedTime = false;
         bool disposed;
+        protected bool _alreadyInFullScreenMode = false;
+        protected bool _alreadyInWindowedMode = false;
         protected bool IsDisposed { get { return disposed; } }
 
         #endregion

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -663,7 +663,7 @@ namespace Microsoft.Xna.Framework.Graphics
                                             PresentationParameters.BackBufferWidth,
                                             PresentationParameters.BackBufferHeight,
                                             format,
-                                            SwapChainFlags.None);
+                                            SwapChainFlags.AllowModeSwitch);
 
                 if (useFullscreenParameter)
                 {
@@ -691,7 +691,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     ModeDescription =
                     {
                         Format = format,
-                        Scaling = DisplayModeScaling.Stretched,
+                        Scaling = DisplayModeScaling.Unspecified,
                         Width = PresentationParameters.BackBufferWidth,
                         Height = PresentationParameters.BackBufferHeight,                        
                     },

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -666,10 +666,9 @@ namespace Microsoft.Xna.Framework.Graphics
                                             SwapChainFlags.None
                                             );
 
+                // This force to switch to fullscreen mode when hardware mode enabled(working in WindowsDX mode).
                 if (useFullscreenParameter)
                 {
-                    // this force to switch to fullscreen mode when hardware mode enabled(working in WindowsDX mode).
-
                     _swapChain.SetFullscreenState(PresentationParameters.IsFullScreen, null);
                 }
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -668,6 +668,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 if (useFullscreenParameter)
                 {
+                    // this force to switch to fullscreen mode when hardware mode enabled(working in WindowsDX mode).
+
                     _swapChain.SetFullscreenState(PresentationParameters.IsFullScreen, null);
                 }
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -691,7 +691,11 @@ namespace Microsoft.Xna.Framework.Graphics
                     ModeDescription =
                     {
                         Format = format,
+#if WINRT
+                        Scaling = DisplayModeScaling.Stretched,
+#else
                         Scaling = DisplayModeScaling.Unspecified,
+#endif
                         Width = PresentationParameters.BackBufferWidth,
                         Height = PresentationParameters.BackBufferHeight,                        
                     },

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -590,7 +590,7 @@ namespace Microsoft.Xna.Framework.Graphics
             _d3dContext = _d3dDevice.ImmediateContext.QueryInterface<SharpDX.Direct3D11.DeviceContext>();
         }
 
-        internal void CreateSizeDependentResources()
+        internal void CreateSizeDependentResources(bool useFullscreenParameter = false)
         {
             _d3dContext.OutputMerger.SetTargets((SharpDX.Direct3D11.DepthStencilView)null,
                                                 (SharpDX.Direct3D11.RenderTargetView)null);
@@ -665,6 +665,11 @@ namespace Microsoft.Xna.Framework.Graphics
                                             format,
                                             SwapChainFlags.None);
 
+                if (useFullscreenParameter)
+                {
+                    _swapChain.SetFullscreenState(PresentationParameters.IsFullScreen, null);
+                }
+
                 // Update Vsync setting.
                 using (var dxgiDevice = _d3dDevice.QueryInterface<SharpDX.DXGI.Device1>())
                 {
@@ -696,7 +701,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     Usage = SharpDX.DXGI.Usage.RenderTargetOutput,
                     BufferCount = 2,
                     SwapEffect = SharpDXHelper.ToSwapEffect(PresentationParameters.PresentationInterval),
-                    IsWindowed = true,
+                    IsWindowed = useFullscreenParameter ? PresentationParameters.IsFullScreen : true,
                 };
 
                 // Once the desired swap chain description is configured, it must be created on the same adapter as our D3D Device

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -663,7 +663,12 @@ namespace Microsoft.Xna.Framework.Graphics
                                             PresentationParameters.BackBufferWidth,
                                             PresentationParameters.BackBufferHeight,
                                             format,
-                                            SwapChainFlags.AllowModeSwitch);
+#if WINRT
+                                            SwapChainFlags.None
+#else
+                                            SwapChainFlags.AllowModeSwitch
+#endif
+                                            );
 
                 if (useFullscreenParameter)
                 {

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -663,11 +663,7 @@ namespace Microsoft.Xna.Framework.Graphics
                                             PresentationParameters.BackBufferWidth,
                                             PresentationParameters.BackBufferHeight,
                                             format,
-#if WINRT
                                             SwapChainFlags.None
-#else
-                                            SwapChainFlags.AllowModeSwitch
-#endif
                                             );
 
                 if (useFullscreenParameter)

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Xna.Framework
             _graphicsDevice.PresentationParameters.BackBufferHeight = _preferredBackBufferHeight;
             _graphicsDevice.PresentationParameters.DepthStencilFormat = _preferredDepthStencilFormat;
             _graphicsDevice.PresentationParameters.PresentationInterval = _synchronizedWithVerticalRetrace ? PresentInterval.Default : PresentInterval.Immediate;
-            _graphicsDevice.PresentationParameters.IsFullScreen = false;
+            _graphicsDevice.PresentationParameters.IsFullScreen = _wantFullScreen;
 
             // TODO: We probably should be resetting the whole 
             // device if this changes as we are targeting a different
@@ -426,8 +426,10 @@ namespace Microsoft.Xna.Framework
                 return true;
 #elif (WINDOWS && DIRECTX)
 
-
-                // FIXME : FULLSCREEN
+                if (_graphicsDevice != null)
+                {
+                    return _graphicsDevice.PresentationParameters.IsFullScreen;
+                }
 
                 return _wantFullScreen;
 #else
@@ -446,8 +448,6 @@ namespace Microsoft.Xna.Framework
 #if WINRT
                 // Just ignore this as it is not relevant on Windows 8
 #elif WINDOWS && DIRECTX
-
-                // FIXME : FULLSCREEN
 
                 _wantFullScreen = value;
 #else

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Xna.Framework
         private DisplayOrientation _supportedOrientations;
         private bool _synchronizedWithVerticalRetrace = true;
         private bool _drawBegun;
+        private bool _hardwareModeSwitch = false;
 
 #if WINDOWS && DIRECTX
 
@@ -234,7 +235,7 @@ namespace Microsoft.Xna.Framework
             _graphicsDevice.PresentationParameters.BackBufferHeight = _preferredBackBufferHeight;
             _graphicsDevice.PresentationParameters.DepthStencilFormat = _preferredDepthStencilFormat;
             _graphicsDevice.PresentationParameters.PresentationInterval = _synchronizedWithVerticalRetrace ? PresentInterval.Default : PresentInterval.Immediate;
-            _graphicsDevice.PresentationParameters.IsFullScreen = _wantFullScreen; // FIXME : FULLSCREEN
+            _graphicsDevice.PresentationParameters.IsFullScreen = false;
 
             // TODO: We probably should be resetting the whole 
             // device if this changes as we are targeting a different
@@ -460,6 +461,12 @@ namespace Microsoft.Xna.Framework
                 }
 #endif
             }
+        }
+
+        public bool HardwareModeSwitch
+        {
+            get { return _hardwareModeSwitch;}
+            set { if (_graphicsDevice == null) _hardwareModeSwitch = value; }
         }
 
 #if ANDROID

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -424,23 +424,13 @@ namespace Microsoft.Xna.Framework
             {
 #if WINRT
                 return true;
-#elif (WINDOWS && DIRECTX)
-
+#else
                 if (_graphicsDevice != null)
                 {
                     return _graphicsDevice.PresentationParameters.IsFullScreen;
                 }
 
                 return _wantFullScreen;
-#else
-                if (_graphicsDevice != null)
-                {
-                    return _graphicsDevice.PresentationParameters.IsFullScreen;
-                }
-                else
-                {
-                    return _wantFullScreen;
-                }
 #endif
             }
             set

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Xna.Framework
         private DisplayOrientation _supportedOrientations;
         private bool _synchronizedWithVerticalRetrace = true;
         private bool _drawBegun;
-        private bool _hardwareModeSwitch = false;
+        private bool _hardwareModeSwitch = true;
 
 #if WINDOWS && DIRECTX
 

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -37,9 +37,6 @@ namespace Microsoft.Xna.Framework
         private bool _hardwareModeSwitch = true;
 
 #if WINDOWS && DIRECTX
-
-        // FIXME : FULLSCREEN
-
         private bool _firstLaunch = true;
 #endif
         bool disposed;
@@ -298,8 +295,6 @@ namespace Microsoft.Xna.Framework
 
 #if WINDOWS && DIRECTX
 
-            // FIXME : FULLSCREEN
-
             if (!_firstLaunch)
             {
                 if (IsFullScreen)
@@ -396,8 +391,6 @@ namespace Microsoft.Xna.Framework
         {
             IsFullScreen = !IsFullScreen;
 #if WINDOWS && DIRECTX
-
-            // FIXME : FULLSCREEN
 
             ApplyChanges();
 #endif

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -34,7 +34,13 @@ namespace Microsoft.Xna.Framework
         private DisplayOrientation _supportedOrientations;
         private bool _synchronizedWithVerticalRetrace = true;
         private bool _drawBegun;
+
+#if WINDOWS && DIRECTX
+
+        // FIXME : FULLSCREEN
+
         private bool _firstLaunch = true;
+#endif
         bool disposed;
 
 #if !WINRT
@@ -228,7 +234,7 @@ namespace Microsoft.Xna.Framework
             _graphicsDevice.PresentationParameters.BackBufferHeight = _preferredBackBufferHeight;
             _graphicsDevice.PresentationParameters.DepthStencilFormat = _preferredDepthStencilFormat;
             _graphicsDevice.PresentationParameters.PresentationInterval = _synchronizedWithVerticalRetrace ? PresentInterval.Default : PresentInterval.Immediate;
-            _graphicsDevice.PresentationParameters.IsFullScreen = _wantFullScreen;
+            _graphicsDevice.PresentationParameters.IsFullScreen = _wantFullScreen; // FIXME : FULLSCREEN
 
             // TODO: We probably should be resetting the whole 
             // device if this changes as we are targeting a different
@@ -290,6 +296,9 @@ namespace Microsoft.Xna.Framework
             TouchPanel.DisplayHeight = _graphicsDevice.PresentationParameters.BackBufferHeight;
 
 #if WINDOWS && DIRECTX
+
+            // FIXME : FULLSCREEN
+
             if (!_firstLaunch)
             {
                 if (IsFullScreen)
@@ -386,6 +395,9 @@ namespace Microsoft.Xna.Framework
         {
             IsFullScreen = !IsFullScreen;
 #if WINDOWS && DIRECTX
+
+            // FIXME : FULLSCREEN
+
             ApplyChanges();
 #endif
         }
@@ -412,6 +424,10 @@ namespace Microsoft.Xna.Framework
 #if WINRT
                 return true;
 #elif (WINDOWS && DIRECTX)
+
+
+                // FIXME : FULLSCREEN
+
                 return _wantFullScreen;
 #else
                 if (_graphicsDevice != null)
@@ -429,6 +445,9 @@ namespace Microsoft.Xna.Framework
 #if WINRT
                 // Just ignore this as it is not relevant on Windows 8
 #elif WINDOWS && DIRECTX
+
+                // FIXME : FULLSCREEN
+
                 _wantFullScreen = value;
 #else
                 _wantFullScreen = value;

--- a/MonoGame.Framework/Windows/WinFormsGameForm.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameForm.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Xna.Framework.Windows
         public const int WM_POINTERUP = 0x0247;
         public const int WM_POINTERDOWN = 0x0246;
         public const int WM_POINTERUPDATE = 0x0245;
-
+        public const int WM_KEYDOWN = 0x0100;
         public const int WM_TABLET_QUERYSYSTEMGESTURESTA = (0x02C0 + 12);
 
         public const int WM_SYSCOMMAND = 0x0112;
@@ -66,11 +66,27 @@ namespace Microsoft.Xna.Framework.Windows
                         m.Result = new IntPtr(flags);
                         return;
                     }
+#if (WINDOWS && DIRECTX)
+                case WM_KEYDOWN:
+                    switch (m.WParam.ToInt32())
+                    {
+                        case 0x5B:  // Left Windows Key
 
+                            if (this.WindowState == FormWindowState.Maximized)
+                            {
+                                this.WindowState = FormWindowState.Minimized;
+                            }
+
+                            break;
+                        case 0x5C: // Right Windows Key
+                            goto case 0x5B;
+                    }
+                    break;
+#endif
                 case WM_SYSCOMMAND:
 
                     var wParam = m.WParam.ToInt32();
-
+                     
                     if (!AllowAltF4 && wParam == 0xF060 && m.LParam.ToInt32() == 0 && Focused)
                     {
                         m.Result = IntPtr.Zero;

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -85,10 +85,16 @@ namespace MonoGame.Framework
         private WinFormsGameWindow _window;
         private readonly List<XnaKeys> _keyState;
 
+#if WINDOWS && DIRECTX
+
+        // FIXME : FULLSCREEN
+
         private int _savedWindowedLocX;
         private int _savedWindowedLocY;
         private int _savedWindowedSizeX;
         private int _savedWindowedSizeY;
+
+#endif
 
         public WinFormsGamePlatform(Game game)
             : base(game)
@@ -126,6 +132,9 @@ namespace MonoGame.Framework
             base.BeforeInitialize();
 
 #if (WINDOWS && DIRECTX)
+
+            // FIXME : FULLSCREEN
+
             _savedWindowedLocX = _window._form.Location.X;
             _savedWindowedLocY = _window._form.Location.Y;
             _savedWindowedSizeX = _window._form.Bounds.Width;
@@ -167,6 +176,8 @@ namespace MonoGame.Framework
         public override void EnterFullScreen()
         {
 #if (WINDOWS && DIRECTX)
+            // FIXME : FULLSCREEN
+
             if (_window._form.Location.X != 0 && _window._form.Location.Y != 0)
             {
                 _savedWindowedLocX = _window._form.Location.X;
@@ -182,7 +193,7 @@ namespace MonoGame.Framework
         public override void ExitFullScreen()
         {
 #if (WINDOWS && DIRECTX)
-
+            // FIXME : FULLSCREEN
              
             _window.IsBorderless = false;
             _window._form.SetBounds(_savedWindowedLocX, _savedWindowedLocY, _savedWindowedSizeX, _savedWindowedSizeY);

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -85,6 +85,11 @@ namespace MonoGame.Framework
         private WinFormsGameWindow _window;
         private readonly List<XnaKeys> _keyState;
 
+        private int _savedWindowedLocX;
+        private int _savedWindowedLocY;
+        private int _savedWindowedSizeX;
+        private int _savedWindowedSizeY;
+
         public WinFormsGamePlatform(Game game)
             : base(game)
         {
@@ -118,8 +123,19 @@ namespace MonoGame.Framework
         public override void BeforeInitialize()
         {
             _window.Initialize(Game.graphicsDeviceManager.PreferredBackBufferWidth, Game.graphicsDeviceManager.PreferredBackBufferHeight);
-
             base.BeforeInitialize();
+
+#if (WINDOWS && DIRECTX)
+            _savedWindowedLocX = _window._form.Location.X;
+            _savedWindowedLocY = _window._form.Location.Y;
+            _savedWindowedSizeX = _window._form.Bounds.Width;
+            _savedWindowedSizeY = _window._form.Bounds.Height;
+
+            if (Game.graphicsDeviceManager.IsFullScreen)
+            {
+                EnterFullScreen();
+            }
+#endif
         }
 
         public override void RunLoop()
@@ -147,12 +163,35 @@ namespace MonoGame.Framework
             return true;
         }
 
+
         public override void EnterFullScreen()
         {
+#if (WINDOWS && DIRECTX)
+            if (_window._form.Location.X != 0 && _window._form.Location.Y != 0)
+            {
+                _savedWindowedLocX = _window._form.Location.X;
+                _savedWindowedLocY = _window._form.Location.Y;
+            }
+            _window.IsBorderless = true;
+
+            var monitor = Screen.PrimaryScreen.Bounds;
+            _window._form.SetBounds(0, 0, monitor.Width, monitor.Height);
+#endif
         }
 
         public override void ExitFullScreen()
         {
+#if (WINDOWS && DIRECTX)
+
+             
+            _window.IsBorderless = false;
+            _window._form.SetBounds(_savedWindowedLocX, _savedWindowedLocY, _savedWindowedSizeX, _savedWindowedSizeY);
+            
+            _savedWindowedLocX = _window._form.Location.X;
+            _savedWindowedLocY = _window._form.Location.Y;
+            _savedWindowedSizeX = _window._form.Bounds.Width;
+            _savedWindowedSizeY = _window._form.Bounds.Height;
+#endif
         }
 
         public void ResetWindowBounds()

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -171,8 +171,8 @@ namespace MonoGame.Framework
             }
             else
             {
-                _window._form.WindowState = FormWindowState.Maximized;
                 _window.IsBorderless = true;
+                _window._form.WindowState = FormWindowState.Maximized;
             }
 #endif
         }
@@ -191,9 +191,8 @@ namespace MonoGame.Framework
             }
             else
             {
-
-                _window.IsBorderless = false;
                 _window._form.WindowState = FormWindowState.Normal;
+                _window.IsBorderless = false;
             }
 #endif
         }

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -162,8 +162,18 @@ namespace MonoGame.Framework
 #if (WINDOWS && DIRECTX)
             // FIXME : FULLSCREEN
 
-            _window._form.WindowState = FormWindowState.Maximized;
-            _window.IsBorderless = true;
+
+            if (Game.graphicsDeviceManager.HardwareModeSwitch)
+            {
+                 Game.GraphicsDevice.PresentationParameters.IsFullScreen = true;
+                 Game.GraphicsDevice.CreateSizeDependentResources(true);
+                 Game.GraphicsDevice.ApplyRenderTargets(null);
+            }
+            else
+            {
+                _window._form.WindowState = FormWindowState.Maximized;
+                _window.IsBorderless = true;
+            }
 #endif
         }
 
@@ -172,9 +182,19 @@ namespace MonoGame.Framework
 #if (WINDOWS && DIRECTX)
 
             // FIXME : FULLSCREEN
-             
-            _window.IsBorderless = false;
-            _window._form.WindowState = FormWindowState.Normal;
+
+            if (Game.graphicsDeviceManager.HardwareModeSwitch)
+            {
+                Game.GraphicsDevice.PresentationParameters.IsFullScreen = false;
+                Game.GraphicsDevice.CreateSizeDependentResources(true);
+                Game.GraphicsDevice.ApplyRenderTargets(null);
+            }
+            else
+            {
+
+                _window.IsBorderless = false;
+                _window._form.WindowState = FormWindowState.Normal;
+            }
 #endif
         }
 

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -122,8 +122,6 @@ namespace MonoGame.Framework
 
 #if (WINDOWS && DIRECTX)
 
-            // FIXME : FULLSCREEN
-
             if (Game.graphicsDeviceManager.IsFullScreen)
             {
                 EnterFullScreen();
@@ -164,7 +162,6 @@ namespace MonoGame.Framework
         public override void EnterFullScreen()
         {
 #if (WINDOWS && DIRECTX)
-            // FIXME : FULLSCREEN
 
             if (_alreadyInFullScreenMode)
             {
@@ -192,8 +189,6 @@ namespace MonoGame.Framework
         public override void ExitFullScreen()
         {
 #if (WINDOWS && DIRECTX)
-            // FIXME : FULLSCREEN
-
             if (_alreadyInWindowedMode)
             {
                 return;

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -85,17 +85,6 @@ namespace MonoGame.Framework
         private WinFormsGameWindow _window;
         private readonly List<XnaKeys> _keyState;
 
-#if WINDOWS && DIRECTX
-
-        // FIXME : FULLSCREEN
-
-        private int _savedWindowedLocX;
-        private int _savedWindowedLocY;
-        private int _savedWindowedSizeX;
-        private int _savedWindowedSizeY;
-
-#endif
-
         public WinFormsGamePlatform(Game game)
             : base(game)
         {
@@ -135,11 +124,6 @@ namespace MonoGame.Framework
 
             // FIXME : FULLSCREEN
 
-            _savedWindowedLocX = _window._form.Location.X;
-            _savedWindowedLocY = _window._form.Location.Y;
-            _savedWindowedSizeX = _window._form.Bounds.Width;
-            _savedWindowedSizeY = _window._form.Bounds.Height;
-
             if (Game.graphicsDeviceManager.IsFullScreen)
             {
                 EnterFullScreen();
@@ -178,30 +162,19 @@ namespace MonoGame.Framework
 #if (WINDOWS && DIRECTX)
             // FIXME : FULLSCREEN
 
-            if (_window._form.Location.X != 0 && _window._form.Location.Y != 0)
-            {
-                _savedWindowedLocX = _window._form.Location.X;
-                _savedWindowedLocY = _window._form.Location.Y;
-            }
+            _window._form.WindowState = FormWindowState.Maximized;
             _window.IsBorderless = true;
-
-            var monitor = Screen.PrimaryScreen.Bounds;
-            _window._form.SetBounds(0, 0, monitor.Width, monitor.Height);
 #endif
         }
 
         public override void ExitFullScreen()
         {
 #if (WINDOWS && DIRECTX)
+
             // FIXME : FULLSCREEN
              
             _window.IsBorderless = false;
-            _window._form.SetBounds(_savedWindowedLocX, _savedWindowedLocY, _savedWindowedSizeX, _savedWindowedSizeY);
-            
-            _savedWindowedLocX = _window._form.Location.X;
-            _savedWindowedLocY = _window._form.Location.Y;
-            _savedWindowedSizeX = _window._form.Bounds.Width;
-            _savedWindowedSizeY = _window._form.Bounds.Height;
+            _window._form.WindowState = FormWindowState.Normal;
 #endif
         }
 

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -128,6 +128,10 @@ namespace MonoGame.Framework
             {
                 EnterFullScreen();
             }
+            else
+            {
+                ExitFullScreen();
+            }
 #endif
         }
 
@@ -162,6 +166,10 @@ namespace MonoGame.Framework
 #if (WINDOWS && DIRECTX)
             // FIXME : FULLSCREEN
 
+            if (_alreadyInFullScreenMode)
+            {
+                return;
+            }
 
             if (Game.graphicsDeviceManager.HardwareModeSwitch)
             {
@@ -174,14 +182,21 @@ namespace MonoGame.Framework
                 _window.IsBorderless = true;
                 _window._form.WindowState = FormWindowState.Maximized;
             }
+
+            _alreadyInWindowedMode = false;
+            _alreadyInFullScreenMode = true;
 #endif
         }
 
         public override void ExitFullScreen()
         {
 #if (WINDOWS && DIRECTX)
-
             // FIXME : FULLSCREEN
+
+            if (_alreadyInWindowedMode)
+            {
+                return;
+            }
 
             if (Game.graphicsDeviceManager.HardwareModeSwitch)
             {
@@ -194,6 +209,10 @@ namespace MonoGame.Framework
                 _window._form.WindowState = FormWindowState.Normal;
                 _window.IsBorderless = false;
             }
+            ResetWindowBounds();
+
+            _alreadyInWindowedMode = true;
+            _alreadyInFullScreenMode = false;
 #endif
         }
 

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -176,6 +176,7 @@ namespace MonoGame.Framework
                  Game.GraphicsDevice.PresentationParameters.IsFullScreen = true;
                  Game.GraphicsDevice.CreateSizeDependentResources(true);
                  Game.GraphicsDevice.ApplyRenderTargets(null);
+                _window._form.WindowState = FormWindowState.Maximized;
             }
             else
             {
@@ -203,6 +204,7 @@ namespace MonoGame.Framework
                 Game.GraphicsDevice.PresentationParameters.IsFullScreen = false;
                 Game.GraphicsDevice.CreateSizeDependentResources(true);
                 Game.GraphicsDevice.ApplyRenderTargets(null);
+                _window._form.WindowState = FormWindowState.Normal;
             }
             else
             {

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -339,6 +339,9 @@ namespace MonoGame.Framework
                 var newWidth = _form.ClientRectangle.Width;
                 var newHeight = _form.ClientRectangle.Height;
 #if !(WINDOWS && DIRECTX)
+
+                // FIXME : FULLSCREEN
+
                 manager.PreferredBackBufferWidth = newWidth;
                 manager.PreferredBackBufferHeight = newHeight;
 #endif

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -338,9 +338,10 @@ namespace MonoGame.Framework
 
                 var newWidth = _form.ClientRectangle.Width;
                 var newHeight = _form.ClientRectangle.Height;
+#if !(WINDOWS && DIRECTX)
                 manager.PreferredBackBufferWidth = newWidth;
                 manager.PreferredBackBufferHeight = newHeight;
-
+#endif
                 if (manager.GraphicsDevice == null)
                     return;
             }

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -354,9 +354,6 @@ namespace MonoGame.Framework
                 var newWidth = _form.ClientRectangle.Width;
                 var newHeight = _form.ClientRectangle.Height;
 #if !(WINDOWS && DIRECTX)
-
-                // FIXME : FULLSCREEN
-
                 manager.PreferredBackBufferWidth = newWidth;
                 manager.PreferredBackBufferHeight = newHeight;
 #endif

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -200,6 +200,21 @@ namespace MonoGame.Framework
 
         private void OnActivated(object sender, EventArgs eventArgs)
         {
+#if (WINDOWS && DIRECTX)
+            if (Game.GraphicsDevice != null)
+            {
+                if (Game.graphicsDeviceManager.HardwareModeSwitch)
+                {
+                    if (!_platform.IsActive && Game.GraphicsDevice.PresentationParameters.IsFullScreen)
+                    {
+                        Game.GraphicsDevice.PresentationParameters.IsFullScreen = true;
+                        Game.GraphicsDevice.CreateSizeDependentResources(true);
+                        Game.GraphicsDevice.ApplyRenderTargets(null);
+                    }
+                }
+            }
+#endif
+
             _platform.IsActive = true;
         }
 


### PR DESCRIPTION
This experimental commit enables IsFullscreen in constructor, and in another methods with ApplyChange and also fixes ToggleFullScreen. Only for WindowsDX platform. Tested with XNA.
 
This is "soft" version - The window is just stretch up and loses borders.

Because these things already arent working it doesnt matter if my changes break them a bit.