### PR TITLE
Fixed a number of outstanding issues with the VS 2013 project templates

### DIFF
--- a/ProjectTemplates/VisualStudio2013/WindowsPhone/MonoGameWindowsPhone.vstemplate
+++ b/ProjectTemplates/VisualStudio2013/WindowsPhone/MonoGameWindowsPhone.vstemplate
@@ -45,7 +45,7 @@
     </Project>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Microsoft.VisualStudio.SmartDevice.ProjectSystem.Base, Version=11.0.0.0, Culture=Neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <Assembly>Microsoft.VisualStudio.SmartDevice.ProjectSystem.Base, Version=12.0.0.0, Culture=Neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
     <FullClassName>Microsoft.VisualStudio.SmartDevice.ProjectSystem.Wizards.ProjectTemplateWizard</FullClassName>
   </WizardExtension>
 </VSTemplate>

--- a/ProjectTemplates/VisualStudio2013/WindowsPhone8.1/Package.appxmanifest
+++ b/ProjectTemplates/VisualStudio2013/WindowsPhone8.1/Package.appxmanifest
@@ -24,13 +24,13 @@
 
   <Applications>
     <Application Id="App"
-        Executable="$safeprojectname$.exe"
+        Executable="$targetnametoken$.exe"
         EntryPoint="$safeprojectname$.App">
         <m3:VisualElements
-            DisplayName="$projectname$"
+            DisplayName="$safeprojectname$"
             Square150x150Logo="Assets\Logo.png"
             Square44x44Logo="Assets\SmallLogo.png"
-            Description="$projectname$"
+            Description="$safeprojectname$"
             ForegroundText="light"
             BackgroundColor="transparent">
             <m3:DefaultTile Wide310x150Logo="Assets\WideLogo.png" Square71x71Logo="Assets\Square71x71Logo.png"/>

--- a/ProjectTemplates/VisualStudio2013/WindowsUniversal/MonoGameWindowsUniversal.vstemplate
+++ b/ProjectTemplates/VisualStudio2013/WindowsUniversal/MonoGameWindowsUniversal.vstemplate
@@ -19,14 +19,14 @@
 	</TemplateData>
  	<TemplateContent>
  		<ProjectCollection>
-			<SolutionFolder Name="$safeprojectname$">
-				<ProjectTemplateLink ProjectName="$safeprojectname$.Shared" CopyParameters="true">
+			<SolutionFolder Name="$projectname$">
+				<ProjectTemplateLink ProjectName="$projectname$.Shared" CopyParameters="true">
 					Shared\Shared.vstemplate
 				</ProjectTemplateLink>
-				<ProjectTemplateLink ProjectName="$safeprojectname$.Windows" CopyParameters="true">
+				<ProjectTemplateLink ProjectName="$projectname$.Windows" CopyParameters="true">
 					Windows\Windows.vstemplate
 				</ProjectTemplateLink>
-				<ProjectTemplateLink ProjectName="$safeprojectname$.WindowsPhone" CopyParameters="true">
+				<ProjectTemplateLink ProjectName="$projectname$.WindowsPhone" CopyParameters="true">
 					WindowsPhone\WindowsPhone.vstemplate
 				</ProjectTemplateLink>
 			</SolutionFolder>

--- a/ProjectTemplates/VisualStudio2013/WindowsUniversal/Shared/Content/Content.mgcb
+++ b/ProjectTemplates/VisualStudio2013/WindowsUniversal/Shared/Content/Content.mgcb
@@ -1,0 +1,15 @@
+
+#----------------------------- Global Properties ----------------------------#
+
+/outputDir:bin/WindowsPhone8
+/intermediateDir:obj/WindowsPhone8
+/platform:WindowsPhone8
+/config:
+/profile:Reach
+/compress:False
+
+#-------------------------------- References --------------------------------#
+
+
+#---------------------------------- Content ---------------------------------#
+

--- a/ProjectTemplates/VisualStudio2013/WindowsUniversal/Shared/Shared.vstemplate
+++ b/ProjectTemplates/VisualStudio2013/WindowsUniversal/Shared/Shared.vstemplate
@@ -18,6 +18,9 @@
 			<ProjectItem ReplaceParameters="true" TargetFileName="GamePage.xaml">GamePage.xaml</ProjectItem>
 			<ProjectItem ReplaceParameters="true" TargetFileName="GamePage.xaml.cs">GamePage.xaml.cs</ProjectItem>
 			<ProjectItem ReplaceParameters="true" TargetFileName="Game1.cs">Game1.cs</ProjectItem>
-		</Project>
+			<Folder Name="Content" TargetFolderName="Content">
+				<ProjectItem ReplaceParameters="true" TargetFileName="Content.mgcb">Content.mgcb</ProjectItem>
+			</Folder>
+	  </Project>
 	</TemplateContent>
 </VSTemplate>

--- a/ProjectTemplates/VisualStudio2013/WindowsUniversal/Windows/Package-managed.appxmanifest
+++ b/ProjectTemplates/VisualStudio2013/WindowsUniversal/Windows/Package-managed.appxmanifest
@@ -22,10 +22,10 @@
 
   <Applications>
     <Application Id="App"
-        Executable="$ext_safeprojectname$.exe"
-        EntryPoint="$ext_safeprojectname$.App">
+        Executable="$targetnametoken$.exe"
+        EntryPoint="$safeprojectname$.App">
         <m2:VisualElements
-            DisplayName="$ext_safeprojectname$"
+            DisplayName="$safeprojectname$"
             Square150x150Logo="Assets\Logo.png"
             Square30x30Logo="Assets\SmallLogo.png"
             Description="$ext_safeprojectname$"

--- a/ProjectTemplates/VisualStudio2013/WindowsUniversal/Windows/Windows.Application.Windows.csproj
+++ b/ProjectTemplates/VisualStudio2013/WindowsUniversal/Windows/Windows.Application.Windows.csproj
@@ -18,6 +18,8 @@
     $if$($includeKeyFile$==true)
     <PackageCertificateKeyFile>$ext_projectname$.Windows_TemporaryKey.pfx</PackageCertificateKeyFile>
     $endif$
+    <MonoGamePlatform>WindowsStoreApp</MonoGamePlatform>
+    <MonoGameContentBuilderExe></MonoGameContentBuilderExe>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -125,6 +127,11 @@
     <Content Include="Assets\StoreLogo.scale-100.png" />
   </ItemGroup>
   <ItemGroup>
+    <MonoGameContentReference Include="..\$ext_safeprojectname$.Shared\Content\Content.mgcb">
+      <Link>Content\Content.mgcb</Link>
+    </MonoGameContentReference>
+  </ItemGroup>  
+  <ItemGroup>
     <Reference Include="MonoGame.Framework">
        <HintPath>$(MSBuildProgramFiles32)\MonoGame\v3.0\Assemblies\Windows8\MonoGame.Framework.dll</HintPath>
     </Reference>
@@ -134,6 +141,7 @@
   </PropertyGroup>
   <Import Project="..\$ext_projectname$.Shared\Shared.Application.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\MonoGame\v3.0\MonoGame.Content.Builder.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/ProjectTemplates/VisualStudio2013/WindowsUniversal/Windows/Windows.Application.Windows.csproj
+++ b/ProjectTemplates/VisualStudio2013/WindowsUniversal/Windows/Windows.Application.Windows.csproj
@@ -8,7 +8,7 @@
     <OutputType>AppContainerExe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>$ext_safeprojectname$</RootNamespace>
-    <AssemblyName>$ext_projectname$.Windows</AssemblyName>
+    <AssemblyName>$ext_safeprojectname$.Windows</AssemblyName>
     <DefaultLanguage>$currentuiculturename$</DefaultLanguage>
     <TargetPlatformVersion>8.1</TargetPlatformVersion>
     <MinimumVisualStudioVersion>12</MinimumVisualStudioVersion>
@@ -16,7 +16,7 @@
     <SynthesizeLinkMetadata>true</SynthesizeLinkMetadata>
     <ProjectTypeGuids>{BC8A1FFA-BEE3-4634-8014-F334798102B3};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     $if$($includeKeyFile$==true)
-    <PackageCertificateKeyFile>$ext_projectname$.Windows_TemporaryKey.pfx</PackageCertificateKeyFile>
+    <PackageCertificateKeyFile>$ext_safeprojectname$.Windows_TemporaryKey.pfx</PackageCertificateKeyFile>
     $endif$
     <MonoGamePlatform>WindowsStoreApp</MonoGamePlatform>
     <MonoGameContentBuilderExe></MonoGameContentBuilderExe>
@@ -117,7 +117,7 @@
       <SubType>Designer</SubType>
     </AppxManifest>
 	$if$($includeKeyFile$==true)
-    <None Include="$ext_projectname$.Windows_TemporaryKey.pfx" />
+    <None Include="$ext_safeprojectname$.Windows_TemporaryKey.pfx" />
     $endif$
   </ItemGroup>
   <ItemGroup>
@@ -127,7 +127,7 @@
     <Content Include="Assets\StoreLogo.scale-100.png" />
   </ItemGroup>
   <ItemGroup>
-    <MonoGameContentReference Include="..\$ext_safeprojectname$.Shared\Content\Content.mgcb">
+    <MonoGameContentReference Include="..\$ext_projectname$.Shared\Content\Content.mgcb">
       <Link>Content\Content.mgcb</Link>
     </MonoGameContentReference>
   </ItemGroup>  

--- a/ProjectTemplates/VisualStudio2013/WindowsUniversal/Windows/Windows.vstemplate
+++ b/ProjectTemplates/VisualStudio2013/WindowsUniversal/Windows/Windows.vstemplate
@@ -22,7 +22,7 @@
 				<ProjectItem ReplaceParameters="true" TargetFileName="AssemblyInfo.cs">Windows.AssemblyInfo.cs</ProjectItem>
 			</Folder>
 			<ProjectItem ReplaceParameters="true" TargetFileName="Package.appxmanifest">Package-managed.appxmanifest</ProjectItem>
-			<ProjectItem ReplaceParameters="false" TargetFileName="$ext_projectname$.Windows_TemporaryKey.pfx" BlendDoNotCreate="true">Windows.TemporaryKey.pfx</ProjectItem>
+			<ProjectItem ReplaceParameters="false" TargetFileName="$ext_safeprojectname$.Windows_TemporaryKey.pfx" BlendDoNotCreate="true">Windows.TemporaryKey.pfx</ProjectItem>
 		</Project>
 	</TemplateContent>
 	<WizardExtension>

--- a/ProjectTemplates/VisualStudio2013/WindowsUniversal/WindowsPhone/Package-PhoneAppx.appxmanifest
+++ b/ProjectTemplates/VisualStudio2013/WindowsUniversal/WindowsPhone/Package-PhoneAppx.appxmanifest
@@ -24,13 +24,13 @@
 
   <Applications>
     <Application Id="App"
-        Executable="$ext_safeprojectname$.exe"
-        EntryPoint="$ext_safeprojectname$.App">
+        Executable="$targetnametoken$.exe"
+        EntryPoint="$safeprojectname$.App">
         <m3:VisualElements
-            DisplayName="$ext_safeprojectname$"
+            DisplayName="$safeprojectname$"
             Square150x150Logo="Assets\Logo.png"
             Square44x44Logo="Assets\SmallLogo.png"
-            Description="$ext_safeprojectname$"
+            Description="$safeprojectname$"
             ForegroundText="light"
             BackgroundColor="transparent">
             <m3:DefaultTile Wide310x150Logo="Assets\WideLogo.png" Square71x71Logo="Assets\Square71x71Logo.png"/>

--- a/ProjectTemplates/VisualStudio2013/WindowsUniversal/WindowsPhone/WindowsPhone.Application.WindowsPhone.csproj
+++ b/ProjectTemplates/VisualStudio2013/WindowsUniversal/WindowsPhone/WindowsPhone.Application.WindowsPhone.csproj
@@ -8,7 +8,7 @@
     <OutputType>AppContainerExe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>$ext_safeprojectname$</RootNamespace>
-    <AssemblyName>$ext_projectname$.WindowsPhone</AssemblyName>
+    <AssemblyName>$ext_safeprojectname$.WindowsPhone</AssemblyName>
     <DefaultLanguage>$currentuiculturename$</DefaultLanguage>
     <TargetPlatformVersion>8.1</TargetPlatformVersion>
     <MinimumVisualStudioVersion>12</MinimumVisualStudioVersion>
@@ -101,7 +101,7 @@
     <Content Include="Assets\WideLogo.scale-240.png" />
   </ItemGroup>
   <ItemGroup>
-    <MonoGameContentReference Include="..\$ext_safeprojectname$.Shared\Content\Content.mgcb">
+    <MonoGameContentReference Include="..\$ext_projectname$.Shared\Content\Content.mgcb">
       <Link>Content\Content.mgcb</Link>
     </MonoGameContentReference>
   </ItemGroup>  

--- a/ProjectTemplates/VisualStudio2013/WindowsUniversal/WindowsPhone/WindowsPhone.Application.WindowsPhone.csproj
+++ b/ProjectTemplates/VisualStudio2013/WindowsUniversal/WindowsPhone/WindowsPhone.Application.WindowsPhone.csproj
@@ -15,6 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{76F1466A-8B6D-4E39-A767-685A06062A39};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SynthesizeLinkMetadata>true</SynthesizeLinkMetadata>
+    <MonoGamePlatform>WindowsPhone8</MonoGamePlatform>
+    <MonoGameContentBuilderExe></MonoGameContentBuilderExe>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -98,6 +100,11 @@
     <Content Include="Assets\StoreLogo.scale-240.png" />
     <Content Include="Assets\WideLogo.scale-240.png" />
   </ItemGroup>
+  <ItemGroup>
+    <MonoGameContentReference Include="..\$ext_safeprojectname$.Shared\Content\Content.mgcb">
+      <Link>Content\Content.mgcb</Link>
+    </MonoGameContentReference>
+  </ItemGroup>  
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '12.0' ">
     <VisualStudioVersion>12.0</VisualStudioVersion>
   </PropertyGroup>
@@ -111,6 +118,7 @@
   </ItemGroup>
   <Import Project="..\$ext_projectname$.Shared\Shared.Application.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\MonoGame\v3.0\MonoGame.Content.Builder.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
* The Windows Phone project would not create in vs2013 (fix suggested by BrianPeek - https://github.com/mono/MonoGame/issues/3363#issuecomment-69652760)
* Fixed the Universal project definitions to use Executable="$targetnametoken$.exe" and $safeprojectname$ everywhere else, also suggested by Brian
* Added the c builder import, MonoGamePlatform and  MonoGameContentBuilderExe tags to the individual Universal projects (they were missing, meaning Content projects couldn't be added at all)
* Added Content in to the Shared project in the universal build and added linked references in the platform projects.  Tested locally and it works.

Resolves issues identified in #3363