### PR TITLE
Fixed AAC build in content pipeline

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
                         // AAC (Advanced Audio Coding)
                         // Requires -strict experimental
                         ffmpegCodecName = "aac";
-                        ffmpegMuxerName = "adts";
+                        ffmpegMuxerName = "ipod";
                         format = 0x0000; /* WAVE_FORMAT_UNKNOWN */
                         break;
                     case ConversionFormat.Vorbis:
@@ -192,7 +192,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
                 var ffmpegExitCode = ExternalTool.Run(
                     "ffmpeg",
                     string.Format(
-                        "-y -i \"{0}\" -c:a {1} -b:a {2} -f:a {3} -strict experimental \"{4}\"",
+                        "-y -i \"{0}\" -vn -c:a {1} -b:a {2} -f:a {3} -strict experimental \"{4}\"",
                         temporarySource,
                         ffmpegCodecName,
                         QualityToBitRate(quality),

--- a/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
@@ -172,8 +172,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
                         break;
                     case ConversionFormat.Aac:
                         // AAC (Advanced Audio Coding)
+                        // Requires -strict experimental
                         ffmpegCodecName = "aac";
-                        ffmpegMuxerName = "aac";
+                        ffmpegMuxerName = "adts";
                         format = 0x0000; /* WAVE_FORMAT_UNKNOWN */
                         break;
                     case ConversionFormat.Vorbis:
@@ -191,7 +192,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
                 var ffmpegExitCode = ExternalTool.Run(
                     "ffmpeg",
                     string.Format(
-                        "-y -i \"{0}\" -c:a {1} -b:a {2} -f:a {3} \"{4}\"",
+                        "-y -i \"{0}\" -c:a {1} -b:a {2} -f:a {3} -strict experimental \"{4}\"",
                         temporarySource,
                         ffmpegCodecName,
                         QualityToBitRate(quality),


### PR DESCRIPTION
Fixes #3428

I can't believe how nobody tested the default format (used by iOS, Android, WindowsGL and others).