### PR TITLE
Fix bug in IntermediateSerializer.Serialize when value of statically-known type is null

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ContentTypeSerializerT.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ContentTypeSerializerT.cs
@@ -43,8 +43,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override void ScanChildren(IntermediateSerializer serializer, ChildCallback callback, object value)
         {
-            var cast = value == null ? default(T) : (T)value;
-            ScanChildren(serializer, callback, cast);
+            if (value == null)
+                return;
+            ScanChildren(serializer, callback, (T)value);
         }
 
         protected internal abstract void Serialize(IntermediateWriter output, T value, ContentSerializerAttribute format);

--- a/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
@@ -149,12 +149,6 @@ namespace Microsoft.Xna.Framework.Content
             Func<object, object> construct = parent => null;
             if (property != null && !property.CanWrite)
                 construct = parent => property.GetValue(parent, null);
-            else if (ReflectionHelpers.IsConcreteClass(elementType))
-            {
-                var constructor = elementType.GetDefaultConstructor();
-                if (constructor != null)
-                    construct = parent => constructor.Invoke(null);
-            }
 
             return (input, parent) =>
             {

--- a/Test/Assets/Xml/14_Namespaces.xml
+++ b/Test/Assets/Xml/14_Namespaces.xml
@@ -18,5 +18,6 @@
     <G Type="MonoGame.Tests.SomethingElse.ContentPipeline.ClassInsideAmbiguousNamespace">
       <Value>true</Value>
     </G>
+    <H Null="true" />
   </Asset>
 </XnaContent>

--- a/Test/ContentPipeline/AssetTestClasses.cs
+++ b/Test/ContentPipeline/AssetTestClasses.cs
@@ -298,6 +298,7 @@ namespace MonoGame.Tests.ContentPipeline
         public object E;
         public object F;
         public object G;
+        public List<string> H;
     }
 
     namespace Nested

--- a/Test/ContentPipeline/IntermediateDeserializerTest.cs
+++ b/Test/ContentPipeline/IntermediateDeserializerTest.cs
@@ -316,6 +316,7 @@ namespace MonoGame.Tests.ContentPipeline
                 Assert.AreEqual(true, ((Nested.ContentPipeline2.ClassInsideNestedUnambiguousNamespace) namespaceClass.F).Value);
                 Assert.IsAssignableFrom<SomethingElse.ContentPipeline.ClassInsideAmbiguousNamespace>(namespaceClass.G);
                 Assert.AreEqual(true, ((SomethingElse.ContentPipeline.ClassInsideAmbiguousNamespace) namespaceClass.G).Value);
+                Assert.IsNull(namespaceClass.H);
             });
         }
 

--- a/Test/ContentPipeline/IntermediateSerializerTest.cs
+++ b/Test/ContentPipeline/IntermediateSerializerTest.cs
@@ -269,7 +269,8 @@ namespace MonoGame.Tests.ContentPipeline
                 D = new Nested.ContentPipeline.ClassInsideNestedAmbiguousNamespace { Value = true },
                 E = new Nested.ClassInsideNestedNamespace { Value = true },
                 F = new Nested.ContentPipeline2.ClassInsideNestedUnambiguousNamespace { Value = true },
-                G = new SomethingElse.ContentPipeline.ClassInsideAmbiguousNamespace { Value = true }
+                G = new SomethingElse.ContentPipeline.ClassInsideAmbiguousNamespace { Value = true },
+                H = null
             });
         }
 


### PR DESCRIPTION
This was a minor bug in the `IntermediateSerializer.Serialize` implementation that was merged a few days ago.

I've fixed it and added a test case for it.