### PR TITLE
Cache timestamp for importer and processor DLLs

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineBuildEvent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineBuildEvent.cs
@@ -51,7 +51,17 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
 
         public string Importer { get; set; }
 
+        /// <summary>
+        /// The date/time stamp of the DLL containing the importer.
+        /// </summary>
+        public DateTime ImporterTime { get; set; }
+
         public string Processor { get; set; }
+
+        /// <summary>
+        /// The date/time stamp of the DLL containing the processor.
+        /// </summary>
+        public DateTime ProcessorTime { get; set; }
 
         [XmlIgnore]
         public OpaqueDataDictionary Parameters { get; set; }
@@ -181,7 +191,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 return true;
 
             // Did the importer assembly change?
-            if (manager.GetImporterAssemblyTimestamp(cachedEvent.Importer) > cachedEvent.DestTime)
+            if (manager.GetImporterAssemblyTimestamp(cachedEvent.Importer) > cachedEvent.ImporterTime)
                 return true;
 
             // Did the importer change?
@@ -189,7 +199,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 return true;
 
             // Did the processor assembly change?
-            if (manager.GetProcessorAssemblyTimestamp(cachedEvent.Processor) > cachedEvent.DestTime)
+            if (manager.GetProcessorAssemblyTimestamp(cachedEvent.Processor) > cachedEvent.ProcessorTime)
                 return true;
 
             // Did the processor change?

--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
@@ -206,7 +206,12 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                         if (attributes.Length != 0)
                         {
                             var processorAttribute = attributes[0] as ContentProcessorAttribute;
-                            _processors.Add(new ProcessorInfo {attribute = processorAttribute, type = t});
+                            _processors.Add(new ProcessorInfo
+                            {
+                                attribute = processorAttribute,
+                                type = t,
+                                assemblyTimestamp = assemblyTimestamp
+                            });
                         }
                     }
                     else if (t.GetInterface(@"ContentTypeWriter") != null)
@@ -530,6 +535,10 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
 
                 // Write the content to disk.
                 WriteXnb(processedObject, pipelineEvent);
+
+                // Store the timestamp of the DLLs containing the importer and processor.
+                pipelineEvent.ImporterTime = GetImporterAssemblyTimestamp(pipelineEvent.Importer);
+                pipelineEvent.ProcessorTime = GetProcessorAssemblyTimestamp(pipelineEvent.Processor);
 
                 // Store the new event into the intermediate folder.
                 pipelineEvent.Save(eventFilepath);


### PR DESCRIPTION
and fix bug where processor timestamps weren't being set (oops) - didn't notice it before because I was testing with a single DLL that contained both the importer and processor.

Fixes potential issue raised by @tomspilman [here](https://github.com/mono/MonoGame/pull/3367#discussion_r22638244).