### PR TITLE
Fixed Error building Audio on MacOS

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
+++ b/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         /// <param name="path">The full path to the executable.</param>
         private static void EnsureExecutable(string path)
         {
-#if LINUX || MONOMAC
+#if LINUX || MACOS
             if(path == "/bin/bash")
                 return;
 


### PR DESCRIPTION
The ffmpeg /ffprobe files are not being set as executable. This fixes it