### PR TITLE
Plane improvements

### DIFF
--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -93,7 +93,7 @@
     <Compile Include="Framework\TouchLocationTest.cs" />
     <Compile Include="Framework\Bounding.cs" />
     <Compile Include="Framework\MathHelperTest.cs" />
-	<Compile Include="Framework\PlaneTest.cs" />
+    <Compile Include="Framework\PlaneTest.cs" />
     <Compile Include="Framework\RayTest.cs" />
     <Compile Include="Framework\GameTest+Methods.cs" />
     <Compile Include="Framework\GameTest+Properties.cs" />

--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -93,6 +93,7 @@
     <Compile Include="Framework\TouchLocationTest.cs" />
     <Compile Include="Framework\Bounding.cs" />
     <Compile Include="Framework\MathHelperTest.cs" />
+	<Compile Include="Framework\PlaneTest.cs" />
     <Compile Include="Framework\RayTest.cs" />
     <Compile Include="Framework\GameTest+Methods.cs" />
     <Compile Include="Framework\GameTest+Properties.cs" />

--- a/MonoGame.Framework/Plane.cs
+++ b/MonoGame.Framework/Plane.cs
@@ -114,28 +114,67 @@ namespace Microsoft.Xna.Framework
         {
             result = ((this.Normal.X * value.X) + (this.Normal.Y * value.Y)) + (this.Normal.Z * value.Z);
         }
-        
-        /*
-        public static void Transform(ref Plane plane, ref Quaternion rotation, out Plane result)
-        {
-            throw new NotImplementedException();
-        }
 
-        public static void Transform(ref Plane plane, ref Matrix matrix, out Plane result)
-        {
-            throw new NotImplementedException();
-        }
-
-        public static Plane Transform(Plane plane, Quaternion rotation)
-        {
-            throw new NotImplementedException();
-        }
-
+        /// <summary>
+        /// Transforms a normalized plane by a matrix.
+        /// </summary>
+        /// <param name="plane">The normalized plane to transform.</param>
+        /// <param name="matrix">The transformation matrix.</param>
+        /// <returns>The transformed plane.</returns>
         public static Plane Transform(Plane plane, Matrix matrix)
         {
-            throw new NotImplementedException();
+            Plane result;
+            Transform(ref plane, ref matrix, out result);
+            return result;
         }
-        */
+
+        /// <summary>
+        /// Transforms a normalized plane by a matrix.
+        /// </summary>
+        /// <param name="plane">The normalized plane to transform.</param>
+        /// <param name="matrix">The transformation matrix.</param>
+        /// <param name="result">The transformed plane.</param>
+        public static void Transform(ref Plane plane, ref Matrix matrix, out Plane result)
+        {
+            // See "Transforming Normals" in http://www.glprogramming.com/red/appendixf.html
+            // for an explanation of how this works.
+
+            Matrix transformedMatrix;
+            Matrix.Invert(ref matrix, out transformedMatrix);
+            Matrix.Transpose(ref transformedMatrix, out transformedMatrix);
+
+            var vector = new Vector4(plane.Normal, plane.D);
+
+            Vector4 transformedVector;
+            Vector4.Transform(ref vector, ref transformedMatrix, out transformedVector);
+
+            result = new Plane(transformedVector);
+        }
+
+        /// <summary>
+        /// Transforms a normalized plane by a quaternion rotation.
+        /// </summary>
+        /// <param name="plane">The normalized plane to transform.</param>
+        /// <param name="rotation">The quaternion rotation.</param>
+        /// <returns>The transformed plane.</returns>
+        public static Plane Transform(Plane plane, Quaternion rotation)
+        {
+            Plane result;
+            Transform(ref plane, ref rotation, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Transforms a normalized plane by a quaternion rotation.
+        /// </summary>
+        /// <param name="plane">The normalized plane to transform.</param>
+        /// <param name="rotation">The quaternion rotation.</param>
+        /// <param name="result">The transformed plane.</param>
+        public static void Transform(ref Plane plane, ref Quaternion rotation, out Plane result)
+        {
+            Vector3.Transform(ref plane.Normal, ref rotation, out result.Normal);
+            result.D = plane.D;
+        }
 
         public void Normalize()
         {

--- a/Test/Framework/PlaneTest.cs
+++ b/Test/Framework/PlaneTest.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.Xna.Framework;
+using NUnit.Framework;
+
+namespace MonoGame.Tests.Framework
+{
+    public class PlaneTest
+    {
+        [Test]
+        public void TransformByMatrix()
+        {
+            // Our test plane.
+            var plane = Plane.Normalize(new Plane(new Vector3(0, 1, 1), 2.5f));
+
+            // Our matrix.
+            var matrix = Matrix.CreateRotationX(MathHelper.PiOver2);
+
+            // Test transform.
+            var expectedResult = new Plane(new Vector3(0, -0.7071068f, 0.7071067f), 1.767767f);
+            Assert.That(Plane.Transform(plane, matrix), Is.EqualTo(expectedResult).Using(PlaneComparer.Epsilon));
+        }
+
+        [Test]
+        public void TransformByRefMatrix()
+        {
+            // Our test plane.
+            var plane = Plane.Normalize(new Plane(new Vector3(1, 0.8f, 0.5f), 2.5f));
+            var originalPlane = plane;
+
+            // Our matrix.
+            var matrix = Matrix.CreateRotationX(MathHelper.PiOver2);
+            var originalMatrix = matrix;
+
+            // Test transform.
+            Plane result;
+            Plane.Transform(ref plane, ref matrix, out result);
+
+            var expectedResult = new Plane(new Vector3(0.7273929f, -0.3636965f, 0.5819144f), 1.818482f);
+            Assert.That(result, Is.EqualTo(expectedResult).Using(PlaneComparer.Epsilon));
+
+            Assert.That(plane, Is.EqualTo(originalPlane));
+            Assert.That(matrix, Is.EqualTo(originalMatrix));
+        }
+
+        [Test]
+        public void TransformByQuaternion()
+        {
+            // Our test plane.
+            var plane = Plane.Normalize(new Plane(new Vector3(0, 1, 1), 2.5f));
+
+            // Our quaternion.
+            var quaternion = Quaternion.CreateFromAxisAngle(Vector3.UnitX, MathHelper.PiOver2);
+
+            // Test transform.
+            var expectedResult = new Plane(new Vector3(0, -0.7071068f, 0.7071067f), 1.767767f);
+            Assert.That(Plane.Transform(plane, quaternion), Is.EqualTo(expectedResult).Using(PlaneComparer.Epsilon));
+        }
+
+        [Test]
+        public void TransformByRefQuaternion()
+        {
+            // Our test plane.
+            var plane = Plane.Normalize(new Plane(new Vector3(1, 0.8f, 0.5f), 2.5f));
+            var originalPlane = plane;
+
+            // Our quaternion.
+            var quaternion = Quaternion.CreateFromAxisAngle(Vector3.UnitX, MathHelper.PiOver2);
+            var originalQuaternion = quaternion;
+
+            // Test transform.
+            Plane result;
+            Plane.Transform(ref plane, ref quaternion, out result);
+
+            var expectedResult = new Plane(new Vector3(0.7273929f, -0.3636965f, 0.5819144f), 1.818482f);
+            Assert.That(result, Is.EqualTo(expectedResult).Using(PlaneComparer.Epsilon));
+
+            Assert.That(plane, Is.EqualTo(originalPlane));
+            Assert.That(quaternion, Is.EqualTo(originalQuaternion));
+        }
+    }
+}

--- a/Test/Runner/Utility.cs
+++ b/Test/Runner/Utility.cs
@@ -72,6 +72,31 @@ namespace MonoGame.Tests {
         }
     }
 
+    public class PlaneComparer : IEqualityComparer<Plane>
+    {
+        static public PlaneComparer Epsilon = new PlaneComparer(0.000001f);
+
+        private readonly float _epsilon;
+
+        private PlaneComparer(float epsilon)
+        {
+            _epsilon = epsilon;
+        }
+
+        public bool Equals(Plane x, Plane y)
+        {
+            return Math.Abs(x.Normal.X - y.Normal.X) < _epsilon &&
+                   Math.Abs(x.Normal.Y - y.Normal.Y) < _epsilon &&
+                   Math.Abs(x.Normal.Z - y.Normal.Z) < _epsilon &&
+                   Math.Abs(x.D - y.D) < _epsilon;
+        }
+
+        public int GetHashCode(Plane obj)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
     public static class ArrayUtil
     {
         public static T[] ConvertTo<T>(byte[] source) where T : struct


### PR DESCRIPTION
I've implemented the missing Plane.Transform methods, to transform a `Plane` by a `Matrix` and a `Quaternion`.

(I think this is my first pull request to MonoGame!)