### PR TITLE
Opening broken .mgcb files throws exceptions

### DIFF
--- a/Tools/Pipeline/Common/IController.cs
+++ b/Tools/Pipeline/Common/IController.cs
@@ -44,7 +44,7 @@ namespace MonoGame.Tools.Pipeline
         /// <summary>
         /// The view this controller is attached to.
         /// </summary>
-        IView View { get; set; }
+        IView View { get; }
 
         /// <summary>
         /// Triggered when the project starts loading.

--- a/Tools/Pipeline/Common/PipelineController.ExcludeAction.cs
+++ b/Tools/Pipeline/Common/PipelineController.ExcludeAction.cs
@@ -30,7 +30,7 @@ namespace MonoGame.Tools.Pipeline
 
             public void Do()
             {
-                _con._view.BeginTreeUpdate();
+                _con.View.BeginTreeUpdate();
 
                 foreach (var obj in _state)
                 {
@@ -40,19 +40,19 @@ namespace MonoGame.Tools.Pipeline
                         if (item.OriginalPath == obj.SourceFile)
                         {
                             _con._project.ContentItems.Remove(item);
-                            _con._view.RemoveTreeItem(item);
+                            _con.View.RemoveTreeItem(item);
                             break;
                         }
                     }
                 }
 
-                _con._view.EndTreeUpdate();
+                _con.View.EndTreeUpdate();
                 _con.ProjectDirty = true;
             }
 
             public void Undo()
             {
-                _con._view.BeginTreeUpdate();
+                _con.View.BeginTreeUpdate();
 
                 foreach (var obj in _state)
                 {
@@ -64,10 +64,10 @@ namespace MonoGame.Tools.Pipeline
                     item.ResolveTypes();
 
                     _con._project.ContentItems.Add(item);
-                    _con._view.AddTreeItem(item);                        
+                    _con.View.AddTreeItem(item);
                 }
 
-                _con._view.EndTreeUpdate();
+                _con.View.EndTreeUpdate();
                 _con.ProjectDirty = true;
             }
         }

--- a/Tools/Pipeline/Common/PipelineController.IncludeAction.cs
+++ b/Tools/Pipeline/Common/PipelineController.IncludeAction.cs
@@ -24,7 +24,7 @@ namespace MonoGame.Tools.Pipeline
             public void Do()
             {
                 var parser = new PipelineProjectParser(_con, _con._project);
-                _con._view.BeginTreeUpdate();
+                _con.View.BeginTreeUpdate();
 
                 _con.Selection.Clear(_con);
 
@@ -40,17 +40,17 @@ namespace MonoGame.Tools.Pipeline
 
                     _files[i] = item.OriginalPath;
 
-                    _con._view.AddTreeItem(item);                    
-                    _con.Selection.Add(item, _con);                    
+                    _con.View.AddTreeItem(item);
+                    _con.Selection.Add(item, _con);
                 }
 
-                _con._view.EndTreeUpdate();
+                _con.View.EndTreeUpdate();
                 _con.ProjectDirty = true;
             }
 
             public void Undo()
             {
-                _con._view.BeginTreeUpdate();
+                _con.View.BeginTreeUpdate();
 
                 foreach (var f in _files)
                 {
@@ -66,7 +66,7 @@ namespace MonoGame.Tools.Pipeline
                     }
                 }
 
-                _con._view.EndTreeUpdate();
+                _con.View.EndTreeUpdate();
                 _con.ProjectDirty = true;
             }
         }

--- a/Tools/Pipeline/Common/PipelineController.NewAction.cs
+++ b/Tools/Pipeline/Common/PipelineController.NewAction.cs
@@ -33,14 +33,14 @@ namespace MonoGame.Tools.Pipeline
 
                 if (File.Exists(fullpath))
                 {
-                    _con._view.ShowError("Error", string.Format("File already exists: '{0}'.", fullpath));
+                    _con.View.ShowError("Error", string.Format("File already exists: '{0}'.", fullpath));
                     return;
                 }
 
                 File.Copy(_template.TemplateFile, fullpath);
 
                 var parser = new PipelineProjectParser(_con, _con._project);
-                _con._view.BeginTreeUpdate();
+                _con.View.BeginTreeUpdate();
 
                 _con.Selection.Clear(_con);
 
@@ -52,11 +52,11 @@ namespace MonoGame.Tools.Pipeline
                     item.ProcessorName = _template.ProcessorName;
                     item.ResolveTypes();
 
-                    _con._view.AddTreeItem(item);
+                    _con.View.AddTreeItem(item);
                     _con.Selection.Add(item, _con);
                 }
 
-                _con._view.EndTreeUpdate();
+                _con.View.EndTreeUpdate();
                 _con.ProjectDirty = true;
             }
 
@@ -68,13 +68,13 @@ namespace MonoGame.Tools.Pipeline
 
                 if (!File.Exists(fullpath))
                 {
-                    _con._view.ShowError("Error", string.Format("File does not exist: '{0}'.", fullpath));
+                    _con.View.ShowError("Error", string.Format("File does not exist: '{0}'.", fullpath));
                     return;
                 }
 
                 File.Delete(fullpath);
                 
-                _con._view.BeginTreeUpdate();
+                _con.View.BeginTreeUpdate();
 
                 for (var i = 0; i < _con._project.ContentItems.Count; i++)
                 {
@@ -84,14 +84,14 @@ namespace MonoGame.Tools.Pipeline
                     if (fullpath == path)
                     {
                         _con._project.ContentItems.Remove(item);
-                        _con._view.RemoveTreeItem(item);
+                        _con.View.RemoveTreeItem(item);
                         _con.Selection.Remove(item, _con);
                     }
                 }
                     
-                _con._view.EndTreeUpdate();
+                _con.View.EndTreeUpdate();
                 _con.ProjectDirty = true;
             }
-        }            
+        }
     }
 }

--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -215,7 +215,7 @@ namespace MonoGame.Tools.Pipeline
                 _project = new PipelineProject();
                 
                 var parser = new PipelineProjectParser(this, _project);
-                var errorCallback = new MGBuildParser.ErrorCallback((msg, args) => View.OutputAppend(string.Format(Path.GetFileName(projectFilePath) + ": " + msg, args)));
+                var errorCallback = new MGBuildParser.ErrorCallback((msg, args) => _view.OutputAppend(string.Format(Path.GetFileName(projectFilePath) + ": " + msg, args)));
                 parser.OpenProject(projectFilePath, errorCallback);
 
                 ResolveTypes();

--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -18,7 +18,6 @@ namespace MonoGame.Tools.Pipeline
     {
         private FileSystemWatcher watcher;
 
-        private readonly IView _view;
         private PipelineProject _project;
 
         private Task _buildTask;
@@ -59,7 +58,7 @@ namespace MonoGame.Tools.Pipeline
             }
         }
 
-        public IView View { get; set; }
+        public IView View { get; private set; }
 
         public event Action OnProjectLoading;
 
@@ -74,8 +73,8 @@ namespace MonoGame.Tools.Pipeline
             _actionStack = new ActionStack();
             Selection = new Selection();
 
-            _view = view;
-            _view.Attach(this);
+            View = view;
+            View.Attach(this);
             _project = project;
             ProjectOpen = false;
 
@@ -100,11 +99,11 @@ namespace MonoGame.Tools.Pipeline
         {
             Debug.Assert(ProjectOpen, "OnItemModified called with no project open?");
             ProjectDirty = true;
-            _view.UpdateProperties(contentItem);
+            View.UpdateProperties(contentItem);
 
-            _view.BeginTreeUpdate();
-            _view.UpdateTreeItem(contentItem);
-            _view.EndTreeUpdate();
+            View.BeginTreeUpdate();
+            View.UpdateTreeItem(contentItem);
+            View.EndTreeUpdate();
         }
 
         public void NewProject()
@@ -118,7 +117,7 @@ namespace MonoGame.Tools.Pipeline
             // So we need the user to choose that location even though the project has not
             // yet actually been saved to disk.
             var projectFilePath = Environment.CurrentDirectory;
-            if (!_view.AskSaveName(ref projectFilePath, "New Project"))
+            if (!View.AskSaveName(ref projectFilePath, "New Project"))
                 return;
 
             CloseProject();
@@ -150,7 +149,7 @@ namespace MonoGame.Tools.Pipeline
                 return;
 
             string projectFilePath;
-            if (!_view.AskImportProject(out projectFilePath))
+            if (!View.AskImportProject(out projectFilePath))
                 return;
 
             CloseProject();
@@ -175,7 +174,7 @@ namespace MonoGame.Tools.Pipeline
 #if SHIPPING
             catch (Exception e)
             {
-                _view.ShowError("Open Project", "Failed to open project!");
+                View.ShowError("Open Project", "Failed to open project!");
                 return;
             }
 #endif
@@ -194,7 +193,7 @@ namespace MonoGame.Tools.Pipeline
                 return;
 
             string projectFilePath;
-            if (!_view.AskOpenProject(out projectFilePath))
+            if (!View.AskOpenProject(out projectFilePath))
                 return;
             
             OpenProject(projectFilePath);
@@ -215,7 +214,7 @@ namespace MonoGame.Tools.Pipeline
                 _project = new PipelineProject();
                 
                 var parser = new PipelineProjectParser(this, _project);
-                var errorCallback = new MGBuildParser.ErrorCallback((msg, args) => _view.OutputAppend(string.Format(Path.GetFileName(projectFilePath) + ": " + msg, args)));
+                var errorCallback = new MGBuildParser.ErrorCallback((msg, args) => View.OutputAppend(string.Format(Path.GetFileName(projectFilePath) + ": " + msg, args)));
                 parser.OpenProject(projectFilePath, errorCallback);
 
                 ResolveTypes();
@@ -247,7 +246,7 @@ namespace MonoGame.Tools.Pipeline
 #if SHIPPING
             catch (Exception e)
             {
-                _view.ShowError("Open Project", "Failed to open project!");
+                View.ShowError("Open Project", "Failed to open project!");
                 return;
             }
 #endif
@@ -277,7 +276,7 @@ namespace MonoGame.Tools.Pipeline
                 if (item != null) {
                     if (item.Exists == !exist) {
                         item.Exists = exist;
-                        _view.ItemExistanceChanged (item);
+                        View.ItemExistanceChanged (item);
                     }
                 }
             }
@@ -302,7 +301,7 @@ namespace MonoGame.Tools.Pipeline
             ProjectDirty = false;
             _project = null;
             _actionStack.Clear();
-            _view.OutputClear();
+            View.OutputClear();
 
             History.Default.StartupProject = null;
             History.Default.Save();
@@ -317,7 +316,7 @@ namespace MonoGame.Tools.Pipeline
             if (saveAs || string.IsNullOrEmpty(_project.OriginalPath))
             {
                 string newFilePath = _project.OriginalPath;
-                if (!_view.AskSaveName(ref newFilePath, null))
+                if (!View.AskSaveName(ref newFilePath, null))
                     return false;
 
                 _project.OriginalPath = newFilePath;
@@ -387,7 +386,7 @@ namespace MonoGame.Tools.Pipeline
             if (OnBuildStarted != null)
                 OnBuildStarted();
 
-            _view.OutputClear();
+            View.OutputClear();
 
             _buildTask = Task.Factory.StartNew(() => DoBuild(commands));
             if (OnBuildFinished != null)
@@ -405,7 +404,7 @@ namespace MonoGame.Tools.Pipeline
             if (OnBuildStarted != null)
                 OnBuildStarted();
 
-            _view.OutputClear();
+            View.OutputClear();
 
             var commands = string.Format("/clean /intermediateDir:\"{0}\" /outputDir:\"{1}\"", _project.IntermediateDir, _project.OutputDir);
             if (LaunchDebugger)
@@ -433,13 +432,13 @@ namespace MonoGame.Tools.Pipeline
             try
             {
                 // Prepare the process.
-                _buildProcess = _view.CreateProcess(FindMGCB(), commands);
+                _buildProcess = View.CreateProcess(FindMGCB(), commands);
                 _buildProcess.StartInfo.WorkingDirectory = Path.GetDirectoryName(_project.OriginalPath);
                 _buildProcess.StartInfo.CreateNoWindow = true;
                 _buildProcess.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
                 _buildProcess.StartInfo.UseShellExecute = false;
                 _buildProcess.StartInfo.RedirectStandardOutput = true;
-                _buildProcess.OutputDataReceived += (sender, args) => _view.OutputAppend(args.Data);
+                _buildProcess.OutputDataReceived += (sender, args) => View.OutputAppend(args.Data);
 
                 // Fire off the process.
                 _buildProcess.Start();
@@ -450,12 +449,12 @@ namespace MonoGame.Tools.Pipeline
             {
                 // If we got a message assume it has everything the user needs to know.
                 if (!string.IsNullOrEmpty(ex.Message))
-                    _view.OutputAppend("Build failed:  " + ex.Message);
+                    View.OutputAppend("Build failed:  " + ex.Message);
                 else
                 {
                     // Else we need to get verbose.
-                    _view.OutputAppend("Build failed:" + Environment.NewLine);
-                    _view.OutputAppend(ex.ToString());
+                    View.OutputAppend("Build failed:" + Environment.NewLine);
+                    View.OutputAppend(ex.ToString());
                 }
             }
 
@@ -476,7 +475,7 @@ namespace MonoGame.Tools.Pipeline
                     return;
 
                 _buildProcess.Kill();
-                _view.OutputAppend("Build terminated!" + Environment.NewLine);
+                View.OutputAppend("Build terminated!" + Environment.NewLine);
             }
         }
 
@@ -494,7 +493,7 @@ namespace MonoGame.Tools.Pipeline
                 return true;
 
             // Ask the user if they want to save or cancel.
-            var result = _view.AskSaveOrCancel();
+            var result = View.AskSaveOrCancel();
 
             // Did we cancel the exit?
             if (result == AskResult.Cancel)
@@ -509,19 +508,19 @@ namespace MonoGame.Tools.Pipeline
 
         private void UpdateTree()
         {
-            _view.BeginTreeUpdate();
+            View.BeginTreeUpdate();
 
             if (_project == null || string.IsNullOrEmpty(_project.OriginalPath))
-                _view.SetTreeRoot(null);
+                View.SetTreeRoot(null);
             else
             {
-                _view.SetTreeRoot(_project);
+                View.SetTreeRoot(_project);
 
                 foreach (var item in _project.ContentItems)
-                    _view.AddTreeItem(item);
+                    View.AddTreeItem(item);
             }            
 
-            _view.EndTreeUpdate();
+            View.EndTreeUpdate();
         }
 
         public bool Exit()
@@ -529,7 +528,7 @@ namespace MonoGame.Tools.Pipeline
             // Can't exit if we're building!
             if (ProjectBuilding)
             {
-                _view.ShowMessage("You cannot exit while the project is building!");
+                View.ShowMessage("You cannot exit while the project is building!");
                 return false;
             }
 
@@ -545,7 +544,7 @@ namespace MonoGame.Tools.Pipeline
                 initialDirectory = Path.Combine(_project.Location, initialDirectory);
 
             List<string> files;
-            if (!_view.ChooseContentFile(initialDirectory, out files))
+            if (!View.ChooseContentFile(initialDirectory, out files))
                 return;
 
             var action = new IncludeAction(this, files);
@@ -621,7 +620,7 @@ namespace MonoGame.Tools.Pipeline
             {
                 i.Observer = this;
                 i.ResolveTypes();
-                _view.UpdateProperties(i);
+                View.UpdateProperties(i);
             }
 
             LoadTemplates(_project.Location);
@@ -654,7 +653,7 @@ namespace MonoGame.Tools.Pipeline
                 var fpath = Path.GetDirectoryName(f);
                 item.TemplateFile = Path.GetFullPath(Path.Combine(fpath, item.TemplateFile));
 
-                _view.OnTemplateDefined(item);
+                View.OnTemplateDefined(item);
 
                 _templateItems.Add(item);
             }

--- a/Tools/Pipeline/Windows/MainView.cs
+++ b/Tools/Pipeline/Windows/MainView.cs
@@ -80,7 +80,6 @@ namespace MonoGame.Tools.Pipeline
         public void Attach(IController controller)
         {
             _controller = controller;
-            _controller.View = this;
 
             var updateMenus = new Action(UpdateMenus);
             var invokeUpdateMenus = new Action(() => Invoke(updateMenus));


### PR DESCRIPTION
Sorry if this is a duplicate pull request... I didn't see another like it. When opening a broken MGCB file in pipeline.exe I am getting:

    System.NullReferenceException: Object reference not set to an instance of an object
      at MonoGame.Tools.Pipeline.PipelineController+<OpenProject>c__AnonStorey0.<>m__0 (System.String msg, System.Object[] args) [0x00027] in /home/emarcotte/src/MonoGame/Tools/Pipeline/Common/PipelineController.cs:218 
      at MGCB.MGBuildParser.ShowError (System.String message, System.Object[] args) [0x00020] in /home/emarcotte/src/MonoGame/Tools/MGCB/CommandLineParser.cs:480 
      at MGCB.MGBuildParser.ParseArgument (System.String arg) [0x0008b] in /home/emarcotte/src/MonoGame/Tools/MGCB/CommandLineParser.cs:336 
      at MGCB.MGBuildParser.Parse (IEnumerable`1 args) [0x00027] in /home/emarcotte/src/MonoGame/Tools/MGCB/CommandLineParser.cs:190 
      at MonoGame.Tools.Pipeline.PipelineProjectParser.OpenProject (System.String projectFilePath, MGCB.ErrorCallback errorCallback) [0x00053] in /home/emarcotte/src/MonoGame/Tools/Pipeline/Common/PipelineProjectParser.cs:238 
      at MonoGame.Tools.Pipeline.PipelineController.OpenProject (System.String projectFilePath) [0x0006a] in /home/emarcotte/src/MonoGame/Tools/Pipeline/Common/PipelineController.cs:219 
      at MonoGame.Tools.Pipeline.MainWindow.OnShowEvent () [0x00063] in /home/emarcotte/src/MonoGame/Tools/Pipeline/Gtk/MainWindow.cs:115 
      at MonoGame.Tools.Pipeline.Program.Main (System.String[] args) [0x00045] in /home/emarcotte/src/MonoGame/Tools/Pipeline/Program.cs:53 

It seems like the `View` property isn't being set on the `PipelineController` but is required by some other code (I didn't chase down this thread very far). The _view is required by the constructor, and seems to work properly when I switch to using it. I can try to dig down further into removing `View` if it isn't needed.

Here's a sample .mgcb file that caused the error:

    /outputDir:bin
    /intermediateDir:obj
    /platform:Linux
    /config:AnyCPU
    /profile:Reach
    /compress:False
    /incremental

The /incremental is invalid and it crashes trying to read it. This happens both at startup (opening file from history) and just doing file -> open. After this change the error message is displayed in the middle.