### PR TITLE
Remove Old Content Addin for XS from the Build process.

### DIFF
--- a/IDE/MonoDevelop/MonoDevelop.MonoGameContent/MonoDevelop.MonoGameContent/MonoDevelop.MonoGameContent.Win.csproj
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGameContent/MonoDevelop.MonoGameContent/MonoDevelop.MonoGameContent.Win.csproj
@@ -53,15 +53,15 @@
     </Reference>
     <Reference Include="Mono.Posix" />
     <Reference Include="MonoDevelop.Core">
-      <HintPath>..\..\..\..\..\..\..\..\..\..\Program Files %28x86%29\Xamarin Studio\bin\MonoDevelop.Core.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Xamarin Studio\bin\MonoDevelop.Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="MonoDevelop.Ide">
-      <HintPath>..\..\..\..\..\..\..\..\..\..\Program Files %28x86%29\Xamarin Studio\bin\MonoDevelop.Ide.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Xamarin Studio\bin\MonoDevelop.Ide.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="MonoDevelop.DesignerSupport">
-      <HintPath>..\..\..\..\..\..\..\..\..\..\Program Files %28x86%29\Xamarin Studio\AddIns\MonoDevelop.DesignerSupport\MonoDevelop.DesignerSupport.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Xamarin Studio\AddIns\MonoDevelop.DesignerSupport\MonoDevelop.DesignerSupport.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/IDE/MonoDevelop/default.build
+++ b/IDE/MonoDevelop/default.build
@@ -21,41 +21,7 @@
     <echo message="Detected : ${os}"/>
   </target>
 
-	<target name="build" description="Build Addins" depends="checkos">
-    <if test="${os == 'Win32NT'}">
-      <copy file="referencepaths.xml" tofile="MonoDevelop.MonoGameContent\MonoDevelop.MonoGameContent\MonoDevelop.MonoGameContent.Linux.csproj.user" overwrite="true"/>
-      <xmlpoke file="MonoDevelop.MonoGameContent\MonoDevelop.MonoGameContent\MonoDevelop.MonoGameContent.Linux.csproj.user"
-               xpath="/ns:Project/ns:PropertyGroup/ns:ReferencePath"
-               value="${mdtooldir};${mdtooldir}\..\AddIns\MonoDevelop.DesignerSupport">
-        <namespaces>
-          <namespace prefix="ns" uri="http://schemas.microsoft.com/developer/msbuild/2003" />
-        </namespaces>
-      </xmlpoke>
-      <exec program="msbuild " commandline="MonoDevelop.MonoGameContent\MonoDevelop.MonoGameContent.Win.sln /t:Clean /p:Configuration=Release" />
-      <exec program="msbuild " commandline="MonoDevelop.MonoGameContent\MonoDevelop.MonoGameContent.Win.sln /t:Build /p:Configuration=Release" />
-      <if test="${directory::exists(mdtooldir)}">
-        <exec program="mdtool " basedir="${mdtooldir}" workingdir="." commandline="setup pack MonoDevelop.MonoGameContent\MonoDevelop.MonoGameContent\bin\MonoDevelop.MonoGameContent.dll"/>
-        <move file="MonoDevelop.MonoGameContent_3.0.0.mpack" todir="Windows" overwrite="true"/>
-      </if>
-      <exec program="msbuild " commandline="MonoDevelop.MonoGameContent\MonoDevelop.MonoGameContent.Linux.sln /t:Clean /p:Configuration=Release" />
-      <exec program="msbuild " commandline="MonoDevelop.MonoGameContent\MonoDevelop.MonoGameContent.Linux.sln /t:Build /p:Configuration=Release" />
-      <if test="${directory::exists(mdtooldir)}">
-        <exec program="mdtool " basedir="${mdtooldir}" workingdir="." commandline="setup pack MonoDevelop.MonoGameContent\MonoDevelop.MonoGameContent\bin\Release\MonoDevelop.MonoGameContent.dll"/>
-        <move file="MonoDevelop.MonoGameContent_3.0.0.mpack" todir="Linux" overwrite="true"/>
-      </if>
-    </if>
-    <if test="${os == 'Unix'}">
-      <exec program="xbuild " commandline="/t:Clean /p:Configuration=Release MonoDevelop.MonoGameContent/MonoDevelop.MonoGameContent.Linux.sln" />
-      <exec program="xbuild " commandline="/t:Build /p:Configuration=Release MonoDevelop.MonoGameContent/MonoDevelop.MonoGameContent.Linux.sln" />
-      <if test="${directory::exists(mdtooldir)}">
-        <exec program="mdtool " basedir="${mdtooldir}" workingdir="." commandline="setup pack MonoDevelop.MonoGameContent\MonoDevelop.MonoGameContent\bin\MonoDevelop.MonoGameContent.dll"/>
-      </if>
-    </if>
-    <if test="${os == 'MacOS'}">
-      <exec program="mdtool" basedir="${mdtooldir}" workingdir="." commandline="build -t:Clean -c:Release  MonoDevelop.MonoGameContent/MonoDevelop.MonoGameContent.Mac.sln" />
-      <exec program="mdtool" basedir="${mdtooldir}" workingdir="." commandline="build -t:Build -c:Release  MonoDevelop.MonoGameContent/MonoDevelop.MonoGameContent.Mac.sln" />
-      <exec program="mdtool" basedir="${mdtooldir}" workingdir="." commandline="setup pack MonoDevelop.MonoGameContent/MonoDevelop.MonoGameContent/bin/Release/MonoDevelop.MonoGameContent.dll"/>
-    </if>
+  <target name="build" description="Build Addins" depends="checkos">
   </target>
 
 


### PR DESCRIPTION
This is an old addin that is no longer needed now the Pipeline tool is cross platform. 
For now we just remove the calls from the nant script. 
The PR covering the new addin will remove this entirely.