### PR TITLE
Fixed two warnings

### DIFF
--- a/MonoGame.Framework/Input/Touch/TouchCollection.cs
+++ b/MonoGame.Framework/Input/Touch/TouchCollection.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
         }
 
         /// <summary>
-        /// Copies the <see cref="TouchLocation "/>collection to specified array starting from the given index.
+        /// Copies the <see cref="TouchLocation"/>collection to specified array starting from the given index.
         /// </summary>
         /// <param name="array">The array to copy <see cref="TouchLocation"/> items.</param>
         /// <param name="arrayIndex">The starting index of the copy operation.</param>

--- a/MonoGame.Framework/iOS/iOSGameViewController.cs
+++ b/MonoGame.Framework/iOS/iOSGameViewController.cs
@@ -65,7 +65,6 @@ namespace Microsoft.Xna.Framework
         }
 
         #region Autorotation for iOS 5 or older
-        [Obsolete]
         public override bool ShouldAutorotateToInterfaceOrientation(UIInterfaceOrientation toInterfaceOrientation)
         {
             DisplayOrientation supportedOrientations = OrientationConverter.Normalize(SupportedOrientations);


### PR DESCRIPTION
The base ShouldAutorotateToInterfaceOrientation method does not have the obsolate attrib anymore, so the override should not have it either.
TouchLocation cref had an extra space.