### PR TITLE
WinRT MediaLibrary speedup

### DIFF
--- a/MonoGame.Framework/Media/MediaLibrary.WinRT.cs
+++ b/MonoGame.Framework/Media/MediaLibrary.WinRT.cs
@@ -127,12 +127,18 @@ namespace Microsoft.Xna.Framework.Media
 
         private async Task GetAllFiles(StorageFolder storageFolder, List<StorageFile> musicFiles)
         {
-            foreach (var file in await storageFolder.GetFilesAsync())
-                if (file.ContentType.StartsWith("audio") && !file.ContentType.EndsWith("url"))
-                    musicFiles.Add(file);
-
-            foreach (var folder in await storageFolder.GetFoldersAsync())
-                await this.GetAllFiles(folder, musicFiles);
+            foreach (var item in await storageFolder.GetItemsAsync())
+                if (item is StorageFile)
+                {
+                    var file = item as StorageFile;
+                    if (file.ContentType.StartsWith("audio") && !file.ContentType.EndsWith("url"))
+                        musicFiles.Add(file);
+                }
+                else
+                {
+                    var folder = item as StorageFolder;
+                    await this.GetAllFiles(folder, musicFiles);
+                }
         }
 
         private AlbumCollection PlatformGetAlbums()


### PR DESCRIPTION
The async IO is very slow on WinRT. When parsing the storage folder for music we made two calls: `GetFilesAsync` to get the files and `GetFoldersAsync` to get subfolders to parse. This PR replaces these two calls with a single `GetItemsAsync` call, which makes the MediaLibrary load almost twice as fast.