### PR TITLE
Gtk Pipeline new project improvement

### DIFF
--- a/Tools/Pipeline/Gtk/MainWindow.cs
+++ b/Tools/Pipeline/Gtk/MainWindow.cs
@@ -172,6 +172,9 @@ namespace MonoGame.Tools.Pipeline
 			var result = (filechooser.Run() == (int)ResponseType.Accept) ? true : false;
 			filePath = filechooser.Filename;
 
+            if (filechooser.Filter == MonoGameContentProjectFileFilter)
+                filePath += ".mgcb";
+
 			filechooser.Destroy ();
 			return result;
 		}


### PR DESCRIPTION
If gtk filter is set to ".mgcb" while creating a new project it should automatically add it to the end of the filename.