### PR TITLE
Check Importer and Processor DLL timestamps when deciding whether content needs rebuild

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineBuildEvent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineBuildEvent.cs
@@ -143,7 +143,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 serializer.Serialize(textWriter, this);
         }
 
-        public bool NeedsRebuild(PipelineBuildEvent cachedEvent)
+        public bool NeedsRebuild(PipelineManager manager, PipelineBuildEvent cachedEvent)
         {
             // If we have no previously cached build event then we cannot
             // be sure that the state hasn't changed... force a rebuild.
@@ -180,13 +180,19 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 cachedEvent.DestFile != DestFile)
                 return true;
 
+            // Did the importer assembly change?
+            if (manager.GetImporterAssemblyTimestamp(cachedEvent.Importer) > cachedEvent.DestTime)
+                return true;
+
             // Did the importer change?
-            // TODO: I need to test the assembly versions here!
             if (cachedEvent.Importer != Importer)
                 return true;
 
+            // Did the processor assembly change?
+            if (manager.GetProcessorAssemblyTimestamp(cachedEvent.Processor) > cachedEvent.DestTime)
+                return true;
+
             // Did the processor change?
-            // TODO: I need to test the assembly versions here!
             if (cachedEvent.Processor != Processor)
                 return true;
 

--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
@@ -22,7 +22,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         [DebuggerDisplay("ImporterInfo: {type.Name}")]
         private struct ImporterInfo
         {
-            public ContentImporterAttribute attribue;
+            public ContentImporterAttribute attribute;
             public Type type;
             public DateTime assemblyTimestamp;
         };
@@ -32,7 +32,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         [DebuggerDisplay("ProcessorInfo: {type.Name}")]
         private struct ProcessorInfo
         {
-            public ContentProcessorAttribute attribue;
+            public ContentProcessorAttribute attribute;
             public Type type;
             public DateTime assemblyTimestamp;
         };
@@ -181,7 +181,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                             var importerAttribute = attributes[0] as ContentImporterAttribute;
                             _importers.Add(new ImporterInfo
                             {
-                                attribue = importerAttribute,
+                                attribute = importerAttribute,
                                 type = t,
                                 assemblyTimestamp = assemblyTimestamp
                             });
@@ -194,7 +194,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                             importerAttribute.DisplayName = t.Name;
                             _importers.Add(new ImporterInfo
                             {
-                                attribue = importerAttribute,
+                                attribute = importerAttribute,
                                 type = t,
                                 assemblyTimestamp = assemblyTimestamp
                             });
@@ -206,7 +206,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                         if (attributes.Length != 0)
                         {
                             var processorAttribute = attributes[0] as ContentProcessorAttribute;
-                            _processors.Add(new ProcessorInfo {attribue = processorAttribute, type = t});
+                            _processors.Add(new ProcessorInfo {attribute = processorAttribute, type = t});
                         }
                     }
                     else if (t.GetInterface(@"ContentTypeWriter") != null)
@@ -271,7 +271,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             // Search for the importer.
             foreach (var info in _importers)
             {
-                if (info.attribue.FileExtensions.Any(e => e.Equals(ext, StringComparison.InvariantCultureIgnoreCase)))
+                if (info.attribute.FileExtensions.Any(e => e.Equals(ext, StringComparison.InvariantCultureIgnoreCase)))
                     return info.type.Name;
             }
 
@@ -302,7 +302,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             foreach (var info in _importers)
             {
                 if (info.type.Name == importer)
-                    return info.attribue.DefaultProcessor;
+                    return info.attribute.DefaultProcessor;
             }
 
             return null;

--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
@@ -24,6 +24,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         {
             public ContentImporterAttribute attribue;
             public Type type;
+            public DateTime assemblyTimestamp;
         };
 
         private List<ImporterInfo> _importers;
@@ -33,6 +34,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         {
             public ContentProcessorAttribute attribue;
             public Type type;
+            public DateTime assemblyTimestamp;
         };
 
         private List<ProcessorInfo> _processors;
@@ -139,6 +141,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             foreach (var assemblyPath in Assemblies)
             {
                 Type[] exportedTypes;
+                DateTime assemblyTimestamp;
                 try
                 {
                     Assembly a;
@@ -148,6 +151,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                         a = Assembly.LoadFrom(assemblyPath);
 
                     exportedTypes = a.GetTypes();
+                    assemblyTimestamp = File.GetLastWriteTime(a.Location);
                 }
                 catch (BadImageFormatException e)
                 {
@@ -175,7 +179,12 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                         if (attributes.Length != 0)
                         {
                             var importerAttribute = attributes[0] as ContentImporterAttribute;
-                            _importers.Add(new ImporterInfo { attribue = importerAttribute, type = t });
+                            _importers.Add(new ImporterInfo
+                            {
+                                attribue = importerAttribute,
+                                type = t,
+                                assemblyTimestamp = assemblyTimestamp
+                            });
                         }
                         else
                         {
@@ -183,7 +192,12 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                             var importerAttribute = new ContentImporterAttribute(".*");
                             importerAttribute.DefaultProcessor = "";
                             importerAttribute.DisplayName = t.Name;
-                            _importers.Add(new ImporterInfo { attribue = importerAttribute, type = t });
+                            _importers.Add(new ImporterInfo
+                            {
+                                attribue = importerAttribute,
+                                type = t,
+                                assemblyTimestamp = assemblyTimestamp
+                            });
                         }
                     }
                     else if (t.GetInterface(@"IContentProcessor") != null)
@@ -264,6 +278,21 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             return null;
         }
 
+        public DateTime GetImporterAssemblyTimestamp(string name)
+        {
+            if (_importers == null)
+                ResolveAssemblies();
+
+            // Search for the importer.
+            foreach (var info in _importers)
+            {
+                if (info.type.Name.Equals(name))
+                    return info.assemblyTimestamp;
+            }
+
+            return DateTime.MaxValue;
+        }
+
         public string FindDefaultProcessor(string importer)
         {
             if (_importers == null)
@@ -341,6 +370,21 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             }
 
             return processor;
+        }
+
+        public DateTime GetProcessorAssemblyTimestamp(string name)
+        {
+            if (_processors == null)
+                ResolveAssemblies();
+
+            // Search for the processor.
+            foreach (var info in _processors)
+            {
+                if (info.type.Name.Equals(name))
+                    return info.assemblyTimestamp;
+            }
+
+            return DateTime.MaxValue;
         }
 
         public OpaqueDataDictionary ValidateProcessorParameters(string name, OpaqueDataDictionary processorParameters)
@@ -445,7 +489,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             // Keep track of all build events. (Required to resolve automatic names "AssetName_n".)
             TrackPipelineBuildEvent(pipelineEvent);
 
-            var rebuild = pipelineEvent.NeedsRebuild(cachedEvent);
+            var rebuild = pipelineEvent.NeedsRebuild(this, cachedEvent);
             if (!rebuild)
             {
                 // While this asset doesn't need to be rebuilt the dependent assets might.


### PR DESCRIPTION
Fixes the issue, mentioned in #3138, where updating a `ContentImporter` or `ContentProcessor` used for a content item, didn't force a rebuild of that content item.

I have followed the implementation suggested by @tomspilman [here](https://github.com/mono/MonoGame/pull/3138#issuecomment-68819320).