### PR TITLE
Fix VertexBuffer.SetData bug introduced in #3356

### DIFF
--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.DirectX.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Xna.Framework.Graphics
                         var box = d3dContext.MapSubresource(stagingBuffer, 0, SharpDX.Direct3D11.MapMode.Read,
                             SharpDX.Direct3D11.MapFlags.None);
 
-                        for (int i = 0; i < data.Length; i++)
+                        for (int i = 0; i < elementCount; i++)
                             SharpDX.Utilities.CopyMemory(
                                 box.DataPointer + i*vertexStride + offsetInBytes,
                                 dataPtr + i*elementSizeInBytes, elementSizeInBytes);

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.PSM.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.PSM.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (_vertexArray == null)
                 _vertexArray = new T[VertexCount];
-            Array.Copy(data, offsetInBytes / vertexStride, _vertexArray, startIndex, elementCount);
+            Array.Copy(data, offsetInBytes / VertexDeclaration.VertexStride, _vertexArray, startIndex, elementCount);
         }
 
         protected override void Dispose(bool disposing)

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.cs
@@ -83,17 +83,72 @@ namespace Microsoft.Xna.Framework.Graphics
             this.GetData<T>(0, data, 0, data.Length, elementSizeInByte);
         }
 
+        /// <summary>
+        /// Sets the vertex buffer data, specifying the index at which to start copying from the source data array,
+        /// the number of elements to copy from the source data array, and the space to leave between elements from the source data array.
+        /// </summary>
+        /// <typeparam name="T">Type of elements in the data array.</typeparam>
+        /// <param name="offsetInBytes">Offset in bytes from the beginning of the vertex buffer to the start of the copied data.</param>
+        /// <param name="data">Data array.</param>
+        /// <param name="startIndex">Index at which to start copying from <paramref name="data"/>.
+        /// Must be within the <paramref name="data"/> array bounds.</param>
+        /// <param name="elementCount">Number of elements to copy from <paramref name="data"/>.
+        /// The combination of <paramref name="startIndex"/> and <paramref name="elementCount"/> 
+        /// must be within the <paramref name="data"/> array bounds.</param>
+        /// <param name="vertexStride">The space to leave between elements copied from <paramref name="data"/>.
+        /// If you specify <c>0</c> for this parameter, it will be treated as if you had specified <c>sizeof(T)</c>.
+        /// With the exception of <c>0</c>, you must specify a value greater than or equal to <c>sizeof(T)</c>.</param>
+        /// <example>
+        /// If <c>T</c> is <c>VertexPositionTexture</c>, but you want to set only the position component of the vertex data,
+        /// you would call this method as follows:
+        /// <code>
+        /// Vector3[] positions = new Vector3[numVertices];
+        /// vertexBuffer.SetData(0, positions, 0, numVertices, vertexBuffer.VertexDeclaration.VertexStride);
+        /// </code>
+        /// 
+        /// Continuing from the previous example, if you want to set only the texture coordinate component of the vertex data,
+        /// you would call this method as follows (note the use of <paramref name="offsetInBytes"/>:
+        /// <code>
+        /// Vector2[] texCoords = new Vector2[numVertices];
+        /// vertexBuffer.SetData(12, texCoords, 0, numVertices, vertexBuffer.VertexDeclaration.VertexStride);
+        /// </code>
+        /// </example>
+        /// <remarks>
+        /// If you provide a <c>byte[]</c> in the <paramref name="data"/> parameter, then you should almost certainly
+        /// set <paramref name="vertexStride"/> to <c>1</c>, to avoid leaving any space between the <c>byte</c> values
+        /// when they are copied into the vertex buffer.
+        /// </remarks>
         public void SetData<T>(int offsetInBytes, T[] data, int startIndex, int elementCount, int vertexStride) where T : struct
         {
             SetDataInternal<T>(offsetInBytes, data, startIndex, elementCount, vertexStride, SetDataOptions.None);
         }
-        		
+
+        /// <summary>
+        /// Sets the vertex buffer data, specifying the index at which to start copying from the source data array,
+        /// and the number of elements to copy from the source data array. This is the same as calling 
+        /// <see cref="SetData{T}(int, T[], int, int, int)"/>  with <c>offsetInBytes</c> equal to <c>0</c>,
+        /// and <c>vertexStride</c> equal to <c>sizeof(T)</c>.
+        /// </summary>
+        /// <typeparam name="T">Type of elements in the data array.</typeparam>
+        /// <param name="data">Data array.</param>
+        /// <param name="startIndex">Index at which to start copying from <paramref name="data"/>.
+        /// Must be within the <paramref name="data"/> array bounds.</param>
+        /// <param name="elementCount">Number of elements to copy from <paramref name="data"/>.
+        /// The combination of <paramref name="startIndex"/> and <paramref name="elementCount"/> 
+        /// must be within the <paramref name="data"/> array bounds.</param>
 		public void SetData<T>(T[] data, int startIndex, int elementCount) where T : struct
         {
             var elementSizeInBytes = Marshal.SizeOf(typeof(T));
             SetDataInternal<T>(0, data, startIndex, elementCount, elementSizeInBytes, SetDataOptions.None);
 		}
 		
+        /// <summary>
+        /// Sets the vertex buffer data. This is the same as calling <see cref="SetData{T}(int, T[], int, int, int)"/> 
+        /// with <c>offsetInBytes</c> and <c>startIndex</c> equal to <c>0</c>, <c>elementCount</c> equal to <c>data.Length</c>, 
+        /// and <c>vertexStride</c> equal to <c>sizeof(T)</c>.
+        /// </summary>
+        /// <typeparam name="T">Type of elements in the data array.</typeparam>
+        /// <param name="data">Data array.</param>
         public void SetData<T>(T[] data) where T : struct
         {
             var elementSizeInBytes = Marshal.SizeOf(typeof(T));

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.cs
@@ -85,7 +85,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
         /// <summary>
         /// Sets the vertex buffer data, specifying the index at which to start copying from the source data array,
-        /// the number of elements to copy from the source data array, and the space to leave between elements from the source data array.
+        /// the number of elements to copy from the source data array, 
+        /// and how far apart elements from the source data array should be when they are copied into the vertex buffer.
         /// </summary>
         /// <typeparam name="T">Type of elements in the data array.</typeparam>
         /// <param name="offsetInBytes">Offset in bytes from the beginning of the vertex buffer to the start of the copied data.</param>
@@ -95,7 +96,13 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="elementCount">Number of elements to copy from <paramref name="data"/>.
         /// The combination of <paramref name="startIndex"/> and <paramref name="elementCount"/> 
         /// must be within the <paramref name="data"/> array bounds.</param>
-        /// <param name="vertexStride">The space to leave between elements copied from <paramref name="data"/>.
+        /// <param name="vertexStride">Specifies how far apart, in bytes, elements from <paramref name="data"/> should be when 
+        /// they are copied into the vertex buffer.
+        /// In almost all cases this should be <c>sizeof(T)</c>, to create a tightly-packed vertex buffer.
+        /// If you specify <c>sizeof(T)</c>, elements from <paramref name="data"/> will be copied into the 
+        /// vertex buffer with no padding between each element.
+        /// If you specify a value greater than <c>sizeof(T)</c>, elements from <paramref name="data"/> will be copied 
+        /// into the vertex buffer with padding between each element.
         /// If you specify <c>0</c> for this parameter, it will be treated as if you had specified <c>sizeof(T)</c>.
         /// With the exception of <c>0</c>, you must specify a value greater than or equal to <c>sizeof(T)</c>.</param>
         /// <example>
@@ -115,7 +122,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </example>
         /// <remarks>
         /// If you provide a <c>byte[]</c> in the <paramref name="data"/> parameter, then you should almost certainly
-        /// set <paramref name="vertexStride"/> to <c>1</c>, to avoid leaving any space between the <c>byte</c> values
+        /// set <paramref name="vertexStride"/> to <c>1</c>, to avoid leaving any padding between the <c>byte</c> values
         /// when they are copied into the vertex buffer.
         /// </remarks>
         public void SetData<T>(int offsetInBytes, T[] data, int startIndex, int elementCount, int vertexStride) where T : struct

--- a/Test/Framework/Visual/VertexBufferTest.cs
+++ b/Test/Framework/Visual/VertexBufferTest.cs
@@ -3,9 +3,12 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.CodeDom;
+using System.Linq;
 using Microsoft.Xna.Framework;
 using NUnit.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using NUnit.Framework.Constraints;
 
 namespace MonoGame.Tests.Visual
 {
@@ -98,6 +101,105 @@ namespace MonoGame.Tests.Visual
                 vertexBuffer.GetData(offsetInBytes, readData, 0, 2, vertexStride);
                 Assert.AreEqual(savedData[2], readData[0]);
                 Assert.AreEqual(savedData[3], readData[1]);
+            };
+            Game.RunOneFrame();
+        }
+
+        //[TestCase(true)]
+        [TestCase(false)]
+        public void ShouldSetAndGetDataBytes(bool dynamic)
+        {
+            Game.DrawWith += (sender, e) =>
+            {
+                var vertexBuffer = (dynamic)
+                    ? new DynamicVertexBuffer(Game.GraphicsDevice, typeof(VertexPositionTexture), savedData.Length, BufferUsage.None)
+                    : new VertexBuffer(Game.GraphicsDevice, typeof(VertexPositionTexture), savedData.Length, BufferUsage.None);
+                var savedDataBytes = ArrayUtil.ConvertFrom(savedData);
+                vertexBuffer.SetData(savedDataBytes);
+
+                var readData = new VertexPositionTexture[4];
+                vertexBuffer.GetData(readData, 0, 4);
+                Assert.AreEqual(savedData, readData);
+            };
+            Game.RunOneFrame();
+        }
+
+        //[TestCase(true)]
+        [TestCase(false, -1, 0, false, typeof(ArgumentOutOfRangeException))]
+        [TestCase(false, 0, 0, false, typeof(ArgumentOutOfRangeException))]
+        [TestCase(false, 0, 1, true, null)]
+        [TestCase(false, 0, -1, false, typeof(ArgumentOutOfRangeException))]
+        [TestCase(false, 0, 80, true, null)]
+        [TestCase(false, 0, 81, false, typeof(ArgumentOutOfRangeException))]
+        [TestCase(false, 1, 0, false, typeof(ArgumentOutOfRangeException))]
+        [TestCase(false, 1, 1, true, null)]
+        [TestCase(false, 1, 79, true, null)]
+        [TestCase(false, 1, 80, false, typeof(ArgumentOutOfRangeException))]
+        [TestCase(false, 79, 1, true, null)]
+        [TestCase(false, 79, 2, false, typeof(ArgumentOutOfRangeException))]
+        [TestCase(false, 80, 0, false, typeof(ArgumentOutOfRangeException))]
+        [TestCase(false, 80, 1, false, typeof(ArgumentOutOfRangeException))]
+        public void SetDataWithElementCount(bool dynamic, int startIndex, int elementCount, bool shouldSucceed, Type expectedExceptionType)
+        {
+            Game.DrawWith += (sender, e) =>
+            {
+                var vertexBuffer = (dynamic)
+                    ? new DynamicVertexBuffer(Game.GraphicsDevice, typeof(VertexPositionTexture), savedData.Length,
+                        BufferUsage.None)
+                    : new VertexBuffer(Game.GraphicsDevice, typeof(VertexPositionTexture), savedData.Length,
+                        BufferUsage.None);
+                var savedDataBytes = ArrayUtil.ConvertFrom(savedData);
+
+                if (!shouldSucceed)
+                    Assert.Throws(expectedExceptionType, () => vertexBuffer.SetData(savedDataBytes, startIndex, elementCount));
+                else
+                {
+                    vertexBuffer.SetData(savedDataBytes, startIndex, elementCount);
+
+                    var readDataBytes = new byte[savedDataBytes.Length];
+                    vertexBuffer.GetData(readDataBytes, startIndex, elementCount);
+                    Assert.AreEqual(
+                        savedDataBytes.Skip(startIndex).Take(elementCount).ToArray(),
+                        readDataBytes.Skip(startIndex).Take(elementCount).ToArray());
+                }
+            };
+            Game.RunOneFrame();
+        }
+
+        //[TestCase(true)]
+        [TestCase(false, 1, -1, false, typeof(ArgumentOutOfRangeException))]
+        [TestCase(false, 80, 0, true, null)]
+        [TestCase(false, 80, 1, true, null)]
+        [TestCase(false, 1, 2, true, null)]
+        [TestCase(false, 1, 40, true, null)]
+        [TestCase(false, 2, 40, true, null)]
+        [TestCase(false, 2, 80, false, typeof(InvalidOperationException))]
+        [TestCase(false, 1, 80, true, null)]
+        [TestCase(false, 1, 81, true, null)]
+        [TestCase(false, 2, 81, false, typeof(InvalidOperationException))]
+        public void SetDataWithElementCountAndVertexStride(bool dynamic, int elementCount, int vertexStride, bool shouldSucceed, Type expectedExceptionType)
+        {
+            Game.DrawWith += (sender, e) =>
+            {
+                var vertexBuffer = (dynamic)
+                    ? new DynamicVertexBuffer(Game.GraphicsDevice, typeof(VertexPositionTexture), savedData.Length,
+                        BufferUsage.None)
+                    : new VertexBuffer(Game.GraphicsDevice, typeof(VertexPositionTexture), savedData.Length,
+                        BufferUsage.None);
+                var savedDataBytes = ArrayUtil.ConvertFrom(savedData);
+
+                if (!shouldSucceed)
+                    Assert.Throws(expectedExceptionType, () => vertexBuffer.SetData(0, savedDataBytes, 0, elementCount, vertexStride));
+                else
+                {
+                    vertexBuffer.SetData(0, savedDataBytes, 0, elementCount, vertexStride);
+
+                    var readDataBytes = new byte[savedDataBytes.Length];
+                    vertexBuffer.GetData(0, readDataBytes, 0, elementCount, vertexStride);
+                    Assert.AreEqual(
+                        savedDataBytes.Take(elementCount).ToArray(), 
+                        readDataBytes.Take(elementCount).ToArray());
+                }
             };
             Game.RunOneFrame();
         }

--- a/Test/Framework/Visual/VertexBufferTest.cs
+++ b/Test/Framework/Visual/VertexBufferTest.cs
@@ -3,12 +3,10 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.CodeDom;
 using System.Linq;
 using Microsoft.Xna.Framework;
 using NUnit.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using NUnit.Framework.Constraints;
 
 namespace MonoGame.Tests.Visual
 {
@@ -168,6 +166,7 @@ namespace MonoGame.Tests.Visual
 
         //[TestCase(true)]
         [TestCase(false, 1, -1, false, typeof(ArgumentOutOfRangeException))]
+        [TestCase(false, 0, 0, false, typeof(ArgumentOutOfRangeException))]
         [TestCase(false, 80, 0, true, null)]
         [TestCase(false, 80, 1, true, null)]
         [TestCase(false, 1, 2, true, null)]
@@ -199,6 +198,39 @@ namespace MonoGame.Tests.Visual
                     Assert.AreEqual(
                         savedDataBytes.Take(elementCount).ToArray(), 
                         readDataBytes.Take(elementCount).ToArray());
+                }
+            };
+            Game.RunOneFrame();
+        }
+
+        //[TestCase(true)]
+        [TestCase(false, 1, 20, true, null)]
+        [TestCase(false, 3, 20, true, null)]
+        [TestCase(false, 4, 0, true, null)]
+        [TestCase(false, 4, 16, false, typeof(ArgumentOutOfRangeException))]
+        [TestCase(false, 4, 20, true, null)]
+        [TestCase(false, 5, 20, false, typeof(ArgumentOutOfRangeException))]
+        public void SetDataStructWithElementCountAndVertexStride(bool dynamic, int elementCount, int vertexStride, bool shouldSucceed, Type expectedExceptionType)
+        {
+            Game.DrawWith += (sender, e) =>
+            {
+                var vertexBuffer = (dynamic)
+                    ? new DynamicVertexBuffer(Game.GraphicsDevice, typeof(VertexPositionTexture), savedData.Length,
+                        BufferUsage.None)
+                    : new VertexBuffer(Game.GraphicsDevice, typeof(VertexPositionTexture), savedData.Length,
+                        BufferUsage.None);
+
+                if (!shouldSucceed)
+                    Assert.Throws(expectedExceptionType, () => vertexBuffer.SetData(0, savedData, 0, elementCount, vertexStride));
+                else
+                {
+                    vertexBuffer.SetData(0, savedData, 0, elementCount, vertexStride);
+
+                    var readData = new VertexPositionTexture[savedData.Length];
+                    vertexBuffer.GetData(0, readData, 0, elementCount, vertexStride);
+                    Assert.AreEqual(
+                        savedData.Take(elementCount).ToArray(),
+                        readData.Take(elementCount).ToArray());
                 }
             };
             Game.RunOneFrame();

--- a/Test/Runner/Utility.cs
+++ b/Test/Runner/Utility.cs
@@ -115,6 +115,23 @@ namespace MonoGame.Tests {
 
             return dest;
         }
+
+        public static byte[] ConvertFrom<T>(T[] source) where T : struct
+        {
+            var sizeOfSource = Marshal.SizeOf(typeof(T));
+            var count = source.Length;
+            var dest = new byte[sizeOfSource * count];
+
+            var pinned = GCHandle.Alloc(dest, GCHandleType.Pinned);
+            var pointer = pinned.AddrOfPinnedObject();
+
+            for (var i = 0; i < count; i++, pointer += sizeOfSource)
+                Marshal.StructureToPtr(source[i], pointer, true);
+
+            pinned.Free();
+
+            return dest;
+        }
     }
 
 	static class MathUtility 


### PR DESCRIPTION
... and add more `SetData` / `GetData` tests to tease out XNA behaviour surrounding `startIndex` / `elementCount` / `vertexStride` parameters.

Fixes the bug introduced in #3356.

Hopefully these tests go some way towards making it clear how these parameters interact. As I understand it, `vertexStride` controls the padding left between source data elements when they are copied to the vertex buffer. It must be `>= sizeof(T)`.

In my opinion, that means it's a somewhat poor choice of name, because if you're passing in a `byte[]`, the value you would choose for `vertexStride` (probably `1`) doesn't really have anything to do with vertex stride. But that's for another time.

I'm sorry for introducing this bug; I'll try to do more testing next time. If you spot anything amiss in this PR, let me know and I'll fix it ASAP.

**IMPORTANT**: @tomspilman , if you want the tests to actually run under XNA, you'll need to change the `RunOneFrame` calls to `Game.Run()`, as per our previous discussion. (I'm not sure why you don't want to use `Game.Run()`, since it has the same effect of running one frame and then exiting. In XNA, `RunOneFrame` seems to assume that the game has already been initialized, which MonoGame does at the start of `RunOneFrame`, but XNA (apparently) doesn't. So it might be non-trivial to get it working in the XNA tests. But that's a separate issue.)