### PR TITLE
Multi Game/GraphicsDevice within single process feature

### DIFF
--- a/Build/Projects/2MGFX.definition
+++ b/Build/Projects/2MGFX.definition
@@ -55,6 +55,9 @@
     <Compile Include="..\..\MonoGame.Framework\ContainmentType.cs">
       <Link>MonoGame.Framework\ContainmentType.cs</Link>
     </Compile>
+    <Compile Include="..\..\MonoGame.Framework\Graphics\GraphicsDeviceContext.cs">
+      <Link>MonoGame.Framework\GraphicsDeviceContext.cs</Link>
+    </Compile>
     <Compile Include="..\..\MonoGame.Framework\Graphics\ColorWriteChannels.cs">
       <Link>MonoGame.Framework\ColorWriteChannels.cs</Link>
     </Compile>

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -449,6 +449,7 @@
     <Compile Include="Graphics\GraphicsAdapter.cs" />
     <Compile Include="Graphics\GraphicsCapabilities.cs" />
     <Compile Include="Graphics\GraphicsDevice.cs" />
+    <Compile Include="Graphics\GraphicsDeviceContext.cs" />
     <Compile Include="Graphics\GraphicsDevice.DirectX.cs">
       <Services>DirectXGraphics</Services>
     </Compile>

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -119,12 +119,6 @@ namespace Microsoft.Xna.Framework
 
                     if (_graphicsDeviceManager != null)
                     {
-                        Effect.FlushCache();
-                        BlendState.ResetStates();
-                        DepthStencilState.ResetStates();
-                        RasterizerState.ResetStates();
-                        SamplerState.ResetStates();
-
                         (_graphicsDeviceManager as GraphicsDeviceManager).Dispose();
                         _graphicsDeviceManager = null;
                     }

--- a/MonoGame.Framework/Graphics/GraphicsDeviceContext.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDeviceContext.cs
@@ -1,0 +1,386 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using Microsoft.Xna.Framework.Utilities;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    internal class GraphicsDeviceContextScope
+        : IDisposable
+    {
+        internal GraphicsDeviceContextScope(GraphicsDeviceContext context)
+        {
+            Debug.Assert(GraphicsDeviceContext.Current == null);
+            GraphicsDeviceContext.Current = context;
+        }
+
+        public void Dispose()
+        {
+            Debug.Assert(GraphicsDeviceContext.Current != null);
+            GraphicsDeviceContext.Current = null;
+        }
+    }
+
+    /// <summary>
+    /// This class tightly coupled and manages various Default GraphicsResource for support multiple <see cref="GraphicsDevice">GraphicsDevices</see>
+    /// To provide necessary backward-compatibility with XNA or past versions of MonoGame framework.
+    /// </summary>
+    internal class GraphicsDeviceContext
+    {
+        [ThreadStatic] private static GraphicsDeviceContext _currentDeviceContext;
+
+        private GraphicsDevice _graphicsDevice;
+
+        public GraphicsDeviceContext(GraphicsDevice graphicsDevice)
+        {
+            _graphicsDevice = graphicsDevice;
+
+            SetupBlendStateFactory();
+            SetupDepthStencilStateFactory();
+            SetupRasterizerStateFactory();
+            SetupSamplerStateFactory();
+        }
+
+        public static GraphicsDeviceContext Current
+        {
+            get { return _currentDeviceContext; }
+            internal set { _currentDeviceContext = value; }
+        }
+
+        public GraphicsDevice GraphicsDevice
+        {
+            get { return _graphicsDevice; }
+        }
+
+        public void Reset()
+        {
+            ResetEffectCache();
+            ResetBlendStates();
+            ResetDepthStencilStates();
+            ResetRasterizerStates();
+            ResetSamplerStates();
+        }
+
+        #region BlendState
+
+        public ObjectFactoryWithReset<BlendState> Additive
+        {
+            get { return _additive; }
+        }
+
+        public ObjectFactoryWithReset<BlendState> AlphaBlend
+        {
+            get { return _alphaBlend; }
+        }
+
+        public ObjectFactoryWithReset<BlendState> NonPremultiplied
+        {
+            get { return _nonPremultiplied; }
+        }
+
+        public ObjectFactoryWithReset<BlendState> Opaque
+        {
+            get { return _opaque; }
+        }
+
+        private ObjectFactoryWithReset<BlendState> _additive;
+        private ObjectFactoryWithReset<BlendState> _alphaBlend;
+        private ObjectFactoryWithReset<BlendState> _nonPremultiplied;
+        private ObjectFactoryWithReset<BlendState> _opaque;
+
+        private void SetupBlendStateFactory()
+        {
+            _additive = new Utilities.ObjectFactoryWithReset<BlendState>(() => new BlendState
+            {
+                Name = "BlendState.Additive",
+                ColorSourceBlend = Blend.SourceAlpha,
+                AlphaSourceBlend = Blend.SourceAlpha,
+                ColorDestinationBlend = Blend.One,
+                AlphaDestinationBlend = Blend.One
+            });
+
+            _alphaBlend = new Utilities.ObjectFactoryWithReset<BlendState>(() => new BlendState()
+            {
+                Name = "BlendState.AlphaBlend",
+                ColorSourceBlend = Blend.One,
+                AlphaSourceBlend = Blend.One,
+                ColorDestinationBlend = Blend.InverseSourceAlpha,
+                AlphaDestinationBlend = Blend.InverseSourceAlpha
+            });
+
+            _nonPremultiplied = new Utilities.ObjectFactoryWithReset<BlendState>(() => new BlendState()
+            {
+                Name = "BlendState.NonPremultiplied",
+                ColorSourceBlend = Blend.SourceAlpha,
+                AlphaSourceBlend = Blend.SourceAlpha,
+                ColorDestinationBlend = Blend.InverseSourceAlpha,
+                AlphaDestinationBlend = Blend.InverseSourceAlpha
+            });
+
+            _opaque = new Utilities.ObjectFactoryWithReset<BlendState>(() => new BlendState()
+            {
+                Name = "BlendState.Opaque",
+                ColorSourceBlend = Blend.One,
+                AlphaSourceBlend = Blend.One,
+                ColorDestinationBlend = Blend.Zero,
+                AlphaDestinationBlend = Blend.Zero
+            });
+        }
+
+        private void ResetBlendStates()
+        {
+            _additive.Reset();
+            _alphaBlend.Reset();
+            _nonPremultiplied.Reset();
+            _opaque.Reset();
+        }
+
+        #endregion
+
+        #region DepthStencilState
+
+        public ObjectFactoryWithReset<DepthStencilState> Default
+        {
+            get { return _default; }
+        }
+
+        public ObjectFactoryWithReset<DepthStencilState> DepthRead
+        {
+            get { return _depthRead; }
+        }
+
+        public ObjectFactoryWithReset<DepthStencilState> None
+        {
+            get { return _none; }
+        }
+
+        private ObjectFactoryWithReset<DepthStencilState> _default;
+        private ObjectFactoryWithReset<DepthStencilState> _depthRead;
+        private ObjectFactoryWithReset<DepthStencilState> _none;
+
+        private void SetupDepthStencilStateFactory()
+        {
+            _default = new ObjectFactoryWithReset<DepthStencilState>(() => new DepthStencilState
+            {
+                Name = "DepthStencilState.Default",
+                DepthBufferEnable = true,
+                DepthBufferWriteEnable = true
+            });
+
+            _depthRead = new ObjectFactoryWithReset<DepthStencilState>(() => new DepthStencilState
+            {
+                Name = "DepthStencilState.DepthRead",
+                DepthBufferEnable = true,
+                DepthBufferWriteEnable = false
+            });
+
+            _none = new ObjectFactoryWithReset<DepthStencilState>(() => new DepthStencilState
+            {
+                Name = "DepthStencilState.None",
+                DepthBufferEnable = false,
+                DepthBufferWriteEnable = false
+            });
+        }
+
+        private void ResetDepthStencilStates()
+        {
+            _default.Reset();
+            _depthRead.Reset();
+            _none.Reset();
+        }
+
+        #endregion
+
+        #region RasterizerState
+
+        public ObjectFactoryWithReset<RasterizerState> CullClockwise
+        {
+            get { return _cullClockwise; }
+        }
+
+        public ObjectFactoryWithReset<RasterizerState> CullCounterClockwise
+        {
+            get { return _cullCounterClockwise; }
+        }
+
+        public ObjectFactoryWithReset<RasterizerState> CullNone
+        {
+            get { return _cullNone; }
+        }
+
+        private ObjectFactoryWithReset<RasterizerState> _cullClockwise;
+        private ObjectFactoryWithReset<RasterizerState> _cullCounterClockwise;
+        private ObjectFactoryWithReset<RasterizerState> _cullNone;
+
+        private void SetupRasterizerStateFactory()
+        {
+            _cullClockwise = new ObjectFactoryWithReset<RasterizerState>(() => new RasterizerState
+            {
+                Name = "RasterizerState.CullClockwise",
+                CullMode = CullMode.CullClockwiseFace
+            });
+
+            _cullCounterClockwise = new ObjectFactoryWithReset<RasterizerState>(() => new RasterizerState
+            {
+                Name = "RasterizerState.CullCounterClockwise",
+                CullMode = CullMode.CullCounterClockwiseFace
+            });
+
+            _cullNone = new ObjectFactoryWithReset<RasterizerState>(() => new RasterizerState
+            {
+                Name = "RasterizerState.CullNone",
+                CullMode = CullMode.None
+            });
+        }
+
+        private void ResetRasterizerStates()
+        {
+            _cullClockwise.Reset();
+            _cullCounterClockwise.Reset();
+            _cullNone.Reset();
+        }
+
+        #endregion
+
+        #region SampleState
+
+        public ObjectFactoryWithReset<SamplerState> AnisotropicClamp
+        {
+            get { return _anisotropicClamp; }
+        }
+
+        public ObjectFactoryWithReset<SamplerState> AnisotropicWrap
+        {
+            get { return _anisotropicWrap; }
+        }
+
+        public ObjectFactoryWithReset<SamplerState> LinearClamp
+        {
+            get { return _linearClamp; }
+        }
+
+        public ObjectFactoryWithReset<SamplerState> LinearWrap
+        {
+            get { return _linearWrap; }
+        }
+
+        public ObjectFactoryWithReset<SamplerState> PointClamp
+        {
+            get { return _pointClamp; }
+        }
+
+        public ObjectFactoryWithReset<SamplerState> PointWrap
+        {
+            get { return _pointWrap; }
+        }
+
+        private ObjectFactoryWithReset<SamplerState> _anisotropicClamp;
+        private ObjectFactoryWithReset<SamplerState> _anisotropicWrap;
+        private ObjectFactoryWithReset<SamplerState> _linearClamp;
+        private ObjectFactoryWithReset<SamplerState> _linearWrap;
+        private ObjectFactoryWithReset<SamplerState> _pointClamp;
+        private ObjectFactoryWithReset<SamplerState> _pointWrap;
+
+        private void SetupSamplerStateFactory()
+        {
+            _anisotropicClamp = new ObjectFactoryWithReset<SamplerState>(() => new SamplerState
+            {
+                Name = "SamplerState.AnisotropicClamp",
+                Filter = TextureFilter.Anisotropic,
+                AddressU = TextureAddressMode.Clamp,
+                AddressV = TextureAddressMode.Clamp,
+                AddressW = TextureAddressMode.Clamp,
+            });
+
+            _anisotropicWrap = new ObjectFactoryWithReset<SamplerState>(() => new SamplerState
+            {
+                Name = "SamplerState.AnisotropicWrap",
+                Filter = TextureFilter.Anisotropic,
+                AddressU = TextureAddressMode.Wrap,
+                AddressV = TextureAddressMode.Wrap,
+                AddressW = TextureAddressMode.Wrap,
+            });
+
+            _linearClamp = new ObjectFactoryWithReset<SamplerState>(() => new SamplerState
+            {
+                Name = "SamplerState.LinearClamp",
+                Filter = TextureFilter.Linear,
+                AddressU = TextureAddressMode.Clamp,
+                AddressV = TextureAddressMode.Clamp,
+                AddressW = TextureAddressMode.Clamp,
+            });
+
+            _linearWrap = new ObjectFactoryWithReset<SamplerState>(() => new SamplerState
+            {
+                Name = "SamplerState.LinearWrap",
+                Filter = TextureFilter.Linear,
+                AddressU = TextureAddressMode.Wrap,
+                AddressV = TextureAddressMode.Wrap,
+                AddressW = TextureAddressMode.Wrap,
+            });
+
+            _pointClamp = new ObjectFactoryWithReset<SamplerState>(() => new SamplerState
+            {
+                Name = "SamplerState.PointClamp",
+                Filter = TextureFilter.Point,
+                AddressU = TextureAddressMode.Clamp,
+                AddressV = TextureAddressMode.Clamp,
+                AddressW = TextureAddressMode.Clamp,
+            });
+
+            _pointWrap = new ObjectFactoryWithReset<SamplerState>(() => new SamplerState
+            {
+                Name = "SamplerState.PointWrap",
+                Filter = TextureFilter.Point,
+                AddressU = TextureAddressMode.Wrap,
+                AddressV = TextureAddressMode.Wrap,
+                AddressW = TextureAddressMode.Wrap,
+            });
+        }
+
+        private void ResetSamplerStates()
+        {
+            _anisotropicClamp.Reset();
+            _anisotropicWrap.Reset();
+            _linearClamp.Reset();
+            _linearWrap.Reset();
+            _pointClamp.Reset();
+            _pointWrap.Reset();
+        }
+
+        #endregion
+
+        #region Effect Cache
+
+        /// <summary>
+        /// The cache of effects from unique byte streams.
+        /// </summary>
+        private readonly Dictionary<int, GraphicsResource> _effectCache = new Dictionary<int, GraphicsResource>();
+
+        public GraphicsResource GetOrAddEffect(int effectKey, Func<GraphicsResource> valueFactory)
+        {
+            GraphicsResource returnValue;
+            if (_effectCache.TryGetValue(effectKey, out returnValue) == false)
+            {
+                returnValue = valueFactory();
+                _effectCache.Add(effectKey, returnValue);
+            }
+
+            return returnValue;
+        }
+
+        internal void ResetEffectCache()
+        {
+            // Dispose all the cached effects.
+            foreach (var effect in _effectCache)
+                effect.Value.Dispose();
+
+            // Clear the cache.
+            _effectCache.Clear();
+        }
+
+        #endregion // Effect Cache
+    }
+}

--- a/MonoGame.Framework/Graphics/States/BlendState.cs
+++ b/MonoGame.Framework/Graphics/States/BlendState.cs
@@ -166,16 +166,46 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
-		private static readonly Utilities.ObjectFactoryWithReset<BlendState> _additive;
-        private static readonly Utilities.ObjectFactoryWithReset<BlendState> _alphaBlend;
-        private static readonly Utilities.ObjectFactoryWithReset<BlendState> _nonPremultiplied;
-        private static readonly Utilities.ObjectFactoryWithReset<BlendState> _opaque;
+        public static BlendState Additive
+        {
+            get
+            {
+                ThrowIfGraphicsDeviceContextNull();
+                DebugAssertGraphicsDeviceContext(GraphicsDeviceContext.Current.Additive);
+                return GraphicsDeviceContext.Current.Additive.Value;
+            }
+        }
 
-        public static BlendState Additive { get { return _additive.Value; } }
-        public static BlendState AlphaBlend { get { return _alphaBlend.Value; } }
-        public static BlendState NonPremultiplied { get { return _nonPremultiplied.Value; } }
-        public static BlendState Opaque { get { return _opaque.Value; } }
-        
+        public static BlendState AlphaBlend
+        {
+            get
+            {
+                ThrowIfGraphicsDeviceContextNull();
+                DebugAssertGraphicsDeviceContext(GraphicsDeviceContext.Current.AlphaBlend);
+                return GraphicsDeviceContext.Current.AlphaBlend.Value;
+            }
+        }
+
+        public static BlendState NonPremultiplied
+        {
+            get
+            {
+                ThrowIfGraphicsDeviceContextNull();
+                DebugAssertGraphicsDeviceContext(GraphicsDeviceContext.Current.NonPremultiplied);
+                return GraphicsDeviceContext.Current.NonPremultiplied.Value; 
+            }
+        }
+
+        public static BlendState Opaque
+        {
+            get
+            {
+                ThrowIfGraphicsDeviceContextNull();
+                DebugAssertGraphicsDeviceContext(GraphicsDeviceContext.Current.Opaque);
+                return GraphicsDeviceContext.Current.Opaque.Value; 
+            }
+        }
+
         public BlendState() 
         {
             _targetBlendState = new TargetBlendState[4];
@@ -187,53 +217,6 @@ namespace Microsoft.Xna.Framework.Graphics
 			_blendFactor = Color.White;
             _multiSampleMask = Int32.MaxValue;
             _independentBlendEnable = false;
-        }
-		
-		static BlendState() 
-        {
-            _additive = new Utilities.ObjectFactoryWithReset<BlendState>(() => new BlendState
-            {
-                Name = "BlendState.Additive",
-                ColorSourceBlend = Blend.SourceAlpha,
-                AlphaSourceBlend = Blend.SourceAlpha,
-                ColorDestinationBlend = Blend.One,
-                AlphaDestinationBlend = Blend.One
-            });
-			
-			_alphaBlend = new Utilities.ObjectFactoryWithReset<BlendState>(() => new BlendState()
-            {
-                Name = "BlendState.AlphaBlend",
-				ColorSourceBlend = Blend.One,
-				AlphaSourceBlend = Blend.One,
-				ColorDestinationBlend = Blend.InverseSourceAlpha,
-				AlphaDestinationBlend = Blend.InverseSourceAlpha
-			});
-			
-			_nonPremultiplied = new Utilities.ObjectFactoryWithReset<BlendState>(() => new BlendState() 
-            {
-                Name = "BlendState.NonPremultiplied",
-				ColorSourceBlend = Blend.SourceAlpha,
-				AlphaSourceBlend = Blend.SourceAlpha,
-				ColorDestinationBlend = Blend.InverseSourceAlpha,
-				AlphaDestinationBlend = Blend.InverseSourceAlpha
-			});
-			
-			_opaque = new Utilities.ObjectFactoryWithReset<BlendState>(() => new BlendState()
-            {
-                Name = "BlendState.Opaque",
-				ColorSourceBlend = Blend.One,
-				AlphaSourceBlend = Blend.One,			    
-				ColorDestinationBlend = Blend.Zero,
-				AlphaDestinationBlend = Blend.Zero
-			});
-		}
-
-        internal static void ResetStates()
-        {
-            _additive.Reset();
-            _alphaBlend.Reset();
-            _nonPremultiplied.Reset();
-            _opaque.Reset();
         }
 	}
 }

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.cs
@@ -48,44 +48,35 @@ namespace Microsoft.Xna.Framework.Graphics
 			ReferenceStencil = 0;
 		}
 
-        private static readonly Utilities.ObjectFactoryWithReset<DepthStencilState> _default;
-        private static readonly Utilities.ObjectFactoryWithReset<DepthStencilState> _depthRead;
-        private static readonly Utilities.ObjectFactoryWithReset<DepthStencilState> _none;
-
-        public static DepthStencilState Default { get { return _default.Value; } }
-        public static DepthStencilState DepthRead { get { return _depthRead.Value; } }
-        public static DepthStencilState None { get { return _none.Value; } }
-		
-		static DepthStencilState ()
-		{
-			_default = new Utilities.ObjectFactoryWithReset<DepthStencilState>(() => new DepthStencilState
-            {
-                Name = "DepthStencilState.Default",
-				DepthBufferEnable = true,
-				DepthBufferWriteEnable = true
-			});
-			
-			_depthRead = new Utilities.ObjectFactoryWithReset<DepthStencilState>(() => new DepthStencilState
-            {
-                Name = "DepthStencilState.DepthRead",
-                DepthBufferEnable = true,
-				DepthBufferWriteEnable = false
-			});
-			
-			_none = new Utilities.ObjectFactoryWithReset<DepthStencilState>(() => new DepthStencilState
-            {
-                Name = "DepthStencilState.None",
-                DepthBufferEnable = false,
-				DepthBufferWriteEnable = false
-			});
-		}
-
-        internal static void ResetStates()
+        public static DepthStencilState Default
         {
-            _default.Reset();
-            _depthRead.Reset();
-            _none.Reset();
+            get
+            {
+                ThrowIfGraphicsDeviceContextNull();
+                DebugAssertGraphicsDeviceContext(GraphicsDeviceContext.Current.Default);
+                return GraphicsDeviceContext.Current.Default.Value;
+            }
         }
+
+        public static DepthStencilState DepthRead
+        {
+            get
+            {
+                ThrowIfGraphicsDeviceContextNull();
+                DebugAssertGraphicsDeviceContext(GraphicsDeviceContext.Current.DepthRead);
+                return GraphicsDeviceContext.Current.DepthRead.Value;
+            }
+        }
+
+        public static DepthStencilState None
+		{
+            get
+            {
+                ThrowIfGraphicsDeviceContextNull();
+                DebugAssertGraphicsDeviceContext(GraphicsDeviceContext.Current.None);
+                return GraphicsDeviceContext.Current.None.Value;
+            }
+		}
 	}
 }
 

--- a/MonoGame.Framework/Graphics/States/RasterizerState.cs
+++ b/MonoGame.Framework/Graphics/States/RasterizerState.cs
@@ -16,14 +16,36 @@ namespace Microsoft.Xna.Framework.Graphics
         public bool ScissorTestEnable { get; set; }
         public float SlopeScaleDepthBias { get; set; }
 
-		private static readonly Utilities.ObjectFactoryWithReset<RasterizerState> _cullClockwise;
-        private static readonly Utilities.ObjectFactoryWithReset<RasterizerState> _cullCounterClockwise;
-        private static readonly Utilities.ObjectFactoryWithReset<RasterizerState> _cullNone;
+        public static RasterizerState CullClockwise
+        {
+            get
+            {
+                ThrowIfGraphicsDeviceContextNull();
+                DebugAssertGraphicsDeviceContext(GraphicsDeviceContext.Current.CullClockwise);
+                return GraphicsDeviceContext.Current.CullClockwise.Value;
+            }
+        }
 
-        public static RasterizerState CullClockwise { get { return _cullClockwise.Value; } }
-        public static RasterizerState CullCounterClockwise { get { return _cullCounterClockwise.Value; } }
-        public static RasterizerState CullNone { get { return _cullNone.Value; } }
-        
+        public static RasterizerState CullCounterClockwise
+        {
+            get
+            {
+                ThrowIfGraphicsDeviceContextNull();
+                DebugAssertGraphicsDeviceContext(GraphicsDeviceContext.Current.CullCounterClockwise);
+                return GraphicsDeviceContext.Current.CullCounterClockwise.Value;
+            }
+        }
+
+        public static RasterizerState CullNone
+        {
+            get
+            {
+                ThrowIfGraphicsDeviceContextNull();
+                DebugAssertGraphicsDeviceContext(GraphicsDeviceContext.Current.CullNone);
+                return GraphicsDeviceContext.Current.CullNone.Value;
+            }
+        }
+
         public RasterizerState()
 		{
 			CullMode = CullMode.CullCounterClockwiseFace;
@@ -34,32 +56,5 @@ namespace Microsoft.Xna.Framework.Graphics
 			SlopeScaleDepthBias = 0;
 		}
 
-		static RasterizerState ()
-		{
-			_cullClockwise = new Utilities.ObjectFactoryWithReset<RasterizerState>(() => new RasterizerState
-            {
-                Name = "RasterizerState.CullClockwise",
-				CullMode = CullMode.CullClockwiseFace
-			});
-
-			_cullCounterClockwise = new Utilities.ObjectFactoryWithReset<RasterizerState>(() => new RasterizerState
-            {
-                Name = "RasterizerState.CullCounterClockwise",
-				CullMode = CullMode.CullCounterClockwiseFace
-			});
-
-			_cullNone = new Utilities.ObjectFactoryWithReset<RasterizerState>(() => new RasterizerState
-            {
-                Name = "RasterizerState.CullNone",
-				CullMode = CullMode.None
-			});
-		}
-
-        internal static void ResetStates()
-        {
-            _cullClockwise.Reset();
-            _cullCounterClockwise.Reset();
-            _cullNone.Reset();
-        }
     }
 }

--- a/MonoGame.Framework/Graphics/States/SamplerState.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.cs
@@ -18,84 +18,73 @@ using GetPName = OpenTK.Graphics.ES20.All;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-  public partial class SamplerState : GraphicsResource
-  {
-        static SamplerState () 
+    public partial class SamplerState : GraphicsResource
+    {
+        public static SamplerState AnisotropicClamp
         {
-			_anisotropicClamp = new Utilities.ObjectFactoryWithReset<SamplerState>(() => new SamplerState
+            get
             {
-                Name = "SamplerState.AnisotropicClamp",
-				Filter = TextureFilter.Anisotropic,
-				AddressU = TextureAddressMode.Clamp,
-				AddressV = TextureAddressMode.Clamp,
-				AddressW = TextureAddressMode.Clamp,
-			});
-			
-			_anisotropicWrap = new Utilities.ObjectFactoryWithReset<SamplerState>(() => new SamplerState
-            {
-                Name = "SamplerState.AnisotropicWrap",
-				Filter = TextureFilter.Anisotropic,
-				AddressU = TextureAddressMode.Wrap,
-				AddressV = TextureAddressMode.Wrap,
-				AddressW = TextureAddressMode.Wrap,
-			});
-			
-			_linearClamp = new Utilities.ObjectFactoryWithReset<SamplerState>(() => new SamplerState
-            {
-                Name = "SamplerState.LinearClamp",
-				Filter = TextureFilter.Linear,
-				AddressU = TextureAddressMode.Clamp,
-				AddressV = TextureAddressMode.Clamp,
-				AddressW = TextureAddressMode.Clamp,
-			});
-			
-			_linearWrap = new Utilities.ObjectFactoryWithReset<SamplerState>(() => new SamplerState
-            {
-                Name = "SamplerState.LinearWrap",
-				Filter = TextureFilter.Linear,
-				AddressU = TextureAddressMode.Wrap,
-				AddressV = TextureAddressMode.Wrap,
-				AddressW = TextureAddressMode.Wrap,
-			});
-			
-			_pointClamp = new Utilities.ObjectFactoryWithReset<SamplerState>(() => new SamplerState
-            {
-                Name = "SamplerState.PointClamp",
-				Filter = TextureFilter.Point,
-				AddressU = TextureAddressMode.Clamp,
-				AddressV = TextureAddressMode.Clamp,
-				AddressW = TextureAddressMode.Clamp,
-			});
-			
-			_pointWrap = new Utilities.ObjectFactoryWithReset<SamplerState>(() => new SamplerState
-            {
-                Name = "SamplerState.PointWrap",
-				Filter = TextureFilter.Point,
-				AddressU = TextureAddressMode.Wrap,
-				AddressV = TextureAddressMode.Wrap,
-				AddressW = TextureAddressMode.Wrap,
-			});
+                ThrowIfGraphicsDeviceContextNull();
+                DebugAssertGraphicsDeviceContext(GraphicsDeviceContext.Current.AnisotropicClamp);
+                return GraphicsDeviceContext.Current.AnisotropicClamp.Value;
+            }
 		}
-		
-		private static readonly Utilities.ObjectFactoryWithReset<SamplerState> _anisotropicClamp;
-        private static readonly Utilities.ObjectFactoryWithReset<SamplerState> _anisotropicWrap;
-        private static readonly Utilities.ObjectFactoryWithReset<SamplerState> _linearClamp;
-        private static readonly Utilities.ObjectFactoryWithReset<SamplerState> _linearWrap;
-        private static readonly Utilities.ObjectFactoryWithReset<SamplerState> _pointClamp;
-        private static readonly Utilities.ObjectFactoryWithReset<SamplerState> _pointWrap;
 
-        public static SamplerState AnisotropicClamp { get { return _anisotropicClamp.Value; } }
-        public static SamplerState AnisotropicWrap { get { return _anisotropicWrap.Value; } }
-        public static SamplerState LinearClamp { get { return _linearClamp.Value; } }
-        public static SamplerState LinearWrap { get { return _linearWrap.Value; } }
-        public static SamplerState PointClamp { get { return _pointClamp.Value; } }
-        public static SamplerState PointWrap { get { return _pointWrap.Value; } }
-        
+        public static SamplerState AnisotropicWrap
+        {
+            get
+            {
+                ThrowIfGraphicsDeviceContextNull();
+                DebugAssertGraphicsDeviceContext(GraphicsDeviceContext.Current.AnisotropicWrap);
+                return GraphicsDeviceContext.Current.AnisotropicWrap.Value;
+            }
+        }
+
+        public static SamplerState LinearClamp
+        {
+            get
+            {
+                ThrowIfGraphicsDeviceContextNull();
+                DebugAssertGraphicsDeviceContext(GraphicsDeviceContext.Current.LinearClamp);
+                return GraphicsDeviceContext.Current.LinearClamp.Value;
+            }
+        }
+
+        public static SamplerState LinearWrap
+        {
+            get
+            {
+                ThrowIfGraphicsDeviceContextNull();
+                DebugAssertGraphicsDeviceContext(GraphicsDeviceContext.Current.LinearWrap);
+                return GraphicsDeviceContext.Current.LinearWrap.Value;
+            }
+        }
+
+        public static SamplerState PointClamp
+        {
+            get
+            {
+                ThrowIfGraphicsDeviceContextNull();
+                DebugAssertGraphicsDeviceContext(GraphicsDeviceContext.Current.PointClamp);
+                return GraphicsDeviceContext.Current.PointClamp.Value;
+            }
+        }
+
+        public static SamplerState PointWrap
+        {
+            get
+            {
+                ThrowIfGraphicsDeviceContextNull();
+                DebugAssertGraphicsDeviceContext(GraphicsDeviceContext.Current.PointWrap);
+                return GraphicsDeviceContext.Current.PointWrap.Value;
+            }
+        }
+
         public TextureAddressMode AddressU { get; set; }
 		public TextureAddressMode AddressV { get; set; }
 		public TextureAddressMode AddressW { get; set; }
 		public TextureFilter Filter { get; set; }
-		
+
 		public int MaxAnisotropy { get; set; }
 		public int MaxMipLevel { get; set; }
 		public float MipMapLevelOfDetailBias { get; set; }
@@ -109,16 +98,6 @@ namespace Microsoft.Xna.Framework.Graphics
             this.MaxAnisotropy = 4;
             this.MaxMipLevel = 0;
             this.MipMapLevelOfDetailBias = 0.0f;
-        }
-
-        internal static void ResetStates()
-        {
-            _anisotropicClamp.Reset();
-            _anisotropicWrap.Reset();
-            _linearClamp.Reset();
-            _linearWrap.Reset();
-            _pointClamp.Reset();
-            _pointWrap.Reset();
         }
     }
 }

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -134,7 +134,7 @@ namespace MonoGame.Framework
         
         public override void Exit()
         {
-            Application.Exit();
+            _window.Dispose();
         }
 
         public override bool BeforeUpdate(GameTime gameTime)


### PR DESCRIPTION
this commit resolves #1823

- FEATURE: GraphicsDeviceContext added for backward compatibility with XNA framework
(Squashed)
- REFACTOR: EffectCache moved from Effect to GraphicsDeviceContext
- REFACTOR: Moved ResetStates in GraphicsDevice to GraphicsDeviceContext
- REFACTOR: Default BlendState are moved to GraphicsDeviceContext
- TASK: Defensive code against usage of GraphicsResource.Current
- FIX: (Windows) Closing game window shouldn't close whole application
- TASK: Build definitions update for GraphicsDeviceContext
- WORKAROUND: Hacks to workaround usage of static member _allWindows in WinFormsGameWindow
- TASK: DebugAssertion for GraphicsDeviceContext added to GraphicsResource
- REFACTOR: Proper disposal of GraphicsResource