### PR TITLE
Fix bug when building effects using ContentProcessorContext.BuildAndLoadAsset

### DIFF
--- a/Tools/2MGFX/ShaderInfo.cs
+++ b/Tools/2MGFX/ShaderInfo.cs
@@ -78,7 +78,8 @@ namespace TwoMGFX
             result.Dependencies = dependencies;
             result.FilePath = fullPath;
             result.FileContent = newFile;
-            result.OutputFilePath = Path.GetFullPath(options.OutputFile);
+            if (!string.IsNullOrEmpty(options.OutputFile))
+                result.OutputFilePath = Path.GetFullPath(options.OutputFile);
             result.AdditionalOutputFiles = new List<string>();
 
             // Remove empty techniques.


### PR DESCRIPTION
Fixes #3349.

As discussed in #3350, this is a better fix for the root issue, which is that `ShaderInfo.OutputFilePath` should only be set when building to disk. `BuildAndLoadAsset` does the build in-memory, so `OutputFilePath` isn't set.