### PR TITLE
iOS 8 rotation handling for iPad and when Info.plist is > SupportedOrientations

### DIFF
--- a/MonoGame.Framework/iOS/iOSGamePlatform.cs
+++ b/MonoGame.Framework/iOS/iOSGamePlatform.cs
@@ -117,7 +117,6 @@ namespace Microsoft.Xna.Framework
             game.Services.AddService (typeof(UIViewController), _viewController);
             Window = new iOSGameWindow (_viewController);
 
-            _mainWindow.RootViewController = _viewController;
             _mainWindow.Add (_viewController.View);
 
             _viewController.InterfaceOrientationChanged += ViewController_InterfaceOrientationChanged;
@@ -201,6 +200,11 @@ namespace Microsoft.Xna.Framework
         {
             // Show the window
             _mainWindow.MakeKeyAndVisible();
+
+            // In iOS 8+ we need to set the root view controller *after* Window MakeKey
+            // This ensures that the viewController's supported interface orientations
+            // will be respected at launch
+            _mainWindow.RootViewController = _viewController;
 
             BeginObservingUIApplication();
 

--- a/MonoGame.Framework/iOS/iOSGameViewController.cs
+++ b/MonoGame.Framework/iOS/iOSGameViewController.cs
@@ -105,40 +105,29 @@ namespace Microsoft.Xna.Framework
 
         #region iOS 8 or newer
 
-        bool _orientationChanged;
-        UIInterfaceOrientation _prevOrientation;
-
 		public override void ViewWillTransitionToSize(CGSize toSize, IUIViewControllerTransitionCoordinator coordinator)
         {
 			CGSize oldSize = View.Bounds.Size;
 
             if (oldSize != toSize)
             {
-                _orientationChanged = true;
+                UIInterfaceOrientation prevOrientation = InterfaceOrientation;
 
-                // At this point, the new orientation hasn't been set
-                _prevOrientation = InterfaceOrientation;
+                // In iOS 8+ DidRotate is no longer called after a rotation
+                // But we need to notify iOSGamePlatform to update back buffer so we explicitly call it 
+
+                // We do this within the animateAlongside action, which at the point of calling
+                // will have the new InterfaceOrientation set
+                coordinator.AnimateAlongsideTransition((context) =>
+                    {
+                        DidRotate(prevOrientation);
+                    }, (context) => 
+                    {
+                    });
+
             }
 
             base.ViewWillTransitionToSize(toSize, coordinator);
-        } 
-
-        public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
-        {
-            if (previousTraitCollection != null)
-            {
-                base.TraitCollectionDidChange(previousTraitCollection);
-
-                // Not every trait change is related to rotation, so avoid unnecessarily updating
-                if(_orientationChanged)
-                {
-                    // In iOS 8+ DidRotate is no longer called after a rotation
-                    // But we need to notify iOSGamePlatform to update back buffer so we explicitly call it 
-                    DidRotate(_prevOrientation);
-
-                    _orientationChanged = false;
-                }
-            }
         }
 
         #endregion


### PR DESCRIPTION
Having another crack of this as I realised I previously didn't correctly read the original issue encountered in #3271 by @Nezz. So there were actually two separate issues:

1. iOS 8 rotation problems when targeting iPad when you allow *both* landscape/portrait rotations. This was something other people in the discussion of #3271 were encountering and that was what my previous fix was targeting.

2. The original issue @Nezz was describing was the case where you're Info.plist is a superset of those specified in the root view controller's supported orientations. So e.g. Info.plist is portrait/landscape but you want the root view controller to only support landscape orientations. In this instance, the behaviour should be that the app launches in landscape.

So I've appended my original fix for 1. along with another fix for 2. I've tried a number of iPad/iPhone simulated devices targeting iOS 7.1/8.1 so I'm hopeful that this solves the issues.