### PR TITLE
Possible fix for PipelineProcessorContext.BuildAndLoadAsset bug

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
@@ -374,7 +374,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             return result;
         }
 
-        private void ResolveOutputFilepath(string sourceFilepath, ref string outputFilepath)
+        internal void ResolveOutputFilepath(string sourceFilepath, ref string outputFilepath)
         {
             // If the output path is null... build it from the source file path.
             if (string.IsNullOrEmpty(outputFilepath))

--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineProcessorContext.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineProcessorContext.cs
@@ -66,6 +66,9 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         {
             var sourceFilepath = PathHelper.Normalize(sourceAsset.Filename);
 
+            string outputFilepath = string.Empty;
+            _manager.ResolveOutputFilepath(sourceFilepath, ref outputFilepath);
+
             // The processorName can be null or empty. In this case the asset should
             // be imported but not processed. This is, for example, necessary to merge
             // animation files as described here:
@@ -76,6 +79,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             var buildEvent = new PipelineBuildEvent 
             { 
                 SourceFile = sourceFilepath,
+                DestFile = outputFilepath,
                 Importer = importerName,
                 Processor = processAsset ? processorName : null,
                 Parameters = _manager.ValidateProcessorParameters(processorName, processorParameters),


### PR DESCRIPTION
I don't know if this is the correct fix - changing `ResolveOutputFilepath` to `internal` makes me uncomfortable. But more generally, it seems to me (without much knowledge of this code) that `BuildAsset` and `BuildAndLoadAsset` could/should share more code than they are currently sharing.

I'm happy to rework this, if you can give me some pointers on a better way to fix it.

In any case, this fixes the issue I raised in #3349, so I'm now able to build dynamically generated effects. Yay!