### PR TITLE
Texture parameters on effects can now be explicitly set to null

### DIFF
--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -125,6 +125,7 @@
     
     <Compile Include="Framework\Visual\BlendStateTest.cs" />
     <Compile Include="Framework\Visual\DepthStencilStateTest.cs" />
+    <Compile Include="Framework\Visual\EffectTest.cs" />
     <Compile Include="Framework\Visual\RasterizerStateTest.cs" />
     <Compile Include="Framework\Visual\SamplerStateTest.cs" />
     <Compile Include="Framework\Visual\ScissorRectangleTest.cs" />

--- a/MonoGame.Framework/Graphics/Effect/EffectPass.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectPass.cs
@@ -121,8 +121,14 @@ namespace Microsoft.Xna.Framework.Graphics
                     var param = _effect.Parameters[sampler.parameter];
                     var texture = param.Data as Texture;
 										
-					// If there is no texture explicitly assigned then skip it
-					// and leave whatever set directly on the device.
+                    // If there is no texture *explicitly* assigned then skip it
+                    // and leave whatever set directly on the device.
+                    // Each time an effect parameter value is set, param.StateKey
+                    // will be incremented. So if our stored _stateKey - which is the cached
+                    // value from the previous time Apply() was called - is less than the 
+                    // current value of param.StateKey, we know that this texture parameter 
+                    // has been explicitly set to a value since the previous time Apply()
+                    // was called.
                     if (param.StateKey >= _stateKey)
 						device.Textures[sampler.textureSlot] = texture;
 
@@ -140,6 +146,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
             }
 
+            // Store current value of NextStateKey, so we can detect whether any texture
+            // parameter values are set between now and the next call to Apply().
             _stateKey = EffectParameter.NextStateKey;
 
 #endif

--- a/MonoGame.Framework/Graphics/Effect/EffectPass.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectPass.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Xna.Framework.Graphics
         private readonly DepthStencilState _depthStencilState;
         private readonly RasterizerState _rasterizerState;
 
+        private ulong _stateKey;
+
 		public string Name { get; private set; }
 
         public EffectAnnotationCollection Annotations { get; private set; }
@@ -90,6 +92,12 @@ namespace Microsoft.Xna.Framework.Graphics
 
 #if OPENGL || DIRECTX
 
+            // If our state key becomes larger than the 
+            // next state key then the keys have rolled 
+            // over and we need to reset.
+            if (_stateKey > EffectParameter.NextStateKey)
+                _stateKey = 0;
+
             if (_vertexShader != null)
             {
                 device.VertexShader = _vertexShader;
@@ -113,9 +121,9 @@ namespace Microsoft.Xna.Framework.Graphics
                     var param = _effect.Parameters[sampler.parameter];
                     var texture = param.Data as Texture;
 										
-					// If there is no texture assigned then skip it
+					// If there is no texture explicitly assigned then skip it
 					// and leave whatever set directly on the device.
-					if (texture != null)
+                    if (param.StateKey >= _stateKey)
 						device.Textures[sampler.textureSlot] = texture;
 
                     // If there is a sampler state set it.
@@ -131,6 +139,8 @@ namespace Microsoft.Xna.Framework.Graphics
                     device.SetConstantBuffer(ShaderStage.Pixel, c, cb);
                 }
             }
+
+            _stateKey = EffectParameter.NextStateKey;
 
 #endif
 

--- a/Test/Framework/Visual/EffectTest.cs
+++ b/Test/Framework/Visual/EffectTest.cs
@@ -1,0 +1,56 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using Microsoft.Xna.Framework.Graphics;
+using NUnit.Framework;
+
+namespace MonoGame.Tests.Visual
+{
+    internal class EffectTest : VisualTestFixtureBase
+    {
+        [Test]
+        public void EffectPassShouldSetTexture()
+        {
+            Game.DrawWith += (sender, e) =>
+            {
+                var texture = new Texture2D(Game.GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
+                Game.GraphicsDevice.Textures[0] = null;
+
+                var effect = new BasicEffect(Game.GraphicsDevice);
+                effect.TextureEnabled = true;
+                effect.Texture = texture;
+
+                Assert.That(Game.GraphicsDevice.Textures[0], Is.Null);
+
+                var effectPass = effect.CurrentTechnique.Passes[0];
+                effectPass.Apply();
+
+                Assert.That(Game.GraphicsDevice.Textures[0], Is.SameAs(texture));
+            };
+            Game.Run();
+        }
+
+        [Test]
+        public void EffectPassShouldSetTextureEvenIfNull()
+        {
+            Game.DrawWith += (sender, e) =>
+            {
+                var texture = new Texture2D(Game.GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
+                Game.GraphicsDevice.Textures[0] = texture;
+
+                var effect = new BasicEffect(Game.GraphicsDevice);
+                effect.TextureEnabled = true;
+                effect.Texture = null;
+
+                Assert.That(Game.GraphicsDevice.Textures[0], Is.SameAs(texture));
+
+                var effectPass = effect.CurrentTechnique.Passes[0];
+                effectPass.Apply();
+
+                Assert.That(Game.GraphicsDevice.Textures[0], Is.Null);
+            };
+            Game.Run();
+        }
+    }
+}

--- a/Test/Framework/Visual/SpriteBatchTest.cs
+++ b/Test/Framework/Visual/SpriteBatchTest.cs
@@ -261,5 +261,53 @@ namespace MonoGame.Tests.Visual {
 		//_spriteBatch.End ();
 
 		//_spriteBatch.GraphicsDevice.RasterizerState.ScissorTestEnable = false;
+
+        [Test]
+        public void DrawRequiresTexture()
+        {
+            Game.DrawWith += (sender, e) =>
+            {
+                _spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.Opaque);
+                Assert.Throws<ArgumentNullException>(() => _spriteBatch.Draw(null, new Vector2(20, 20), Color.White));
+                _spriteBatch.End();
+            };
+            Game.Run();
+        }
+
+        [Test]
+        public void DrawWithTexture()
+        {
+            Game.DrawWith += (sender, e) =>
+            {
+                Assert.That(Game.GraphicsDevice.Textures[0], Is.Null);
+
+                _spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.Opaque);
+                _spriteBatch.Draw(_texture, new Vector2(20, 20), Color.White);
+                _spriteBatch.End();
+
+                Assert.That(Game.GraphicsDevice.Textures[0], Is.SameAs(_texture));
+            };
+            Game.Run();
+        }
+
+        [Test]
+        public void DrawWithTextureAlreadySet()
+        {
+            Game.DrawWith += (sender, e) =>
+            {
+                var texture2 = new Texture2D(Game.GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
+
+                Game.GraphicsDevice.Textures[0] = texture2;
+                Game.GraphicsDevice.Textures[1] = _texture;
+
+                _spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.Opaque);
+                _spriteBatch.Draw(_texture, new Vector2(20, 20), Color.White);
+                _spriteBatch.End();
+
+                Assert.That(Game.GraphicsDevice.Textures[0], Is.SameAs(_texture));
+                Assert.That(Game.GraphicsDevice.Textures[1], Is.SameAs(_texture));
+            };
+            Game.Run();
+        }
 	}
 }

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Framework\Vector4Test.cs" />
     <Compile Include="Framework\Visual\BlendStateTest.cs" />
     <Compile Include="Framework\Visual\DepthStencilStateTest.cs" />
+    <Compile Include="Framework\Visual\EffectTest.cs" />
     <Compile Include="Framework\Visual\IndexBufferTest.cs" />
     <Compile Include="Framework\Visual\RasterizerStateTest.cs" />
     <Compile Include="Framework\Visual\SamplerStateTest.cs" />


### PR DESCRIPTION
Fixes #3351.

Please feel free to review this thoroughly before merging :) I haven't changed many lines of code in `EffectPass`, but it's quite a fundamental change. I hope I've understood the `_stateKey` system correctly - I based it on how `ConstantBuffer.Update` works.