### PR TITLE
Fix intermittent VertexBuffer.GetData bug when vertexStride != sizeof(T)

### DIFF
--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.DirectX.cs
@@ -88,7 +88,6 @@ namespace Microsoft.Xna.Framework.Graphics
                 var dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
                 var startBytes = startIndex * vertexStride;
                 var dataPtr = (IntPtr)(dataHandle.AddrOfPinnedObject().ToInt64() + startBytes);
-                SharpDX.DataPointer DataPointer = new SharpDX.DataPointer(dataPtr, elementCount * TsizeInBytes);
 
                 lock (GraphicsDevice._d3dContext)
                 {
@@ -101,7 +100,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     }
                     else
                     {
-                        for (int i = 0; i < data.Length; i++)
+                        for (int i = 0; i < elementCount; i++)
                             SharpDX.Utilities.CopyMemory(dataPtr + i * TsizeInBytes, box.DataPointer + i * vertexStride + offsetInBytes, TsizeInBytes);
                     }
 


### PR DESCRIPTION
and remove unused DataPointer variable.

This bug has been present since at least February 2014, but I suspect it wasn't noticed because not many people, if any, used the overload of `GetData` that specifies a `vertexStride`.

The tests I added recently exercised this code path, and caused the loop to overrun the buffer, but it was intermittent, depending on what happened to be in the memory following the buffer.