### PR TITLE
Implement IntermediateSerializer.Serialize

### DIFF
--- a/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
+++ b/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
@@ -364,6 +364,7 @@
     <Compile Include="Serialization\Intermediate\LongSerializer.cs" />
     <Compile Include="Serialization\Intermediate\MatrixSerializer.cs" />
     <Compile Include="Serialization\Intermediate\NamedValueDictionarySerializer.cs" />    
+    <Compile Include="Serialization\Intermediate\NamespaceAliasHelper.cs" />
 	<Compile Include="Serialization\Intermediate\NullableSerializer.cs" />
     <Compile Include="Serialization\Intermediate\PlaneSerializer.cs" />
     <Compile Include="Serialization\Intermediate\PointSerializer.cs" />

--- a/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
+++ b/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
@@ -363,6 +363,7 @@
     <Compile Include="Serialization\Intermediate\ListSerializer.cs" />
     <Compile Include="Serialization\Intermediate\LongSerializer.cs" />
     <Compile Include="Serialization\Intermediate\MatrixSerializer.cs" />
+    <Compile Include="Serialization\Intermediate\NamedValueDictionarySerializer.cs" />    
 	<Compile Include="Serialization\Intermediate\NullableSerializer.cs" />
     <Compile Include="Serialization\Intermediate\PlaneSerializer.cs" />
     <Compile Include="Serialization\Intermediate\PointSerializer.cs" />

--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -141,6 +141,9 @@
     <Compile Include="ContentPipeline\IntermediateDeserializerTest.cs">
         <Platforms>Windows,MacOS,Linux</Platforms>
     </Compile>
+    <Compile Include="ContentPipeline\IntermediateSerializerTest.cs">
+        <Platforms>Windows,MacOS,Linux</Platforms>
+    </Compile>
     <Compile Include="ContentPipeline\ModelProcessorTests.cs">
         <Platforms>Windows,MacOS,Linux</Platforms>
     </Compile>
@@ -476,6 +479,9 @@
     <Content Include="Assets\Xml\04_ExcludingPublicMembers.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+	<Content Include="Assets\Xml\04_ExcludingPublicMembersOutput.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Assets\Xml\05_RenamingXmlElements.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -523,7 +529,10 @@
     </Content>
     <Content Include="Assets\Xml\20_SystemTypes.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>    
+    </Content>
+	<Content Include="Assets\Xml\21_QualifiedTypes.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
 
     <Content Include="Assets\Fonts\Default.xnb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/MonoGame.Framework.Content.Pipeline/Graphics/Font/CharacterRegion.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/Font/CharacterRegion.cs
@@ -86,9 +86,5 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 				}
 			}
 		}
-
 	}
 }
-
-
-

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ArraySerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ArraySerializer.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 {
@@ -21,6 +22,16 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
             _listSerializer.Initialize(serializer);
         }
 
+        public override bool ObjectIsEmpty(T[] value)
+        {
+            return value.Length == 0;
+        }
+
+        protected internal override void ScanChildren(IntermediateSerializer serializer, ChildCallback callback, T[] value)
+        {
+            _listSerializer.ScanChildren(serializer, callback, new List<T>(value));
+        }
+
         protected internal override T[] Deserialize(IntermediateReader input, ContentSerializerAttribute format, T[] existingInstance)
         {
             var result = _listSerializer.Deserialize(input, format, null);
@@ -29,7 +40,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override void Serialize(IntermediateWriter output, T[] value, ContentSerializerAttribute format)
         {
-            throw new NotImplementedException();
+            _listSerializer.Serialize(output, new List<T>(value), format);
         }
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ColorSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ColorSerializer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override Color Deserialize(string[] inputs, ref int index)
         {
-            // NOTE: The value is serialized in BGRA format.
+            // NOTE: The value is serialized in ARGB format.
             var value = uint.Parse(inputs[index++], NumberStyles.HexNumber, CultureInfo.InvariantCulture);
             return new Color(   (int)(value >> 16 & 0xFF),
                                 (int)(value >> 8 & 0xFF),
@@ -28,12 +28,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override void Serialize(Color value, List<string> results)
         {
-            // NOTE: The value is serialized in BGRA format.
-            var packed = (uint)((value.R << 16) |
-                                (value.G << 8) |
-                                (value.B << 0) |
-                                (value.A << 24));
-            results.Add(XmlConvert.ToString(packed));
+            // NOTE: The value is serialized in ARGB format.
+            results.Add(string.Format("{0:X}{1:X}{2:X}{3:X}", value.A, value.R, value.G, value.B));
         }
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ExternalReferenceSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ExternalReferenceSerializer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override void Serialize(IntermediateWriter output, ExternalReference<T> value, ContentSerializerAttribute format)
         {
-            throw new NotImplementedException();
+            output.WriteExternalReference(value);
         }
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateWriter.cs
@@ -3,19 +3,29 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Xml;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 {
     public sealed class IntermediateWriter
     {
-        private string _filePath;
+        private readonly List<object> _writtenObjects;
+        private readonly Dictionary<object, string> _sharedResources;
+        private readonly List<ExternalReference> _externalReferences;
+        private readonly string _filePath;
 
         internal IntermediateWriter(IntermediateSerializer serializer, XmlWriter xmlWriter, string filePath)
         {
             Serializer = serializer;
             Xml = xmlWriter;
             _filePath = filePath;
+
+            _writtenObjects = new List<object>();
+            _sharedResources = new Dictionary<object, string>();
+            _externalReferences = new List<ExternalReference>();
         }
 
         public XmlWriter Xml { get; private set; }
@@ -24,37 +34,180 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         public void WriteExternalReference<T>(ExternalReference<T> value)
         {
-            throw new NotImplementedException();
+            var externalReference = new ExternalReference
+            {
+                ID = "#External" + (_externalReferences.Count + 1),
+                TargetType = typeof(T).FullName,
+                FileName = MakeRelativePath(value.Filename)
+            };
+            _externalReferences.Add(externalReference);
+
+            Xml.WriteElementString("Reference", externalReference.ID);
+        }
+
+        private string MakeRelativePath(string path)
+        {
+            var fullReferencePath = Path.GetFullPath(Path.GetDirectoryName(_filePath)) + Path.DirectorySeparatorChar;
+            var fullPath = Path.GetFullPath(path);
+            return new Uri(fullReferencePath).MakeRelativeUri(new Uri(fullPath)).ToString();
+        }
+
+        private class ExternalReference
+        {
+            public string ID;
+            public string TargetType;
+            public string FileName;
         }
 
         public void WriteObject<T>(T value, ContentSerializerAttribute format)
         {
-            throw new NotImplementedException();
+            WriteObject(value, format, Serializer.GetTypeSerializer(typeof(T)));
         }
 
         public void WriteObject<T>(T value, ContentSerializerAttribute format, ContentTypeSerializer typeSerializer)
         {
-            throw new NotImplementedException();
+            WriteObjectInternal(value, format, typeSerializer, typeof(T));
+        }
+
+        internal void WriteObjectInternal(object value, ContentSerializerAttribute format, ContentTypeSerializer typeSerializer, Type declaredType)
+        {
+            if (format.Optional && (value == null || typeSerializer.ObjectIsEmpty(value)))
+                return;
+
+            if (!format.FlattenContent)
+            {
+                Xml.WriteStartElement(format.ElementName);
+
+                if (value != null && !typeSerializer.TargetType.IsValueType)
+                {
+                    if (_writtenObjects.Contains(value))
+                        throw new InvalidOperationException("Cyclic reference found during serialization. You may be missing a [ContentSerializer(SharedResource=true)] attribute.");
+                    _writtenObjects.Add(value);
+                }
+
+                if (value == null)
+                {
+                    if (!format.AllowNull)
+                        throw new InvalidOperationException(string.Format("Element {0} cannot be null.", format.ElementName));
+
+                    Xml.WriteAttributeString("Null", "true");
+                }
+                else if (value.GetType() != declaredType && !IsNullableType(declaredType))
+                {
+                    Xml.WriteStartAttribute("Type");
+                    WriteTypeName(value.GetType());
+                    Xml.WriteEndAttribute();
+
+                    typeSerializer = Serializer.GetTypeSerializer(value.GetType());
+                }
+            }
+
+            if (value != null)
+                typeSerializer.Serialize(this, value, format);
+
+            if (!format.FlattenContent)
+                Xml.WriteEndElement();
+        }
+
+        private static bool IsNullableType(Type type)
+        {
+            return Nullable.GetUnderlyingType(type) != null;
         }
 
         public void WriteRawObject<T>(T value, ContentSerializerAttribute format)
         {
-            throw new NotImplementedException();
+            WriteRawObject(value, format, Serializer.GetTypeSerializer(typeof(T)));
         }
 
         public void WriteRawObject<T>(T value, ContentSerializerAttribute format, ContentTypeSerializer typeSerializer)
         {
-            throw new NotImplementedException();
+            if (!format.FlattenContent)
+                Xml.WriteStartElement(format.ElementName);
+
+            typeSerializer.Serialize(this, value, format);
+
+            if (!format.FlattenContent)
+                Xml.WriteEndElement();
         }
 
         public void WriteSharedResource<T>(T value, ContentSerializerAttribute format)
         {
-            throw new NotImplementedException();       
+            var sharedResourceID = GetSharedResourceID(value);
+
+            if (format.FlattenContent)
+                Xml.WriteValue(sharedResourceID);
+            else
+                Xml.WriteElementString(format.ElementName, sharedResourceID);
+        }
+
+        private string GetSharedResourceID(object value)
+        {
+            string id;
+            if (!_sharedResources.TryGetValue(value, out id))
+                _sharedResources.Add(value, id = "#Resource" + (_sharedResources.Count + 1));
+            return id;
+        }
+
+        internal void WriteSharedResources()
+        {
+            if (!_sharedResources.Any())
+                return;
+
+            Xml.WriteStartElement("Resources");
+
+            // Loop like this because we might create more shared resources while we're serializing.
+            var writtenSharedResources = new List<string>();
+            while (_sharedResources.Any(x => !writtenSharedResources.Contains(x.Value)))
+            {
+                var sharedResource = _sharedResources.First(x => !writtenSharedResources.Contains(x.Value));
+                writtenSharedResources.Add(sharedResource.Value);
+
+                WriteSharedResource(sharedResource.Value, sharedResource.Key);
+            }
+
+            Xml.WriteEndElement();
+        }
+
+        private void WriteSharedResource(string id, object sharedResource)
+        {
+            Xml.WriteStartElement("Resource");
+
+            Xml.WriteAttributeString("ID", id);
+
+            Xml.WriteStartAttribute("Type");
+            WriteTypeName(sharedResource.GetType());
+            Xml.WriteEndAttribute();
+
+            Serializer.GetTypeSerializer(sharedResource.GetType()).Serialize(this, sharedResource, new ContentSerializerAttribute());
+
+            Xml.WriteEndElement();
+        }
+
+        internal void WriteExternalReferences()
+        {
+            if (!_externalReferences.Any())
+                return;
+
+            Xml.WriteStartElement("ExternalReferences");
+
+            foreach (var externalReference in _externalReferences)
+            {
+                Xml.WriteStartElement("ExternalReference");
+                
+                Xml.WriteAttributeString("ID", externalReference.ID);
+                Xml.WriteAttributeString("TargetType", externalReference.TargetType);
+
+                Xml.WriteValue(externalReference.FileName);
+
+                Xml.WriteEndElement();
+            }
+
+            Xml.WriteEndElement();
         }
 
         public void WriteTypeName(Type type)
         {
-            throw new NotImplementedException();
+            Xml.WriteString(Serializer.GetTypeName(type));
         }
     }        
 }

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/NamespaceAliasHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/NamespaceAliasHelper.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+
+namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
+{
+    internal class NamespaceAliasHelper
+    {
+        private readonly IntermediateSerializer _serializer;
+
+        /// <summary>
+        /// Maps "My.Namespace.LongName" -> "ShortName" for type lookups.
+        /// </summary>
+        private Dictionary<string, AliasedNamespace> _namespaceLookupReverse;
+
+        private class AliasedNamespace
+        {
+            public string Alias;
+            public string TypePrefix;
+        }
+
+        public NamespaceAliasHelper(IntermediateSerializer serializer)
+        {
+            _serializer = serializer;
+        }
+
+        public void WriteNamespaces<T>(XmlWriter writer, T value)
+        {
+            // Maps "My.Namespace.LongName" -> "ShortName" for type lookups.
+            _namespaceLookupReverse = new Dictionary<string, AliasedNamespace>();
+
+            var childNamespaces = new List<string>();
+            ContentTypeSerializer.ChildCallback onScanChild = (contentTypeSerializer, child) =>
+            {
+                if (child == null)
+                    return;
+
+                var childType = child.GetType();
+
+                if (contentTypeSerializer.TargetType == childType)
+                    return;
+
+                if (_serializer.HasTypeAlias(childType))
+                    return;
+
+                var childNamespace = childType.Namespace;
+
+                if (string.IsNullOrEmpty(childNamespace))
+                    return;
+
+                childNamespaces.Add(childNamespace);
+            };
+
+            // Force top-level object type to be included.
+            onScanChild(_serializer.GetTypeSerializer(typeof(object)), value);
+
+            var serializer = _serializer.GetTypeSerializer(typeof(T));
+            serializer.ScanChildren(_serializer, onScanChild, value);
+
+            childNamespaces = childNamespaces.Distinct().ToList();
+
+            // Do first pass to determinate what our aliases are.
+            var sortedChildNamespaces = new List<string>(childNamespaces);
+            sortedChildNamespaces.Sort();
+            var tempAliases = new Dictionary<string, string>();
+            foreach (var childNamespace in sortedChildNamespaces)
+            {
+                var alias = FindAlias(tempAliases, childNamespace);
+                if (alias != null)
+                    tempAliases.Add(childNamespace, alias);
+            }
+
+            // Do second pass to calculate the TypePrefix for each alias.
+            foreach (var childNamespace in childNamespaces)
+            {
+                var alias = FindAvailableAlias(tempAliases, childNamespace, childNamespace);
+                if (alias != null)
+                    _namespaceLookupReverse.Add(childNamespace, alias);
+            }
+
+            var writtenAliases = new List<string>();
+            foreach (var kvp in _namespaceLookupReverse)
+            {
+                if (!string.IsNullOrEmpty(kvp.Value.TypePrefix))
+                    continue;
+                if (!writtenAliases.Contains(kvp.Value.Alias))
+                    writer.WriteAttributeString("xmlns", kvp.Value.Alias, null, kvp.Key);
+                writtenAliases.Add(kvp.Value.Alias);
+            }
+        }
+
+        private string FindAlias(Dictionary<string, string> aliases, string childNamespace)
+        {
+            if (string.IsNullOrEmpty(childNamespace))
+                return null;
+
+            var alias = childNamespace.Substring(childNamespace.LastIndexOf('.') + 1);
+            if (aliases.All(x => x.Value != alias))
+                return alias;
+
+            // Find the longest parent namespace.
+            if (aliases.Any(x => childNamespace.StartsWith(x.Key)))
+            {
+                string longestParentNamespace = string.Empty;
+                foreach (var kvp in aliases)
+                {
+                    if (childNamespace.StartsWith(kvp.Key) && kvp.Key.Length > longestParentNamespace.Length)
+                        longestParentNamespace = kvp.Key;
+                }
+                return aliases[longestParentNamespace];
+            }
+
+            return null;
+        }
+
+        private AliasedNamespace FindAvailableAlias(Dictionary<string, string> tempAliases, string childNamespace, string originalNamespace)
+        {
+            string alias;
+            if (tempAliases.TryGetValue(childNamespace, out alias))
+            {
+                if (alias == childNamespace.Substring(childNamespace.LastIndexOf('.') + 1))
+                    return new AliasedNamespace
+                    {
+                        Alias = alias,
+                        TypePrefix = string.Empty
+                    };
+
+                var namespaceParent = tempAliases
+                    .Where(x => x.Value == alias)
+                    .Select(x => x.Key)
+                    .OrderBy(x => x.Length)
+                    .First();
+                return new AliasedNamespace
+                {
+                    Alias = alias,
+                    TypePrefix = GetRelativeNamespace(namespaceParent, childNamespace) + "."
+                };
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Returns just the portion <paramref name="@namespace"/> relative to <paramref name="namespaceParent"/>.
+        /// For example, given namespaceParent=Foo.Bar and @namespace=Foo.Bar.Baz, will return Baz.
+        /// </summary>
+        private static string GetRelativeNamespace(string namespaceParent, string @namespace)
+        {
+            if (@namespace.StartsWith(namespaceParent))
+                return @namespace.Substring(namespaceParent.Length + 1);
+            throw new InvalidOperationException();
+        }
+
+        public bool TryGetAliasedTypeName(Type type, out string typeName)
+        {
+            if (!string.IsNullOrEmpty(type.Namespace))
+            {
+                AliasedNamespace namespaceAlias;
+                if (_namespaceLookupReverse.TryGetValue(type.Namespace, out namespaceAlias))
+                {
+                    typeName = namespaceAlias.Alias + ":" + namespaceAlias.TypePrefix + type.Name;
+                    return true;
+                }
+            }
+
+            typeName = null;
+            return false;
+        }
+    }
+}

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/NullableSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/NullableSerializer.cs
@@ -25,7 +25,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override void Serialize(IntermediateWriter output, T? value, ContentSerializerAttribute format)
         {
-            throw new NotImplementedException();
+            var results = new List<string>();
+            _serializer.Serialize(value.Value, results);
+            output.Xml.WriteRaw(results.First());
         }
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/TimeSpanSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/TimeSpanSerializer.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
         protected internal override void Serialize(TimeSpan value, List<string> results)
         {
             results.Add(XmlConvert.ToString(value));
-            
         }
     }
 }

--- a/Test/Assets/Xml/01_TheBasics.xml
+++ b/Test/Assets/Xml/01_TheBasics.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <XnaContent>
-  <Asset Type="MonoGame.Tests.ContentPipeline.TheBasics">
+  <Asset Type="TheBasics">
     <GetSetProperty>Hello World</GetSetProperty>
     <PublicField>1</PublicField>
     <Nested>

--- a/Test/Assets/Xml/01_TheBasics.xml
+++ b/Test/Assets/Xml/01_TheBasics.xml
@@ -7,5 +7,9 @@
       <Name>Shawn</Name>
       <IsEnglish>true</IsEnglish>
     </Nested>
+    <Nested2>
+      <Name>Shawn</Name>
+      <IsEnglish>true</IsEnglish>
+    </Nested2>
   </Asset>
 </XnaContent>

--- a/Test/Assets/Xml/02_Inheritance.xml
+++ b/Test/Assets/Xml/02_Inheritance.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <XnaContent>
-  <Asset Type="MonoGame.Tests.ContentPipeline.Inheritance">
+  <Asset Type="Inheritance">
     <elf>23</elf>
     <hello>world</hello>
   </Asset>

--- a/Test/Assets/Xml/03_IncludingPrivateMembers.xml
+++ b/Test/Assets/Xml/03_IncludingPrivateMembers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <XnaContent>
-  <Asset Type="MonoGame.Tests.ContentPipeline.IncludingPrivateMembers">
+  <Asset Type="IncludingPrivateMembers">
     <elf>23</elf>
   </Asset>
 </XnaContent>

--- a/Test/Assets/Xml/04_ExcludingPublicMembers.xml
+++ b/Test/Assets/Xml/04_ExcludingPublicMembers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <XnaContent>
-  <Asset Type="MonoGame.Tests.ContentPipeline.ExcludingPublicMembers">
+  <Asset Type="ExcludingPublicMembers">
     <elf>23</elf> <!-- Should NOT be serialized -->
   </Asset>
 </XnaContent>

--- a/Test/Assets/Xml/04_ExcludingPublicMembersOutput.xml
+++ b/Test/Assets/Xml/04_ExcludingPublicMembersOutput.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<XnaContent>
+  <Asset Type="ExcludingPublicMembers" />
+</XnaContent>

--- a/Test/Assets/Xml/05_RenamingXmlElements.xml
+++ b/Test/Assets/Xml/05_RenamingXmlElements.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <XnaContent>
-  <Asset Type="MonoGame.Tests.ContentPipeline.RenamingXmlElements">
+  <Asset Type="RenamingXmlElements">
     <ShawnSaysHello>world</ShawnSaysHello>
     <ElvesAreCool>23</ElvesAreCool>
   </Asset>

--- a/Test/Assets/Xml/06_NullReferences.xml
+++ b/Test/Assets/Xml/06_NullReferences.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <XnaContent>
-  <Asset Type="MonoGame.Tests.ContentPipeline.NullReferences">
+  <Asset Type="NullReferences">
     <hello Null="true" />
   </Asset>
 </XnaContent>

--- a/Test/Assets/Xml/07_OptionalElements.xml
+++ b/Test/Assets/Xml/07_OptionalElements.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <XnaContent>
-  <Asset Type="MonoGame.Tests.ContentPipeline.OptionalElements">
+  <Asset Type="OptionalElements">
     <b Null="true" />
     <c></c>
   </Asset>

--- a/Test/Assets/Xml/08_AllowNull.xml
+++ b/Test/Assets/Xml/08_AllowNull.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <XnaContent>
-  <Asset Type="MonoGame.Tests.ContentPipeline.AllowNull">
+  <Asset Type="AllowNull">
     <a Null="true"></a> <!-- This should throw an exception -->
   </Asset>
 </XnaContent>

--- a/Test/Assets/Xml/09_Collections.xml
+++ b/Test/Assets/Xml/09_Collections.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <XnaContent>
-  <Asset Type="MonoGame.Tests.ContentPipeline.Collections">
+  <Asset Type="Collections">
     <StringArray>
       <Item>Hello</Item>
       <Item>World</Item>

--- a/Test/Assets/Xml/10_CollectionItemName.xml
+++ b/Test/Assets/Xml/10_CollectionItemName.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <XnaContent>
-  <Asset Type="MonoGame.Tests.ContentPipeline.CollectionItemName">
+  <Asset Type="CollectionItemName">
     <w00t>
       <Flibble>Hello</Flibble>
       <Flibble>World</Flibble>

--- a/Test/Assets/Xml/11_Dictionaries.xml
+++ b/Test/Assets/Xml/11_Dictionaries.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <XnaContent>
-  <Asset Type="MonoGame.Tests.ContentPipeline.Dictionaries">
+  <Asset Type="Dictionaries">
     <TestDictionary>
       <Item>
         <Key>23</Key>

--- a/Test/Assets/Xml/12_MathTypes.xml
+++ b/Test/Assets/Xml/12_MathTypes.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <XnaContent>
-  <Asset Type="MonoGame.Tests.ContentPipeline.MathTypes">
+  <Asset Type="MathTypes">
     <Point>1 2</Point>
     <Rectangle>1 2 3 4</Rectangle>
-    <Vector3>1.0 2.0 3.0</Vector3>
+    <Vector3>1 2 3.1</Vector3>
     <Vector4>1 2 3 4</Vector4>
     <Quaternion>1 2 3 4</Quaternion>
     <Plane>1 2 3 4</Plane>

--- a/Test/Assets/Xml/13_PolymorphicTypes.xml
+++ b/Test/Assets/Xml/13_PolymorphicTypes.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <XnaContent>
-  <Asset Type="MonoGame.Tests.ContentPipeline.PolymorphicTypes">
+  <Asset Type="PolymorphicTypes">
     <Hello Type="string">World</Hello>
     <Elf Type="int">23</Elf>
     <TypedArray>
       <Item>
         <Value>true</Value>
       </Item>
-      <Item Type="MonoGame.Tests.ContentPipeline.PolymorphicB">
+      <Item Type="PolymorphicB">
         <Value>true</Value>
       </Item>
-      <Item Type="MonoGame.Tests.ContentPipeline.PolymorphicC">
+      <Item Type="PolymorphicC">
         <Value>true</Value>
       </Item>
     </TypedArray>
-    <UntypedArray Type="MonoGame.Tests.ContentPipeline.PolymorphicA[]">
+    <UntypedArray Type="PolymorphicA[]">
       <Item>
         <Value>true</Value>
       </Item>
-      <Item Type="MonoGame.Tests.ContentPipeline.PolymorphicB">
+      <Item Type="PolymorphicB">
         <Value>true</Value>
       </Item>
-      <Item Type="MonoGame.Tests.ContentPipeline.PolymorphicC">
+      <Item Type="PolymorphicC">
         <Value>true</Value>
       </Item>
     </UntypedArray>

--- a/Test/Assets/Xml/14_Namespaces.xml
+++ b/Test/Assets/Xml/14_Namespaces.xml
@@ -1,12 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<XnaContent xmlns:Test="MonoGame.Tests.ContentPipeline"
-            xmlns:Framework="Microsoft.Xna.Framework"
-            xmlns:Graphics="Microsoft.Xna.Framework.Graphics">
-  <Asset Type="Test:NamespaceClass">
-    <A Type="Test:NamespaceHelper">
+<XnaContent xmlns:ContentPipeline="MonoGame.Tests.ContentPipeline" xmlns:Framework="Microsoft.Xna.Framework" xmlns:Graphics="Microsoft.Xna.Framework.Graphics" xmlns:Nested="MonoGame.Tests.ContentPipeline.Nested" xmlns:ContentPipeline2="MonoGame.Tests.ContentPipeline.Nested.ContentPipeline2">
+  <Asset Type="ContentPipeline:NamespaceClass">
+    <A Type="ContentPipeline:NamespaceHelper">
       <Value>true</Value>
     </A>
     <B Type="Framework:Vector2">0 0</B>
     <C Type="Graphics:SpriteSortMode">Immediate</C>
+    <D Type="Nested:ContentPipeline.ClassInsideNestedAmbiguousNamespace">
+      <Value>true</Value>
+    </D>
+    <E Type="Nested:ClassInsideNestedNamespace">
+      <Value>true</Value>
+    </E>
+    <F Type="ContentPipeline2:ClassInsideNestedUnambiguousNamespace">
+      <Value>true</Value>
+    </F>
+    <G Type="MonoGame.Tests.SomethingElse.ContentPipeline.ClassInsideAmbiguousNamespace">
+      <Value>true</Value>
+    </G>
   </Asset>
 </XnaContent>

--- a/Test/Assets/Xml/15_FlattenContent.xml
+++ b/Test/Assets/Xml/15_FlattenContent.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <XnaContent>
-  <Asset Type="MonoGame.Tests.ContentPipeline.FlattenContent">
+  <Asset Type="FlattenContent">
     <Name>Shawn</Name>
     <IsEnglish>true</IsEnglish>
     <Boo>Hello</Boo>

--- a/Test/Assets/Xml/16_SharedResources.xml
+++ b/Test/Assets/Xml/16_SharedResources.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <XnaContent>
-  <Asset Type="MonoGame.Tests.ContentPipeline.SharedResources">
+  <Asset Type="SharedResources">
     <Head>#Resource1</Head>
   </Asset>
   <Resources>
-    <Resource ID="#Resource1" Type="MonoGame.Tests.ContentPipeline.Linked">
+    <Resource ID="#Resource1" Type="Linked">
       <Value>1</Value>
       <Next>#Resource2</Next>
     </Resource>
-    <Resource ID="#Resource2" Type="MonoGame.Tests.ContentPipeline.Linked">
+    <Resource ID="#Resource2" Type="Linked">
       <Value>2</Value>
       <Next>#Resource3</Next>
     </Resource>
-    <Resource ID="#Resource3" Type="MonoGame.Tests.ContentPipeline.Linked">
+    <Resource ID="#Resource3" Type="Linked">
       <Value>3</Value>
       <Next>#Resource1</Next>
     </Resource>

--- a/Test/Assets/Xml/17_ExternalReferences.xml
+++ b/Test/Assets/Xml/17_ExternalReferences.xml
@@ -4,6 +4,9 @@
     <Texture>
       <Reference>#External1</Reference>
     </Texture>
+    <Texture2>
+      <Reference>#External1</Reference>
+    </Texture2>
     <Shader>
       <Reference>#External2</Reference>
     </Shader>

--- a/Test/Assets/Xml/17_ExternalReferences.xml
+++ b/Test/Assets/Xml/17_ExternalReferences.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <XnaContent>
-  <Asset Type="MonoGame.Tests.ContentPipeline.ExternalReferences">
+  <Asset Type="ExternalReferences">
     <Texture>
       <Reference>#External1</Reference>
     </Texture>

--- a/Test/Assets/Xml/18_PrimitiveTypes.xml
+++ b/Test/Assets/Xml/18_PrimitiveTypes.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <XnaContent>
-  <Asset Type="MonoGame.Tests.ContentPipeline.PrimitiveTypes">
+  <Asset Type="PrimitiveTypes">
     <Char>A</Char>
+    <Char2>°</Char2>
+    <Char3>Δ</Char3>
     <Byte>127</Byte>
     <SByte>-127</SByte>
     <Short>-1000</Short>
@@ -10,9 +12,9 @@
     <UInt>100000</UInt>
     <Long>-10000000</Long>
     <ULong>10000000</ULong>
-    <Float>1234567.0</Float>
-    <Double>1234567890.0</Double>
-    <NullChar Null="true"></NullChar>
-    <NotNullChar>&#32;</NotNullChar>
+    <Float>1234567</Float>
+    <Double>1234567890</Double>
+    <NullChar Null="true" />
+    <NotNullChar>B</NotNullChar>
   </Asset>
 </XnaContent>

--- a/Test/Assets/Xml/19_FontDescription.xml
+++ b/Test/Assets/Xml/19_FontDescription.xml
@@ -1,44 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<XnaContent xmlns:Graphics="Microsoft.Xna.Framework.Content.Pipeline.Graphics">
-  
-  <Asset Type="MonoGame.Tests.ContentPipeline.ExtendedFontDescription">
-      
+<XnaContent>
+  <Asset Type="ExtendedFontDescription">
     <FontName>Foo</FontName>
     <Size>30</Size>
     <Spacing>0.75</Spacing>
     <UseKerning>true</UseKerning>
     <Style>Bold</Style>
-
-    <DefaultCharacter>*</DefaultCharacter> 
-
+    <DefaultCharacter>*</DefaultCharacter>
     <CharacterRegions>
-      
-      <!-- Standard letters and numbers -->
       <CharacterRegion>
-        <Start>32</Start>
-        <End>126</End>
+        <Start> </Start>
+        <End>~</End>
       </CharacterRegion>
-
-      <!-- Δ Delta symbol -->
       <CharacterRegion>
-        <Start>&#916;</Start>
-        <End>&#916;</End>
+        <Start>°</Start>
+        <End>°</End>
       </CharacterRegion>
-
-      <!-- ° Degree symbol -->
       <CharacterRegion>
-        <Start>&#176;</Start>
-        <End>&#176;</End>
+        <Start>Δ</Start>
+        <End>Δ</End>
       </CharacterRegion>
-      
     </CharacterRegions>
-
-    <ExtendedListProperty>      
+    <ExtendedListProperty>
       <Item>item0</Item>
       <Item>item1</Item>
-      <Item>item2</Item>          
+      <Item>item2</Item>
     </ExtendedListProperty>
-
   </Asset>
-  
 </XnaContent>

--- a/Test/Assets/Xml/20_SystemTypes.xml
+++ b/Test/Assets/Xml/20_SystemTypes.xml
@@ -1,10 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<XnaContent xmlns:Graphics="Microsoft.Xna.Framework.Content.Pipeline.Graphics">
-
-  <Asset Type="MonoGame.Tests.ContentPipeline.SystemTypes">
-
+<XnaContent>
+  <Asset Type="SystemTypes">
     <TimeSpan>PT42.5S</TimeSpan>
-    
   </Asset>
-
 </XnaContent>

--- a/Test/Assets/Xml/21_QualifiedTypes.xml
+++ b/Test/Assets/Xml/21_QualifiedTypes.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<XnaContent>
+    <Asset Type="MonoGame.Tests.ContentPipeline.QualifiedTypes">
+        <GetSetProperty>Hello World</GetSetProperty>
+        <PublicField>1</PublicField>
+        <Nested>
+            <Name>Shawn</Name>
+            <IsEnglish>true</IsEnglish>
+        </Nested>
+    </Asset>
+</XnaContent>

--- a/Test/ContentPipeline/AssetTestClasses.cs
+++ b/Test/ContentPipeline/AssetTestClasses.cs
@@ -10,195 +10,272 @@ using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
 
+#region The Basics
+public class TheBasics
+{
+    public int PublicField;
+    protected int ProtectedField;
+    private int PrivateField;
+    internal int InternalField;
+
+    public string GetSetProperty
+    {
+        get;
+        set;
+    }
+
+    public string GetOnlyProperty
+    {
+        get { return "Hello World"; }
+    }
+
+    public string SetOnlyProperty { set; private get; }
+
+    public NestedClass Nested = new NestedClass();
+}
+
+public class NestedClass
+{
+    public string Name;
+    public bool IsEnglish;
+}
+#endregion
+
+#region Inheritance
+public class InheritanceBase
+{
+    public int elf;
+}
+
+public class Inheritance : InheritanceBase
+{
+    public string hello;
+}
+#endregion
+
+#region IncludingPrivateMembers
+public class IncludingPrivateMembers
+{
+    public IncludingPrivateMembers()
+    {
+    }
+
+    public IncludingPrivateMembers(int elf)
+    {
+        this.elf = elf;
+    }
+
+    [ContentSerializer]
+    private int elf; // will be serialized
+
+    public int GetElfValue()
+    {
+        return elf;
+    }
+}
+#endregion
+
+#region ExcludingPublicMembers
+public class ExcludingPublicMembers
+{
+    [ContentSerializerIgnore]
+    public int elf; // will not be serialized
+}
+#endregion
+
+#region RenamingXmlElements
+public class RenamingXmlElements
+{
+    [ContentSerializer(ElementName = "ShawnSaysHello")]
+    public string hello;
+
+    [ContentSerializer(ElementName = "ElvesAreCool")]
+    public int elf;
+}
+#endregion
+
+#region NullReferences
+public class NullReferences
+{
+    public string hello = "world";
+}
+#endregion
+
+#region OptionalElements
+public class OptionalElements
+{
+    [ContentSerializer(Optional = true)]
+    public string a = null;
+
+    public string b = "b";
+
+    [ContentSerializer(Optional = true)]
+    public string c = "c";
+}
+#endregion
+
+#region AllowNull
+public class AllowNull
+{
+    [ContentSerializer(AllowNull = false)]
+    string a;
+}
+#endregion
+
+#region Collections
+public class Collections
+{
+    public string[] StringArray;
+    public List<string> StringList;
+    public int[] IntArray;
+}
+#endregion
+
+#region CollectionItemName
+public class CollectionItemName
+{
+    [ContentSerializer(ElementName = "w00t", CollectionItemName = "Flibble")]
+    public string[] StringArray;
+}
+#endregion
+
+#region Dictionaries
+public class Dictionaries
+{
+    public Dictionary<int, bool> TestDictionary = new Dictionary<int, bool>();
+}
+#endregion
+
+#region Primitive Types
+public class PrimitiveTypes
+{
+    public char Char;
+    public char Char2;
+    public char Char3;
+    public byte Byte;
+    public sbyte SByte;
+    public short Short;
+    public ushort UShort;
+    public int Int;
+    public uint UInt;
+    public long Long;
+    public ulong ULong;
+    public float Float;
+    public double Double;
+    public char? NullChar;                        
+    public char? NotNullChar;
+}
+#endregion
+
+#region MathTypes
+public class MathTypes
+{
+    public Point Point;
+    public Rectangle Rectangle;
+    public Vector3 Vector3;
+    public Vector4 Vector4;
+    public Quaternion Quaternion;
+    public Plane Plane;
+    public Matrix Matrix;
+    public Color Color;
+    public Vector2[] Vector2Array = new Vector2[0];
+}
+#endregion
+
+#region PolymorphicTypes
+public class PolymorphicA
+{
+    public bool Value;
+}
+
+public class PolymorphicB : PolymorphicA { }
+public class PolymorphicC : PolymorphicA { }
+
+public class PolymorphicTypes
+{
+    public object Hello;
+    public object Elf;
+    public PolymorphicA[] TypedArray;
+    public Array UntypedArray;
+}
+#endregion
+
+#region FlattenContent
+public class FlattenContent
+{
+    [ContentSerializer(FlattenContent = true)]
+    public NestedClass Nested;
+
+    [ContentSerializer(FlattenContent = true, CollectionItemName = "Boo")]
+    public string[] Collection;
+}
+#endregion
+
+#region SharedResources
+public class SharedResources
+{
+    [ContentSerializer(SharedResource = true)]
+    public Linked Head;
+}
+
+public class Linked
+{
+    public int Value;
+
+    [ContentSerializer(SharedResource = true)]
+    public Linked Next;
+}
+#endregion
+
+#region CircularReferences
+public class CircularReferences
+{
+    public CircularLinked Head;
+}
+
+public class CircularLinked
+{
+    public int Value;
+
+    public CircularLinked Next;
+}
+#endregion
+
+#region ExternalReferences
+public class ExternalReferences
+{
+    public ExternalReference<Texture2D> Texture;
+    public ExternalReference<Effect> Shader;
+}
+#endregion
+
+#region FontDescription
+class ExtendedFontDescription : FontDescription
+{
+    public ExtendedFontDescription()
+        : base("Arial", 14, 0)
+    {
+    }
+
+    [ContentSerializer(Optional = true, CollectionItemName = "Item")]
+    public List<string> ExtendedListProperty
+    {
+        get { return _list; }
+    }
+
+    private List<string> _list = new List<string>();
+}
+#endregion
+
+#region SystemTypes
+class SystemTypes
+{
+    public TimeSpan TimeSpan;
+}
+#endregion
+
 namespace MonoGame.Tests.ContentPipeline
 {
-    #region The Basics
-    public class TheBasics
-    {
-        public int PublicField;
-        protected int ProtectedField;
-        private int PrivateField;
-        internal int InternalField;
-
-        public string GetSetProperty
-        {
-            get; set;
-        }
-
-        public string GetOnlyProperty
-        {
-            get { return "Hello World"; }
-        }
-
-        public string SetOnlyProperty { set; private get; }
-
-        public NestedClass Nested = new NestedClass();
-    }
-
-    public class NestedClass
-    {
-        public string Name;
-        public bool IsEnglish;
-    }
-    #endregion
-
-    #region Inheritance
-    public class InheritanceBase
-    {
-        public int elf;
-    }
-
-    public class Inheritance : InheritanceBase
-    {
-        public string hello;
-    }
-    #endregion
-
-    #region IncludingPrivateMembers
-    public class IncludingPrivateMembers
-    {
-        public IncludingPrivateMembers()
-        {
-        }
-
-        public IncludingPrivateMembers(int elf)
-        {
-            this.elf = elf;
-        }
-
-        [ContentSerializer]
-        private int elf; // will be serialized
-
-        public int GetElfValue()
-        {
-            return elf;
-        }
-    }
-    #endregion
-
-    #region ExcludingPublicMembers
-    public class ExcludingPublicMembers
-    {
-        [ContentSerializerIgnore]
-        public int elf; // will not be serialized
-    }
-    #endregion
-
-    #region RenamingXmlElements
-    public class RenamingXmlElements
-    {
-        [ContentSerializer(ElementName = "ShawnSaysHello")]
-        public string hello;
-
-        [ContentSerializer(ElementName = "ElvesAreCool")]
-        public int elf;
-    }
-    #endregion
-
-    #region NullReferences
-    public class NullReferences
-    {
-        public string hello = "world";
-    }
-    #endregion
-
-    #region OptionalElements
-    public class OptionalElements
-    {
-        [ContentSerializer(Optional = true)]
-        public string a = null;
-
-        public string b = "b";
-
-        [ContentSerializer(Optional = true)]
-        public string c = "c";
-    }
-    #endregion
-
-    #region AllowNull
-    public class AllowNull
-    {
-        [ContentSerializer(AllowNull = false)]
-        string a;
-    }
-    #endregion
-
-    #region Collections
-    public class Collections
-    {
-        public string[] StringArray;
-        public List<string> StringList;
-        public int[] IntArray;
-    }
-    #endregion
-
-    #region CollectionItemName
-    public class CollectionItemName
-    {
-        [ContentSerializer(ElementName = "w00t", CollectionItemName = "Flibble")]
-        public string[] StringArray;
-    }
-    #endregion
-
-    #region Dictionaries
-    public class Dictionaries
-    {
-        public Dictionary<int, bool> TestDictionary = new Dictionary<int, bool>();
-    }
-    #endregion
-
-    #region Primitive Types
-    public class PrimitiveTypes
-    {
-        public char Char;
-        public byte Byte;
-        public sbyte SByte;
-        public short Short;
-        public ushort UShort;
-        public int Int;
-        public uint UInt;
-        public long Long;
-        public ulong ULong;
-        public float Float;
-        public double Double;
-        public char? NullChar;                        
-        public char? NotNullChar;
-    }
-    #endregion
-
-    #region MathTypes
-    public class MathTypes
-    {
-        public Point Point;
-        public Rectangle Rectangle;
-        public Vector3 Vector3;
-        public Vector4 Vector4;
-        public Quaternion Quaternion;
-        public Plane Plane;
-        public Matrix Matrix;
-        public Color Color;
-        public Vector2[] Vector2Array = new Vector2[0];
-    }
-    #endregion
-
-    #region PolymorphicTypes
-    public class PolymorphicA
-    {
-        public bool Value;
-    }
-
-    public class PolymorphicB : PolymorphicA { }
-    public class PolymorphicC : PolymorphicA { }
-
-    public class PolymorphicTypes
-    {
-        public object Hello;
-        public object Elf;
-        public PolymorphicA[] TypedArray;
-        public Array UntypedArray;
-    }
-    #endregion
-
     #region Namespaces
     public class NamespaceHelper
     {
@@ -210,66 +287,73 @@ namespace MonoGame.Tests.ContentPipeline
         public object A;
         public object B;
         public object C;
-    }
-    #endregion
-
-    #region FlattenContent
-    public class FlattenContent
-    {
-        [ContentSerializer(FlattenContent = true)]
-        public NestedClass Nested;
-
-        [ContentSerializer(FlattenContent = true, CollectionItemName = "Boo")]
-        public string[] Collection;
-    }
-    #endregion
-
-    #region SharedResources
-    public class SharedResources
-    {
-        [ContentSerializer(SharedResource = true)]
-        public Linked Head;
+        public object D;
+        public object E;
+        public object F;
+        public object G;
     }
 
-    public class Linked
+    namespace Nested
     {
-        public int Value;
-
-        [ContentSerializer(SharedResource = true)]
-        public Linked Next;
-    }
-    #endregion
-
-    #region ExternalReferences
-    public class ExternalReferences
-    {
-        public ExternalReference<Texture2D> Texture;
-        public ExternalReference<Effect> Shader;
-    }
-    #endregion
-
-    #region FontDescription
-    class ExtendedFontDescription : FontDescription
-    {
-        public ExtendedFontDescription()
-            : base("Arial", 14, 0)
+        public class ClassInsideNestedNamespace
         {
+            public bool Value;
         }
 
-        [ContentSerializer(Optional = true, CollectionItemName = "Item")]
-        public List<string> ExtendedListProperty
+        namespace ContentPipeline
         {
-            get { return _list; }
+            public class ClassInsideNestedAmbiguousNamespace
+            {
+                public bool Value;
+            }
         }
 
-        private List<string> _list = new List<string>();
+        namespace ContentPipeline2
+        {
+            public class ClassInsideNestedUnambiguousNamespace
+            {
+                public bool Value;
+            }
+        }
     }
     #endregion
 
-    #region SystemTypes
-    class SystemTypes
+    #region The Basics Namespaced
+    public class QualifiedTypes
     {
-        public TimeSpan TimeSpan;
+        public int PublicField;
+        protected int ProtectedField;
+        private int PrivateField;
+        internal int InternalField;
+
+        public string GetSetProperty
+        {
+            get;
+            set;
+        }
+
+        public string GetOnlyProperty
+        {
+            get { return "Hello World"; }
+        }
+
+        public string SetOnlyProperty { set; private get; }
+
+        public NestedQualifiedType Nested = new NestedQualifiedType();
+    }
+
+    public class NestedQualifiedType
+    {
+        public string Name;
+        public bool IsEnglish;
     }
     #endregion
+}
+
+namespace MonoGame.Tests.SomethingElse.ContentPipeline
+{
+    public class ClassInsideAmbiguousNamespace
+    {
+        public bool Value;
+    }
 }

--- a/Test/ContentPipeline/AssetTestClasses.cs
+++ b/Test/ContentPipeline/AssetTestClasses.cs
@@ -31,7 +31,13 @@ public class TheBasics
 
     public string SetOnlyProperty { set; private get; }
 
-    public NestedClass Nested = new NestedClass();
+    public NestedClass Nested;
+    public NestedClass Nested2;
+
+    public TheBasics()
+    {
+        Nested = Nested2 = new NestedClass();
+    }
 }
 
 public class NestedClass
@@ -245,6 +251,7 @@ public class CircularLinked
 public class ExternalReferences
 {
     public ExternalReference<Texture2D> Texture;
+    public ExternalReference<Texture2D> Texture2;
     public ExternalReference<Effect> Shader;
 }
 #endregion

--- a/Test/ContentPipeline/IntermediateDeserializerTest.cs
+++ b/Test/ContentPipeline/IntermediateDeserializerTest.cs
@@ -252,7 +252,7 @@ namespace MonoGame.Tests.ContentPipeline
             {
                 Assert.AreEqual(new Point(1, 2), mathTypes.Point);
                 Assert.AreEqual(new Rectangle(1, 2, 3, 4), mathTypes.Rectangle);
-                Assert.AreEqual(new Vector3(1, 2, 3), mathTypes.Vector3);
+                Assert.AreEqual(new Vector3(1, 2, 3.1f), mathTypes.Vector3);
                 Assert.AreEqual(new Vector4(1, 2, 3, 4), mathTypes.Vector4);
                 Assert.AreEqual(new Quaternion(1, 2, 3, 4), mathTypes.Quaternion);
                 Assert.AreEqual(new Plane(1, 2, 3, 4), mathTypes.Plane);
@@ -262,27 +262,6 @@ namespace MonoGame.Tests.ContentPipeline
                 Assert.AreEqual(2, mathTypes.Vector2Array.Length);
                 Assert.AreEqual(Vector2.Zero, mathTypes.Vector2Array[0]);
                 Assert.AreEqual(Vector2.One, mathTypes.Vector2Array[1]);
-            });
-        }
-
-        [Test]
-        public void PrimitiveTypes()
-        {
-            DeserializeCompileAndLoad<PrimitiveTypes>("18_PrimitiveTypes.xml", primitiveTypes =>
-            {
-                Assert.AreEqual('A', primitiveTypes.Char);
-                Assert.AreEqual(127, primitiveTypes.Byte);
-                Assert.AreEqual(-127, primitiveTypes.SByte);
-                Assert.AreEqual(-1000, primitiveTypes.Short);
-                Assert.AreEqual(1000, primitiveTypes.UShort);
-                Assert.AreEqual(-100000, primitiveTypes.Int);
-                Assert.AreEqual(100000, primitiveTypes.UInt);
-                Assert.AreEqual(-10000000, primitiveTypes.Long);
-                Assert.AreEqual(10000000, primitiveTypes.ULong);
-                Assert.AreEqual(1234567.0f, primitiveTypes.Float);
-                Assert.AreEqual(1234567890.0, primitiveTypes.Double);
-                Assert.AreEqual(null, primitiveTypes.NullChar);
-                Assert.AreEqual(' ', primitiveTypes.NotNullChar);
             });
         }
 
@@ -325,6 +304,14 @@ namespace MonoGame.Tests.ContentPipeline
                 Assert.AreEqual(Vector2.Zero, namespaceClass.B);
                 Assert.IsAssignableFrom<SpriteSortMode>(namespaceClass.C);
                 Assert.AreEqual(SpriteSortMode.Immediate, namespaceClass.C);
+                Assert.IsAssignableFrom<Nested.ContentPipeline.ClassInsideNestedAmbiguousNamespace>(namespaceClass.D);
+                Assert.AreEqual(true, ((Nested.ContentPipeline.ClassInsideNestedAmbiguousNamespace) namespaceClass.D).Value);
+                Assert.IsAssignableFrom<Nested.ClassInsideNestedNamespace>(namespaceClass.E);
+                Assert.AreEqual(true, ((Nested.ClassInsideNestedNamespace) namespaceClass.E).Value);
+                Assert.IsAssignableFrom<Nested.ContentPipeline2.ClassInsideNestedUnambiguousNamespace>(namespaceClass.F);
+                Assert.AreEqual(true, ((Nested.ContentPipeline2.ClassInsideNestedUnambiguousNamespace) namespaceClass.F).Value);
+                Assert.IsAssignableFrom<SomethingElse.ContentPipeline.ClassInsideAmbiguousNamespace>(namespaceClass.G);
+                Assert.AreEqual(true, ((SomethingElse.ContentPipeline.ClassInsideAmbiguousNamespace) namespaceClass.G).Value);
             });
         }
 
@@ -368,6 +355,29 @@ namespace MonoGame.Tests.ContentPipeline
                 Assert.IsTrue(externalReferences.Texture.Filename.EndsWith(@"\Xml\grass.tga"));
                 Assert.NotNull(externalReferences.Shader);
                 Assert.IsTrue(externalReferences.Shader.Filename.EndsWith(@"\Xml\foliage.fx"));
+            });
+        }
+
+        [Test]
+        public void PrimitiveTypes()
+        {
+            DeserializeCompileAndLoad<PrimitiveTypes>("18_PrimitiveTypes.xml", primitiveTypes =>
+            {
+                Assert.AreEqual('A', primitiveTypes.Char);
+                Assert.AreEqual('°', primitiveTypes.Char2);
+                Assert.AreEqual('Δ', primitiveTypes.Char3);
+                Assert.AreEqual(127, primitiveTypes.Byte);
+                Assert.AreEqual(-127, primitiveTypes.SByte);
+                Assert.AreEqual(-1000, primitiveTypes.Short);
+                Assert.AreEqual(1000, primitiveTypes.UShort);
+                Assert.AreEqual(-100000, primitiveTypes.Int);
+                Assert.AreEqual(100000, primitiveTypes.UInt);
+                Assert.AreEqual(-10000000, primitiveTypes.Long);
+                Assert.AreEqual(10000000, primitiveTypes.ULong);
+                Assert.AreEqual(1234567.0f, primitiveTypes.Float);
+                Assert.AreEqual(1234567890.0, primitiveTypes.Double);
+                Assert.AreEqual(null, primitiveTypes.NullChar);
+                Assert.AreEqual('B', primitiveTypes.NotNullChar);
             });
         }
 
@@ -422,6 +432,20 @@ namespace MonoGame.Tests.ContentPipeline
             DeserializeCompileAndLoad<SystemTypes>("20_SystemTypes.xml", sysTypes =>
             {
                 Assert.AreEqual(TimeSpan.FromSeconds(42.5f), sysTypes.TimeSpan);
+            });
+        }
+
+        [Test]
+        public void QualifiedTypes()
+        {
+            DeserializeCompileAndLoad<QualifiedTypes>("21_QualifiedTypes.xml", theBasics =>
+            {
+                Assert.AreEqual(1, theBasics.PublicField);
+                Assert.AreEqual(0, theBasics.InternalField);
+                Assert.AreEqual("Hello World", theBasics.GetSetProperty);
+                Assert.NotNull(theBasics.Nested);
+                Assert.AreEqual("Shawn", theBasics.Nested.Name);
+                Assert.AreEqual(true, theBasics.Nested.IsEnglish);
             });
         }
     }

--- a/Test/ContentPipeline/IntermediateDeserializerTest.cs
+++ b/Test/ContentPipeline/IntermediateDeserializerTest.cs
@@ -114,6 +114,10 @@ namespace MonoGame.Tests.ContentPipeline
                 Assert.NotNull(theBasics.Nested);
                 Assert.AreEqual("Shawn", theBasics.Nested.Name);
                 Assert.AreEqual(true, theBasics.Nested.IsEnglish);
+                Assert.NotNull(theBasics.Nested2);
+                Assert.AreEqual("Shawn", theBasics.Nested2.Name);
+                Assert.AreEqual(true, theBasics.Nested2.IsEnglish);
+                Assert.AreNotSame(theBasics.Nested, theBasics.Nested2);
             });
         }
 
@@ -353,6 +357,9 @@ namespace MonoGame.Tests.ContentPipeline
             {
                 Assert.NotNull(externalReferences.Texture);
                 Assert.IsTrue(externalReferences.Texture.Filename.EndsWith(@"\Xml\grass.tga"));
+                Assert.NotNull(externalReferences.Texture2);
+                Assert.IsTrue(externalReferences.Texture2.Filename.EndsWith(@"\Xml\grass.tga"));
+                Assert.AreNotSame(externalReferences.Texture, externalReferences.Texture2);
                 Assert.NotNull(externalReferences.Shader);
                 Assert.IsTrue(externalReferences.Shader.Filename.EndsWith(@"\Xml\foliage.fx"));
             });

--- a/Test/ContentPipeline/IntermediateSerializerTest.cs
+++ b/Test/ContentPipeline/IntermediateSerializerTest.cs
@@ -102,16 +102,18 @@ namespace MonoGame.Tests.ContentPipeline
         [Test]
         public void TheBasics()
         {
+            var nestedObject = new NestedClass
+            {
+                Name = "Shawn",
+                IsEnglish = true
+            };
             SerializeAndAssert("01_TheBasics.xml", new TheBasics
             {
                 PublicField = 1,
                 InternalField = 0,
                 GetSetProperty = "Hello World",
-                Nested = new NestedClass
-                {
-                    Name = "Shawn",
-                    IsEnglish = true
-                }
+                Nested = nestedObject,
+                Nested2 = nestedObject
             });
         }
 
@@ -323,9 +325,11 @@ namespace MonoGame.Tests.ContentPipeline
         [Test]
         public void ExternalReferences()
         {
+            var grassExternalReference = new ExternalReference<Texture2D>(Path.GetFullPath("Assets/Xml/grass.tga"));
             SerializeAndAssert("17_ExternalReferences.xml", new ExternalReferences
             {
-                Texture = new ExternalReference<Texture2D>(Path.GetFullPath("Assets/Xml/grass.tga")),
+                Texture = grassExternalReference,
+                Texture2 = grassExternalReference,
                 Shader = new ExternalReference<Effect>(Path.GetFullPath("Assets/Xml/foliage.fx"))
             });
         }

--- a/Test/ContentPipeline/IntermediateSerializerTest.cs
+++ b/Test/ContentPipeline/IntermediateSerializerTest.cs
@@ -70,6 +70,11 @@ namespace MonoGame.Tests.ContentPipeline
 
             var actualXml = Serialize(filePath, value);
 
+            // Normalize line endings - git on build server seems to set
+            // core.autocrlf to false.
+            expectedXml = expectedXml.Replace(Environment.NewLine, "\n");
+            actualXml = actualXml.Replace(Environment.NewLine, "\n");
+
             Assert.AreEqual(expectedXml, actualXml);
         }
 

--- a/Test/ContentPipeline/IntermediateSerializerTest.cs
+++ b/Test/ContentPipeline/IntermediateSerializerTest.cs
@@ -1,0 +1,382 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Web;
+using System.Xml;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Content.Pipeline;
+using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
+using Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler;
+using Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate;
+using Microsoft.Xna.Framework.Graphics;
+using NUnit.Framework;
+#if XNA
+using System.Reflection;
+#endif
+
+namespace MonoGame.Tests.ContentPipeline
+{
+    // These tests are based on "Everything you ever wanted to know about IntermediateSerializer" by Shawn Hargreaves
+    // http://blogs.msdn.com/b/shawnhar/archive/2008/08/12/everything-you-ever-wanted-to-know-about-intermediateserializer.aspx
+
+    class IntermediateSerializerTest
+    {
+        class TestContentManager : ContentManager
+        {
+            class FakeGraphicsService : IGraphicsDeviceService
+            {
+                public GraphicsDevice GraphicsDevice { get; private set; }
+                public event EventHandler<EventArgs> DeviceCreated;
+                public event EventHandler<EventArgs> DeviceDisposing;
+                public event EventHandler<EventArgs> DeviceReset;
+                public event EventHandler<EventArgs> DeviceResetting;
+            }
+
+            class FakeServiceProvider : IServiceProvider
+            {
+                public object GetService(Type serviceType)
+                {
+                    if (serviceType == typeof(IGraphicsDeviceService))
+                        return new FakeGraphicsService();
+
+                    throw new NotImplementedException();
+                }
+            }
+
+            private readonly MemoryStream _xnbStream;
+
+            public TestContentManager(MemoryStream xnbStream)
+                : base(new FakeServiceProvider(), "NONE")
+            {
+                _xnbStream = xnbStream;
+            }
+
+            protected override Stream OpenStream(string assetName)
+            {
+                return new MemoryStream(_xnbStream.GetBuffer(), false);
+            }
+        }
+
+        private static void SerializeAndAssert<T>(string file, T value)
+        {
+            var filePath = Paths.Xml(file);
+            var expectedXml = File.ReadAllText(filePath);
+
+            var actualXml = Serialize(filePath, value);
+
+            Assert.AreEqual(expectedXml, actualXml);
+        }
+
+        private static string Serialize<T>(string filePath, T value)
+        {
+            string referenceRelocationPath = filePath;
+
+            // Note: Can't use StringBuilder here because it is always UTF-16,
+            // while our test XML files use a UTF-8 encoding.
+            var memoryStream = new MemoryStream();
+            var xmlWriterSettings = new XmlWriterSettings
+            {
+                Encoding = Encoding.UTF8,
+                Indent = true
+            };
+            using (var writer = XmlWriter.Create(memoryStream, xmlWriterSettings))
+                IntermediateSerializer.Serialize(writer, value, referenceRelocationPath);
+
+            memoryStream.Position = 0;
+            var actualXml = new StreamReader(memoryStream).ReadToEnd();
+
+            return actualXml;
+        }
+
+        [Test]
+        public void TheBasics()
+        {
+            SerializeAndAssert("01_TheBasics.xml", new TheBasics
+            {
+                PublicField = 1,
+                InternalField = 0,
+                GetSetProperty = "Hello World",
+                Nested = new NestedClass
+                {
+                    Name = "Shawn",
+                    IsEnglish = true
+                }
+            });
+        }
+
+        [Test]
+        public void Inheritance()
+        {
+            SerializeAndAssert("02_Inheritance.xml", new Inheritance
+            {
+                elf = 23,
+                hello = "world"
+            });
+        }
+
+        [Test]
+        public void IncludingPrivateMembers()
+        {
+            SerializeAndAssert("03_IncludingPrivateMembers.xml", new IncludingPrivateMembers(23));
+        }
+
+        [Test]
+        public void ExcludingPublicMembers()
+        {
+            SerializeAndAssert("04_ExcludingPublicMembersOutput.xml", new ExcludingPublicMembers
+            {
+                elf = 23
+            });
+        }
+
+        [Test]
+        public void RenamingXmlElements()
+        {
+            SerializeAndAssert("05_RenamingXmlElements.xml", new RenamingXmlElements
+            {
+                hello = "world",
+                elf = 23
+            });
+        }
+
+        [Test]
+        public void NullReferences()
+        {
+            SerializeAndAssert("06_NullReferences.xml", new NullReferences
+            {
+                hello = null
+            });
+        }
+
+        [Test]
+        public void OptionalElements()
+        {
+            SerializeAndAssert("07_OptionalElements.xml", new OptionalElements
+            {
+                a = null,
+                b = null,
+                c = string.Empty
+            });
+        }
+
+        [Test]
+        public void AllowNull()
+        {
+            // [AllowNull] "has no effect when serializing to XML"
+            // (http://blogs.msdn.com/b/shawnhar/archive/2008/08/12/everything-you-ever-wanted-to-know-about-intermediateserializer.aspx)
+
+            // Except for... it does have an effect. XNA throws an exception when
+            // you try to serialize a null element which has [AllowNull] specified.
+            Assert.Throws<InvalidOperationException>(() =>
+                Serialize("output", new AllowNull()));
+        }
+
+        [Test]
+        public void Collections()
+        {
+            SerializeAndAssert("09_Collections.xml", new Collections
+            {
+                StringArray = new[] { "Hello", "World" },
+                StringList = new List<string> { "This", "is", "a", "test" },
+                IntArray = new[] { 1, 2, 3, 23, 42 }
+            });
+        }
+
+        [Test]
+        public void CollectionItemName()
+        {
+            SerializeAndAssert("10_CollectionItemName.xml", new CollectionItemName
+            {
+                StringArray = new[] { "Hello", "World" }
+            });
+        }
+
+        [Test]
+        public void Dictionaries()
+        {
+            SerializeAndAssert("11_Dictionaries.xml", new Dictionaries
+            {
+                TestDictionary = new Dictionary<int, bool>
+                {
+                    { 23, true },
+                    { 42, false }
+                }
+            });
+        }
+
+        [Test]
+        public void MathTypes()
+        {
+            SerializeAndAssert("12_MathTypes.xml", new MathTypes
+            {
+                Point = new Point(1, 2),
+                Rectangle = new Rectangle(1, 2, 3, 4),
+                Vector3 = new Vector3(1, 2, 3.1f),
+                Vector4 = new Vector4(1, 2, 3, 4),
+                Quaternion = new Quaternion(1, 2, 3, 4),
+                Plane = new Plane(1, 2, 3, 4),
+                Matrix = new Matrix(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16),
+                Color = new Color{ A = 0xFF, R = 0x64, G = 0x95, B = 0xED },
+                Vector2Array = new []{ new Vector2(0, 0), new Vector2(1, 1) }
+            });
+        }
+
+        [Test]
+        public void PolymorphicTypes()
+        {
+            SerializeAndAssert("13_PolymorphicTypes.xml", new PolymorphicTypes
+            {
+                Hello = "World",
+                Elf = 23,
+
+                TypedArray = new[]
+                {
+                    new PolymorphicA { Value = true },
+                    new PolymorphicB { Value = true },
+                    new PolymorphicC { Value = true }
+                },
+
+                UntypedArray = new[]
+                {
+                    new PolymorphicA { Value = true },
+                    new PolymorphicB { Value = true },
+                    new PolymorphicC { Value = true }
+                }
+            });
+        }
+
+        [Test]
+        public void Namespaces()
+        {
+            SerializeAndAssert("14_Namespaces.xml", new NamespaceClass
+            {
+                A = new NamespaceHelper { Value = true },
+                B = new Vector2(0, 0),
+                C = SpriteSortMode.Immediate,
+                D = new Nested.ContentPipeline.ClassInsideNestedAmbiguousNamespace { Value = true },
+                E = new Nested.ClassInsideNestedNamespace { Value = true },
+                F = new Nested.ContentPipeline2.ClassInsideNestedUnambiguousNamespace { Value = true },
+                G = new SomethingElse.ContentPipeline.ClassInsideAmbiguousNamespace { Value = true }
+            });
+        }
+
+        [Test]
+        public void FlattenContent()
+        {
+            SerializeAndAssert("15_FlattenContent.xml", new FlattenContent
+            {
+                Nested = new NestedClass
+                {
+                    Name = "Shawn",
+                    IsEnglish = true
+                },
+                Collection = new[] { "Hello", "World" }
+            });
+        }
+
+        [Test]
+        public void CircularReferences()
+        {
+            var resource1 = new CircularLinked();
+            var resource2 = new CircularLinked();
+            var resource3 = new CircularLinked();
+
+            resource1.Next = resource2;
+            resource2.Next = resource3;
+            resource3.Next = resource1;
+
+            Assert.Throws<InvalidOperationException>(() =>
+                Serialize("output", new CircularReferences
+                {
+                    Head = resource1
+                }));
+        }
+
+        [Test]
+        public void SharedResources()
+        {
+            var resource1 = new Linked { Value = 1 };
+            var resource2 = new Linked { Value = 2 };
+            var resource3 = new Linked { Value = 3 };
+
+            resource1.Next = resource2;
+            resource2.Next = resource3;
+            resource3.Next = resource1;
+
+            SerializeAndAssert("16_SharedResources.xml", new SharedResources
+            {
+                Head = resource1
+            });
+        }
+
+        [Test]
+        public void ExternalReferences()
+        {
+            SerializeAndAssert("17_ExternalReferences.xml", new ExternalReferences
+            {
+                Texture = new ExternalReference<Texture2D>(Path.GetFullPath("Assets/Xml/grass.tga")),
+                Shader = new ExternalReference<Effect>(Path.GetFullPath("Assets/Xml/foliage.fx"))
+            });
+        }
+
+        [Test]
+        public void PrimitiveTypes()
+        {
+            SerializeAndAssert("18_PrimitiveTypes.xml", new PrimitiveTypes
+            {
+                Char = 'A',
+                Char2 = '°',
+                Char3 = 'Δ',
+                Byte = 127,
+                SByte = -127,
+                Short = -1000,
+                UShort = 1000,
+                Int = -100000,
+                UInt = 100000,
+                Long = -10000000,
+                ULong = 10000000,
+                Float = 1234567.0f,
+                Double = 1234567890.0,
+                NullChar = null,
+                NotNullChar = 'B'
+            });
+        }
+
+        [Test]
+        public void FontDescription()
+        {
+            var fontDescription = new ExtendedFontDescription
+            {
+                FontName = "Foo",
+                Size = 30,
+                Spacing = 0.75f,
+                UseKerning = true,
+                Style = FontDescriptionStyle.Bold,
+                DefaultCharacter = '*',
+                ExtendedListProperty = { "item0", "item1", "item2" }
+            };
+
+            for (var i = 32; i <= 126; i++)
+                fontDescription.Characters.Add((char) i);
+            fontDescription.Characters.Add(HttpUtility.HtmlDecode("&#916;")[0]);
+            fontDescription.Characters.Add(HttpUtility.HtmlDecode("&#176;")[0]);
+
+            SerializeAndAssert("19_FontDescription.xml", fontDescription);
+        }
+
+        [Test]
+        public void SystemTypes()
+        {
+            SerializeAndAssert("20_SystemTypes.xml", new SystemTypes
+            {
+                TimeSpan = TimeSpan.FromSeconds(42.5f)
+            });
+        }
+    }
+}

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -87,6 +87,7 @@
     <Compile Include="ContentPipeline\AssetTestClasses.cs" />
     <Compile Include="ContentPipeline\FontDescriptionTests.cs" />
     <Compile Include="ContentPipeline\IntermediateDeserializerTest.cs" />
+    <Compile Include="ContentPipeline\IntermediateSerializerTest.cs" />
     <Compile Include="ContentPipeline\ModelProcessorTests.cs" />
     <Compile Include="ContentPipeline\TestContentBuildLogger.cs" />
     <Compile Include="ContentPipeline\TestProcessorContext.cs" />
@@ -460,6 +461,9 @@
     <Content Include="Assets\Xml\04_ExcludingPublicMembers.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Assets\Xml\04_ExcludingPublicMembersOutput.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Assets\Xml\05_RenamingXmlElements.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -563,6 +567,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Assets\Xml\20_SystemTypes.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\Xml\21_QualifiedTypes.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
and supporting code, including `IntermediateWriter` and `ReflectiveSerializer.Serialize`.

Related to #2621.

I made some changes to the existing XML test files, for two reasons:

* To make them round-trippable, and
* To remove namespace alias usage from most test files, except for the one specifically related to namespaces

The code should be mostly okay, but `IntermediateSerializer.WriteNamespaces` could do with some cleaning up. That method was the most complicated to write out of all this; it took me a while to figure out XNA's behaviour.

On the bright side, I've ended up with a number of test cases dealing with nested namespaces, ambiguous namespaces, and nested ambiguous namespaces, so it shouldn't be too hard to go in and do some internal refactoring on that `WriteNamespaces` method, without too much risk of breaking anything.