### PR TITLE
Metro to Modern transformation

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -1155,16 +1155,16 @@
     <Compile Include="Windows8\InputEvents.cs">
       <Platforms>Windows8,WindowsPhone81</Platforms>
     </Compile>
-    <Compile Include="Windows8\MetroFrameworkView.cs">
+    <Compile Include="Windows8\ModernFrameworkView.cs">
       <Platforms>Windows8</Platforms>
     </Compile>
-    <Compile Include="Windows8\MetroGamePlatform.cs">
+    <Compile Include="Windows8\ModernGamePlatform.cs">
       <Platforms>Windows8,WindowsPhone81</Platforms>
     </Compile>
-    <Compile Include="Windows8\MetroGameWindow.cs">
+    <Compile Include="Windows8\ModernGameWindow.cs">
       <Platforms>Windows8,WindowsPhone81</Platforms>
     </Compile>
-    <Compile Include="Windows8\MetroHelper.cs">
+    <Compile Include="Windows8\ModernHelper.cs">
       <Platforms>Windows8,WindowsPhone,WindowsPhone81</Platforms>
     </Compile>
     <Compile Include="Windows8\SharpDXHelper.cs">

--- a/MonoGame.Framework/Content/ContentTypeReader.cs
+++ b/MonoGame.Framework/Content/ContentTypeReader.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Xna.Framework.Content
 		public static string Normalize(string fileName, string[] extensions)
 		{
 #if WINRT
-            if (MetroHelper.AppDataFileExists(fileName))
+            if (ModernHelper.AppDataFileExists(fileName))
                 return fileName;
 #else
             if (File.Exists(fileName))
@@ -138,7 +138,7 @@ namespace Microsoft.Xna.Framework.Content
                 string fileNamePlusExt = fileName + ext;
 
 #if WINRT
-                if (MetroHelper.AppDataFileExists(fileNamePlusExt))
+                if (ModernHelper.AppDataFileExists(fileNamePlusExt))
                     return fileNamePlusExt;
 #else
 			    if (File.Exists(fileNamePlusExt))

--- a/MonoGame.Framework/GamePlatform.cs
+++ b/MonoGame.Framework/GamePlatform.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Xna.Framework
 #elif WINDOWS_PHONE
             return new MonoGame.Framework.WindowsPhone.WindowsPhoneGamePlatform(game);
 #elif WINRT
-            return new MetroGamePlatform(game);
+            return new ModernGamePlatform(game);
 #elif WEB
             return new WebGamePlatform(game);
 #endif

--- a/MonoGame.Framework/GameTimer.cs
+++ b/MonoGame.Framework/GameTimer.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Xna.Framework
 
             // Do we need to initialize the window event handlers?
             if (_windowEvents == null && Window.Current != null)
-                _windowEvents = new InputEvents(Window.Current.CoreWindow, SharedGraphicsDeviceManager.Current.SwapChainBackgroundPanel, MetroGamePlatform.TouchQueue);
+                _windowEvents = new InputEvents(Window.Current.CoreWindow, SharedGraphicsDeviceManager.Current.SwapChainBackgroundPanel, ModernGamePlatform.TouchQueue);
             if (_windowEvents != null)
                 _windowEvents.UpdateState();
 

--- a/MonoGame.Framework/Windows8/GameFrameworkViewSource.cs
+++ b/MonoGame.Framework/Windows8/GameFrameworkViewSource.cs
@@ -19,7 +19,7 @@ namespace MonoGame.Framework
         [CLSCompliant(false)]
         public IFrameworkView CreateView()
         {
-            return new MetroFrameworkView<T>(_gameConstructorCustomizationDelegate);
+            return new ModernFrameworkView<T>(_gameConstructorCustomizationDelegate);
         }
     }
 }

--- a/MonoGame.Framework/Windows8/ModernFrameworkView.cs
+++ b/MonoGame.Framework/Windows8/ModernFrameworkView.cs
@@ -1,4 +1,4 @@
-﻿// MIT License - Copyright (C) The Mono.Xna Team
+﻿// MonoGame - Copyright (C) The MonoGame Team
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Windows8/ModernFrameworkView.cs
+++ b/MonoGame.Framework/Windows8/ModernFrameworkView.cs
@@ -1,18 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// MIT License - Copyright (C) The Mono.Xna Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using Windows.ApplicationModel.Activation;
 using Windows.ApplicationModel.Core;
 using Windows.UI.Core;
-using Windows.ApplicationModel.Activation;
 
 namespace Microsoft.Xna.Framework
 {
-    class MetroFrameworkView<T> : IFrameworkView
+    class ModernFrameworkView<T> : IFrameworkView
         where T : Game, new()
     {
-        public MetroFrameworkView(Action<T, IActivatedEventArgs> gameConstructorCustomizationDelegate)
+        public ModernFrameworkView(Action<T, IActivatedEventArgs> gameConstructorCustomizationDelegate)
         {
             this._gameConstructorCustomizationDelegate = gameConstructorCustomizationDelegate;
         }
@@ -33,8 +33,8 @@ namespace Microsoft.Xna.Framework
             if (args.Kind == ActivationKind.Launch)
             {
                 // Save any launch parameters to be parsed by the platform.
-                MetroGamePlatform.LaunchParameters = ((LaunchActivatedEventArgs)args).Arguments;
-                MetroGamePlatform.PreviousExecutionState = ((LaunchActivatedEventArgs)args).PreviousExecutionState;
+                ModernGamePlatform.LaunchParameters = ((LaunchActivatedEventArgs)args).Arguments;
+                ModernGamePlatform.PreviousExecutionState = ((LaunchActivatedEventArgs)args).PreviousExecutionState;
 
                 // Construct the game.                
                 _game = new T();
@@ -48,8 +48,8 @@ namespace Microsoft.Xna.Framework
             {
                 // Save any protocol launch parameters to be parsed by the platform.
                 var protocolArgs = args as ProtocolActivatedEventArgs;
-                MetroGamePlatform.LaunchParameters = protocolArgs.Uri.AbsoluteUri;
-                MetroGamePlatform.PreviousExecutionState = protocolArgs.PreviousExecutionState;
+                ModernGamePlatform.LaunchParameters = protocolArgs.Uri.AbsoluteUri;
+                ModernGamePlatform.PreviousExecutionState = protocolArgs.PreviousExecutionState;
 
                 // Construct the game if it does not exist
                 // Protocol can be used to reactivate a suspended game
@@ -77,7 +77,7 @@ namespace Microsoft.Xna.Framework
         public void SetWindow(CoreWindow window)
         {
             // Initialize the singleton window.
-            MetroGameWindow.Instance.Initialize(window, null, MetroGamePlatform.TouchQueue);
+            ModernGameWindow.Instance.Initialize(window, null, ModernGamePlatform.TouchQueue);
         }
 
         public void Uninitialize()

--- a/MonoGame.Framework/Windows8/ModernGamePlatform.cs
+++ b/MonoGame.Framework/Windows8/ModernGamePlatform.cs
@@ -1,4 +1,4 @@
-// MIT License - Copyright (C) The Mono.Xna Team
+// MonoGame - Copyright (C) The MonoGame Team
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Windows8/ModernGamePlatform.cs
+++ b/MonoGame.Framework/Windows8/ModernGamePlatform.cs
@@ -1,90 +1,20 @@
-#region License
-/*
-Microsoft Public License (Ms-PL)
-MonoGame - Copyright © 2009-2011 The MonoGame Team
+// MIT License - Copyright (C) The Mono.Xna Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
 
-All rights reserved.
-
-This license governs use of the accompanying software. If you use the software,
-you accept this license. If you do not accept the license, do not use the
-software.
-
-1. Definitions
-
-The terms "reproduce," "reproduction," "derivative works," and "distribution"
-have the same meaning here as under U.S. copyright law.
-
-A "contribution" is the original software, or any additions or changes to the
-software.
-
-A "contributor" is any person that distributes its contribution under this
-license.
-
-"Licensed patents" are a contributor's patent claims that read directly on its
-contribution.
-
-2. Grant of Rights
-
-(A) Copyright Grant- Subject to the terms of this license, including the
-license conditions and limitations in section 3, each contributor grants you a
-non-exclusive, worldwide, royalty-free copyright license to reproduce its
-contribution, prepare derivative works of its contribution, and distribute its
-contribution or any derivative works that you create.
-
-(B) Patent Grant- Subject to the terms of this license, including the license
-conditions and limitations in section 3, each contributor grants you a
-non-exclusive, worldwide, royalty-free license under its licensed patents to
-make, have made, use, sell, offer for sale, import, and/or otherwise dispose of
-its contribution in the software or derivative works of the contribution in the
-software.
-
-3. Conditions and Limitations
-
-(A) No Trademark License- This license does not grant you rights to use any
-contributors' name, logo, or trademarks.
-
-(B) If you bring a patent claim against any contributor over patents that you
-claim are infringed by the software, your patent license from such contributor
-to the software ends automatically.
-
-(C) If you distribute any portion of the software, you must retain all
-copyright, patent, trademark, and attribution notices that are present in the
-software.
-
-(D) If you distribute any portion of the software in source code form, you may
-do so only under this license by including a complete copy of this license with
-your distribution. If you distribute any portion of the software in compiled or
-object code form, you may only do so under a license that complies with this
-license.
-
-(E) The software is licensed "as-is." You bear the risk of using it. The
-contributors give no express warranties, guarantees or conditions. You may have
-additional consumer rights under your local laws which this license cannot
-change. To the extent permitted under your local laws, the contributors exclude
-the implied warranties of merchantability, fitness for a particular purpose and
-non-infringement.
-*/
-#endregion License
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Diagnostics;
-
-//using Microsoft.Xna.Framework.Audio;
-using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input.Touch;
 using Windows.ApplicationModel.Activation;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml.Media;
+using Microsoft.Xna.Framework.Input.Touch;
+
 #if WINDOWS_PHONE81
 using Windows.UI.Xaml;
 #endif
 
 namespace Microsoft.Xna.Framework
 {
-    class MetroGamePlatform : GamePlatform
+    class ModernGamePlatform : GamePlatform
     {
 		//private OpenALSoundController soundControllerInstance = null;
         internal static string LaunchParameters;
@@ -93,7 +23,7 @@ namespace Microsoft.Xna.Framework
 
         internal static ApplicationExecutionState PreviousExecutionState { get; set; }
 
-        public MetroGamePlatform(Game game)
+        public ModernGamePlatform(Game game)
             : base(game)
         {
 #if !WINDOWS_PHONE81
@@ -102,8 +32,8 @@ namespace Microsoft.Xna.Framework
             ViewState = ApplicationView.Value;
 #endif
             // Setup the game window.
-            Window = MetroGameWindow.Instance;
-            MetroGameWindow.Instance.Game = game;
+            Window = ModernGameWindow.Instance;
+            ModernGameWindow.Instance.Game = game;
 
             // Setup the launch parameters.
             // - Parameters can optionally start with a forward slash.
@@ -174,22 +104,22 @@ namespace Microsoft.Xna.Framework
 
         public override void RunLoop()
         {
-            MetroGameWindow.Instance.RunLoop();
+            ModernGameWindow.Instance.RunLoop();
         }
 
         public override void StartRunLoop()
         {
             CompositionTarget.Rendering += (o, a) =>
             {
-                MetroGameWindow.Instance.Tick();
+                ModernGameWindow.Instance.Tick();
             };
         }
         
         public override void Exit()
         {
-            if (!MetroGameWindow.Instance.IsExiting)
+            if (!ModernGameWindow.Instance.IsExiting)
             {
-                MetroGameWindow.Instance.IsExiting = true;
+                ModernGameWindow.Instance.IsExiting = true;
 #if WINDOWS_PHONE81
                 Application.Current.Exit();
 #endif
@@ -207,7 +137,7 @@ namespace Microsoft.Xna.Framework
             var device = Game.GraphicsDevice;
             if (device != null)
             {
-                // For a Metro app we need to re-apply the
+                // For a Modern app we need to re-apply the
                 // render target before every draw.  
                 // 
                 // I guess the OS changes it and doesn't restore it?
@@ -219,7 +149,7 @@ namespace Microsoft.Xna.Framework
 
         public override void EnterFullScreen()
         {
-            // Metro has no concept of fullscreen vs windowed!
+            // Modern has no concept of fullscreen vs windowed!
 #if WINDOWS_PHONE81
             StatusBar.GetForCurrentView().HideAsync();
 #endif
@@ -227,7 +157,7 @@ namespace Microsoft.Xna.Framework
 
         public override void ExitFullScreen()
         {
-            // Metro has no concept of fullscreen vs windowed!
+            // Modern has no concept of fullscreen vs windowed!
 #if WINDOWS_PHONE81
             StatusBar.GetForCurrentView().ShowAsync();
 #endif
@@ -255,7 +185,7 @@ namespace Microsoft.Xna.Framework
 
         protected override void OnIsMouseVisibleChanged() 
         {
-            MetroGameWindow.Instance.SetCursor(Game.IsMouseVisible);
+            ModernGameWindow.Instance.SetCursor(Game.IsMouseVisible);
         }
 		
         protected override void Dispose(bool disposing)
@@ -265,7 +195,7 @@ namespace Microsoft.Xna.Framework
             if (graphicsDeviceManager != null)
                 graphicsDeviceManager.Dispose();
 
-            MetroGameWindow.Instance.Dispose();
+            ModernGameWindow.Instance.Dispose();
 			
 			base.Dispose(disposing);
         }

--- a/MonoGame.Framework/Windows8/ModernGameWindow.cs
+++ b/MonoGame.Framework/Windows8/ModernGameWindow.cs
@@ -1,4 +1,4 @@
-﻿// MIT License - Copyright (C) The Mono.Xna Team
+﻿// MonoGame - Copyright (C) The MonoGame Team
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Windows8/ModernGameWindow.cs
+++ b/MonoGame.Framework/Windows8/ModernGameWindow.cs
@@ -1,62 +1,19 @@
-﻿#region License
-/*
-Microsoft Public License (Ms-PL)
-XnaTouch - Copyright © 2009 The XnaTouch Team
-
-All rights reserved.
-
-This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
-accept the license, do not use the software.
-
-1. Definitions
-The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
-U.S. copyright law.
-
-A "contribution" is the original software, or any additions or changes to the software.
-A "contributor" is any person that distributes its contribution under this license.
-"Licensed patents" are a contributor's patent claims that read directly on its contribution.
-
-2. Grant of Rights
-(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-
-3. Conditions and Limitations
-(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
-your patent license from such contributor to the software ends automatically.
-(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
-notices that are present in the software.
-(D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
-a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
-code form, you may only do so under a license that complies with this license.
-(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
-or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
-permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
-purpose and non-infringement.
-*/
-#endregion License
+﻿// MIT License - Copyright (C) The Mono.Xna Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.ComponentModel;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Reflection;
 using System.Runtime.InteropServices;
-
+using Windows.Graphics.Display;
 using Windows.UI.Core;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
-using Windows.Graphics.Display;
-
 using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input;
 using Microsoft.Xna.Framework.Input.Touch;
 
 namespace Microsoft.Xna.Framework
 {
-    partial class MetroGameWindow : GameWindow
+    partial class ModernGameWindow : GameWindow
     {
         private DisplayOrientation _supportedOrientations;
         private DisplayOrientation _orientation;
@@ -91,7 +48,7 @@ namespace Microsoft.Xna.Framework
             get { return false; }
             set 
             {
-                // You cannot resize a Metro window!
+                // You cannot resize a Modern window!
             }
         }
 
@@ -100,7 +57,7 @@ namespace Microsoft.Xna.Framework
             get { return _orientation; }
         }
 
-        private MetroGamePlatform Platform { get { return Game.Instance.Platform as MetroGamePlatform; } }
+        private ModernGamePlatform Platform { get { return Game.Instance.Platform as ModernGamePlatform; } }
 
         protected internal override void SetSupportedOrientations(DisplayOrientation orientations)
         {
@@ -129,11 +86,11 @@ namespace Microsoft.Xna.Framework
 
         #endregion
 
-        static public MetroGameWindow Instance { get; private set; }
+        static public ModernGameWindow Instance { get; private set; }
 
-        static MetroGameWindow()
+        static ModernGameWindow()
         {
-            Instance = new MetroGameWindow();
+            Instance = new ModernGameWindow();
         }
 
         public void Initialize(CoreWindow coreWindow, UIElement inputElement, TouchQueue touchQueue)
@@ -277,7 +234,7 @@ namespace Microsoft.Xna.Framework
         protected override void SetTitle(string title)
         {
             // NOTE: There is no concept of a window 
-            // title in a Metro application.
+            // title in a Modern application.
         }
 
         internal void SetCursor(bool visible)

--- a/MonoGame.Framework/Windows8/ModernHelper.cs
+++ b/MonoGame.Framework/Windows8/ModernHelper.cs
@@ -1,4 +1,4 @@
-﻿// MIT License - Copyright (C) The Mono.Xna Team
+﻿// MonoGame - Copyright (C) The MonoGame Team
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 

--- a/MonoGame.Framework/Windows8/ModernHelper.cs
+++ b/MonoGame.Framework/Windows8/ModernHelper.cs
@@ -1,14 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// MIT License - Copyright (C) The Mono.Xna Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Windows.Storage;
+using Windows.ApplicationModel;
 
 namespace Microsoft.Xna.Framework
 {
-    static internal class MetroHelper
+    static internal class ModernHelper
     {
         static public bool AppDataFileExists(string fileName)
         {
@@ -16,7 +17,7 @@ namespace Microsoft.Xna.Framework
 
                 try
                 {
-                    var file = await Windows.ApplicationModel.Package.Current.InstalledLocation.GetFileAsync(fileName);
+                    var file = await Package.Current.InstalledLocation.GetFileAsync(fileName);
                     return file == null ? false : true;
                 }
                 catch (FileNotFoundException)

--- a/MonoGame.Framework/Windows8/XamlGame.cs
+++ b/MonoGame.Framework/Windows8/XamlGame.cs
@@ -35,10 +35,10 @@ namespace MonoGame.Framework
                 throw new NullReferenceException("The swap chain panel cannot be null!");
 
             // Save any launch parameters to be parsed by the platform.
-            MetroGamePlatform.LaunchParameters = launchParameters;
+            ModernGamePlatform.LaunchParameters = launchParameters;
 
             // Setup the window class.
-            MetroGameWindow.Instance.Initialize(window, swapChainBackgroundPanel, MetroGamePlatform.TouchQueue);
+            ModernGameWindow.Instance.Initialize(window, swapChainBackgroundPanel, ModernGamePlatform.TouchQueue);
 
             // Construct the game.
             var game = new T();
@@ -71,7 +71,7 @@ namespace MonoGame.Framework
 #endif
         
         /// <summary>
-        /// Preserves the previous execution state in MetroGamePlatform and returns the constructed game object initialized with the given window.
+        /// Preserves the previous execution state in ModernGamePlatform and returns the constructed game object initialized with the given window.
         /// </summary>
         /// <param name="args">The command line arguments from launch.</param>
         /// <param name="window">The core window object.</param>
@@ -79,14 +79,14 @@ namespace MonoGame.Framework
         /// <returns></returns>
         static public T Create(LaunchActivatedEventArgs args, CoreWindow window, SwapChainBackgroundPanel swapChainBackgroundPanel)
         {
-            MetroGamePlatform.PreviousExecutionState = args.PreviousExecutionState;
+            ModernGamePlatform.PreviousExecutionState = args.PreviousExecutionState;
 
             return Create(args.Arguments, window, swapChainBackgroundPanel);
         }
 
         static public T Create(ProtocolActivatedEventArgs args, CoreWindow window, SwapChainBackgroundPanel swapChainBackgroundPanel)
         {
-            MetroGamePlatform.PreviousExecutionState = args.PreviousExecutionState;
+            ModernGamePlatform.PreviousExecutionState = args.PreviousExecutionState;
 
             return Create(args.Uri.AbsoluteUri, window, swapChainBackgroundPanel);
         }


### PR DESCRIPTION
All classes begins with Metro should be renamed to Modern(without UI) because Microsoft is changed it long time ago - http://www.theverge.com/2012/8/10/3232921/microsoft-modern-ui-style-metro-style-replacement
Also I remove not used references and fix licenses.