### PR TITLE
Implement vertexStride in VertexBuffer.SetData for DirectX platform.

### DIFF
--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.DirectX.cs
@@ -138,18 +138,52 @@ namespace Microsoft.Xna.Framework.Graphics
                 var startBytes = startIndex * elementSizeInBytes;
                 var dataPtr = (IntPtr)(dataHandle.AddrOfPinnedObject().ToInt64() + startBytes);
 
-                var box = new SharpDX.DataBox(dataPtr, 1, 0);
+                var d3dContext = GraphicsDevice._d3dContext;
+                lock (d3dContext)
+                {
+                    if (vertexStride == elementSizeInBytes)
+                    {
+                        var box = new SharpDX.DataBox(dataPtr, 1, 0);
 
-                var region = new SharpDX.Direct3D11.ResourceRegion();
-                region.Top = 0;
-                region.Front = 0;
-                region.Back = 1;
-                region.Bottom = 1;
-                region.Left = offsetInBytes;
-                region.Right = offsetInBytes + (elementCount * elementSizeInBytes);
+                        var region = new SharpDX.Direct3D11.ResourceRegion();
+                        region.Top = 0;
+                        region.Front = 0;
+                        region.Back = 1;
+                        region.Bottom = 1;
+                        region.Left = offsetInBytes;
+                        region.Right = offsetInBytes + (elementCount * elementSizeInBytes);
 
-                lock (GraphicsDevice._d3dContext)
-                    GraphicsDevice._d3dContext.UpdateSubresource(box, _buffer, 0, region);
+                        d3dContext.UpdateSubresource(box, _buffer, 0, region);
+                    }
+                    else
+                    {
+                        // Copy the buffer to a staging resource, so that any elements we don't write to will still be correct.
+                        var stagingDesc = _buffer.Description;
+                        stagingDesc.BindFlags = SharpDX.Direct3D11.BindFlags.None;
+                        stagingDesc.CpuAccessFlags = SharpDX.Direct3D11.CpuAccessFlags.Read | SharpDX.Direct3D11.CpuAccessFlags.Write;
+                        stagingDesc.Usage = SharpDX.Direct3D11.ResourceUsage.Staging;
+                        stagingDesc.OptionFlags = SharpDX.Direct3D11.ResourceOptionFlags.None;
+                        var stagingBuffer = new SharpDX.Direct3D11.Buffer(GraphicsDevice._d3dDevice, stagingDesc);
+
+                        lock (GraphicsDevice._d3dContext)
+                            d3dContext.CopyResource(_buffer, stagingBuffer);
+
+                        // Map the staging resource to a CPU accessible memory
+                        var box = d3dContext.MapSubresource(stagingBuffer, 0, SharpDX.Direct3D11.MapMode.Read, SharpDX.Direct3D11.MapFlags.None);
+
+                        for (int i = 0; i < data.Length; i++)
+                            SharpDX.Utilities.CopyMemory(box.DataPointer + i * vertexStride + offsetInBytes, dataPtr + i * elementSizeInBytes, elementSizeInBytes);
+
+                        // Make sure that we unmap the resource in case of an exception
+                        d3dContext.UnmapSubresource(stagingBuffer, 0);
+
+                        // Copy back from staging resource to real buffer.
+                        lock (GraphicsDevice._d3dContext)
+                            d3dContext.CopyResource(stagingBuffer, _buffer);
+
+                        stagingBuffer.Dispose();
+                    }
+                }
 
                 dataHandle.Free();
             }

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.DirectX.cs
@@ -139,50 +139,53 @@ namespace Microsoft.Xna.Framework.Graphics
                 var dataPtr = (IntPtr)(dataHandle.AddrOfPinnedObject().ToInt64() + startBytes);
 
                 var d3dContext = GraphicsDevice._d3dContext;
-                lock (d3dContext)
+                
+                if (vertexStride == elementSizeInBytes)
                 {
-                    if (vertexStride == elementSizeInBytes)
-                    {
-                        var box = new SharpDX.DataBox(dataPtr, 1, 0);
+                    var box = new SharpDX.DataBox(dataPtr, 1, 0);
 
-                        var region = new SharpDX.Direct3D11.ResourceRegion();
-                        region.Top = 0;
-                        region.Front = 0;
-                        region.Back = 1;
-                        region.Bottom = 1;
-                        region.Left = offsetInBytes;
-                        region.Right = offsetInBytes + (elementCount * elementSizeInBytes);
+                    var region = new SharpDX.Direct3D11.ResourceRegion();
+                    region.Top = 0;
+                    region.Front = 0;
+                    region.Back = 1;
+                    region.Bottom = 1;
+                    region.Left = offsetInBytes;
+                    region.Right = offsetInBytes + (elementCount * elementSizeInBytes);
 
+                    lock (d3dContext)
                         d3dContext.UpdateSubresource(box, _buffer, 0, region);
-                    }
-                    else
-                    {
-                        // Copy the buffer to a staging resource, so that any elements we don't write to will still be correct.
-                        var stagingDesc = _buffer.Description;
-                        stagingDesc.BindFlags = SharpDX.Direct3D11.BindFlags.None;
-                        stagingDesc.CpuAccessFlags = SharpDX.Direct3D11.CpuAccessFlags.Read | SharpDX.Direct3D11.CpuAccessFlags.Write;
-                        stagingDesc.Usage = SharpDX.Direct3D11.ResourceUsage.Staging;
-                        stagingDesc.OptionFlags = SharpDX.Direct3D11.ResourceOptionFlags.None;
-                        var stagingBuffer = new SharpDX.Direct3D11.Buffer(GraphicsDevice._d3dDevice, stagingDesc);
+                }
+                else
+                {
+                    // Copy the buffer to a staging resource, so that any elements we don't write to will still be correct.
+                    var stagingDesc = _buffer.Description;
+                    stagingDesc.BindFlags = SharpDX.Direct3D11.BindFlags.None;
+                    stagingDesc.CpuAccessFlags = SharpDX.Direct3D11.CpuAccessFlags.Read | SharpDX.Direct3D11.CpuAccessFlags.Write;
+                    stagingDesc.Usage = SharpDX.Direct3D11.ResourceUsage.Staging;
+                    stagingDesc.OptionFlags = SharpDX.Direct3D11.ResourceOptionFlags.None;
+                    var stagingBuffer = new SharpDX.Direct3D11.Buffer(GraphicsDevice._d3dDevice, stagingDesc);
 
-                        lock (GraphicsDevice._d3dContext)
-                            d3dContext.CopyResource(_buffer, stagingBuffer);
+                    lock (d3dContext)
+                    {
+                        d3dContext.CopyResource(_buffer, stagingBuffer);
 
                         // Map the staging resource to a CPU accessible memory
-                        var box = d3dContext.MapSubresource(stagingBuffer, 0, SharpDX.Direct3D11.MapMode.Read, SharpDX.Direct3D11.MapFlags.None);
+                        var box = d3dContext.MapSubresource(stagingBuffer, 0, SharpDX.Direct3D11.MapMode.Read,
+                            SharpDX.Direct3D11.MapFlags.None);
 
                         for (int i = 0; i < data.Length; i++)
-                            SharpDX.Utilities.CopyMemory(box.DataPointer + i * vertexStride + offsetInBytes, dataPtr + i * elementSizeInBytes, elementSizeInBytes);
+                            SharpDX.Utilities.CopyMemory(
+                                box.DataPointer + i*vertexStride + offsetInBytes,
+                                dataPtr + i*elementSizeInBytes, elementSizeInBytes);
 
                         // Make sure that we unmap the resource in case of an exception
                         d3dContext.UnmapSubresource(stagingBuffer, 0);
 
                         // Copy back from staging resource to real buffer.
-                        lock (GraphicsDevice._d3dContext)
-                            d3dContext.CopyResource(stagingBuffer, _buffer);
-
-                        stagingBuffer.Dispose();
+                        d3dContext.CopyResource(stagingBuffer, _buffer);
                     }
+
+                    stagingBuffer.Dispose();
                 }
 
                 dataHandle.Free();

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public void SetData<T>(int offsetInBytes, T[] data, int startIndex, int elementCount, int vertexStride) where T : struct
         {
-            SetDataInternal<T>(offsetInBytes, data, startIndex, elementCount, VertexDeclaration.VertexStride, SetDataOptions.None);
+            SetDataInternal<T>(offsetInBytes, data, startIndex, elementCount, vertexStride, SetDataOptions.None);
         }
         		
 		public void SetData<T>(T[] data, int startIndex, int elementCount) where T : struct

--- a/Test/Framework/Visual/VertexBufferTest.cs
+++ b/Test/Framework/Visual/VertexBufferTest.cs
@@ -121,7 +121,36 @@ namespace MonoGame.Tests.Visual
                 Assert.AreEqual(savedData[2].Position, readData[2]);
                 Assert.AreEqual(savedData[3].Position, readData[3]);
             };
-            Game.RunOneFrame();
+            Game.Run();
+        }
+
+        //[TestCase(true)]
+        [TestCase(false)]
+        public void SetPosition(bool dynamic)
+        {
+            Game.DrawWith += (sender, e) =>
+            {
+                var vertexBuffer = (dynamic)
+                    ? new DynamicVertexBuffer(Game.GraphicsDevice, typeof(VertexPositionTexture), savedData.Length, BufferUsage.None)
+                    : new VertexBuffer(Game.GraphicsDevice, typeof(VertexPositionTexture), savedData.Length, BufferUsage.None);
+                var positions = new[]
+                {
+                    savedData[0].Position,
+                    savedData[1].Position,
+                    savedData[2].Position,
+                    savedData[3].Position
+                };
+                var vertexStride = VertexPositionTexture.VertexDeclaration.VertexStride;
+                vertexBuffer.SetData(0, positions, 0, 4, vertexStride);
+
+                var readData = new Vector3[4];
+                vertexBuffer.GetData(0, readData, 0, 4, vertexStride);
+                Assert.AreEqual(savedData[0].Position, readData[0]);
+                Assert.AreEqual(savedData[1].Position, readData[1]);
+                Assert.AreEqual(savedData[2].Position, readData[2]);
+                Assert.AreEqual(savedData[3].Position, readData[3]);
+            };
+            Game.Run();
         }
 
         //[TestCase(true)]
@@ -144,8 +173,37 @@ namespace MonoGame.Tests.Visual
                 Assert.AreEqual(savedData[2].TextureCoordinate, readData[2]);
                 Assert.AreEqual(savedData[3].TextureCoordinate, readData[3]);
             };
-            Game.RunOneFrame();
+            Game.Run();
         }
-                
+
+        //[TestCase(true)]
+        [TestCase(false)]
+        public void SetTextureCoordinate(bool dynamic)
+        {
+            Game.DrawWith += (sender, e) =>
+            {
+                var vertexBuffer = (dynamic)
+                    ? new DynamicVertexBuffer(Game.GraphicsDevice, typeof(VertexPositionTexture), savedData.Length, BufferUsage.None)
+                    : new VertexBuffer(Game.GraphicsDevice, typeof(VertexPositionTexture), savedData.Length, BufferUsage.None);
+                var texCoords = new[]
+                {
+                    savedData[0].TextureCoordinate,
+                    savedData[1].TextureCoordinate,
+                    savedData[2].TextureCoordinate,
+                    savedData[3].TextureCoordinate
+                };
+                var vertexStride = VertexPositionTexture.VertexDeclaration.VertexStride;
+                var offsetInBytes = VertexPositionTexture.VertexDeclaration.GetVertexElements()[1].Offset;
+                vertexBuffer.SetData(offsetInBytes, texCoords, 0, 4, vertexStride);
+
+                var readData = new Vector2[4];
+                vertexBuffer.GetData(offsetInBytes, readData, 0, 4, vertexStride);
+                Assert.AreEqual(savedData[0].TextureCoordinate, readData[0]);
+                Assert.AreEqual(savedData[1].TextureCoordinate, readData[1]);
+                Assert.AreEqual(savedData[2].TextureCoordinate, readData[2]);
+                Assert.AreEqual(savedData[3].TextureCoordinate, readData[3]);
+            };
+            Game.Run();
+        }
     }
 }

--- a/Test/Framework/Visual/VertexBufferTest.cs
+++ b/Test/Framework/Visual/VertexBufferTest.cs
@@ -121,7 +121,7 @@ namespace MonoGame.Tests.Visual
                 Assert.AreEqual(savedData[2].Position, readData[2]);
                 Assert.AreEqual(savedData[3].Position, readData[3]);
             };
-            Game.Run();
+            Game.RunOneFrame();
         }
 
         //[TestCase(true)]
@@ -150,7 +150,7 @@ namespace MonoGame.Tests.Visual
                 Assert.AreEqual(savedData[2].Position, readData[2]);
                 Assert.AreEqual(savedData[3].Position, readData[3]);
             };
-            Game.Run();
+            Game.RunOneFrame();
         }
 
         //[TestCase(true)]
@@ -173,7 +173,7 @@ namespace MonoGame.Tests.Visual
                 Assert.AreEqual(savedData[2].TextureCoordinate, readData[2]);
                 Assert.AreEqual(savedData[3].TextureCoordinate, readData[3]);
             };
-            Game.Run();
+            Game.RunOneFrame();
         }
 
         //[TestCase(true)]
@@ -203,7 +203,7 @@ namespace MonoGame.Tests.Visual
                 Assert.AreEqual(savedData[2].TextureCoordinate, readData[2]);
                 Assert.AreEqual(savedData[3].TextureCoordinate, readData[3]);
             };
-            Game.Run();
+            Game.RunOneFrame();
         }
     }
 }


### PR DESCRIPTION
This code roughly mirrors the equivalent path in `GetData`, although it is only used when `vertexStride != elementSize`, so it doesn't affect existing usage. An alternative implementation (which I actually tried first), which avoids the need for a staging buffer, would call `UpdateSubresource` once for each element, but I guess that would be very slow for large arrays.

Note that this only implements the `vertexStride` parameter for non-dynamic `VertexBuffer`s (which is actually harder than it would be for dynamic `VertexBuffer`s, since you wouldn't need the staging buffer for a dynamic `VertexBuffer`).

I changed `Game.RunOneFrame()` to `Game.Run()` for these tests, because `Game.RunOneFrame()` doesn't seem to call `Draw()` when running tests in XNA, so the tests gave false positives. If this is really the case (I'd be happy to be wrong!), then we should update other tests to match, or figure out why `Game.RunOneFrame()` isn't calling `Draw()`.