### PR TITLE
Application run loop workaround to support mono windows

### DIFF
--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -380,7 +380,7 @@ namespace MonoGame.Framework
                 OnIdle(this, null);
 
                 // Application.Run does this after processing idle handler
-                WaitMessage();
+                //WaitMessage();
             }
 
             // We need to remove the WM_QUIT message in the message 


### PR DESCRIPTION
This change will make MonoGame running on Mono-Windows, which will help deploying MonoGame based games without .Net framework.