### PR TITLE
LZ4 moved to more consistent place

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentWriter.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.IO;
-using Microsoft.Xna.Framework.Content.Pipeline.LZ4;
+using Microsoft.Xna.Framework.Content.Pipeline.Utilities.LZ4;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Framework.Content.Pipeline.Builder;
 using System.Collections.Generic;

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentWriter.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.IO;
-using LZ4n;
+using Microsoft.Xna.Framework.Content.Pipeline.LZ4;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Framework.Content.Pipeline.Builder;
 using System.Collections.Generic;

--- a/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe.cs
@@ -27,10 +27,10 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using System;
 
-namespace Microsoft.Xna.Framework.Content.Pipeline.LZ4
+namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities.LZ4
 {
 	/// <summary>Unsafe LZ4 codec.</summary>
-	public static partial class LZ4Codec
+	internal static partial class LZ4Codec
 	{
 		/// <summary>Copies block of memory.</summary>
 		/// <param name="src">The source.</param>

--- a/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe.cs
@@ -27,7 +27,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using System;
 
-namespace LZ4n
+namespace Microsoft.Xna.Framework.Content.Pipeline.LZ4
 {
 	/// <summary>Unsafe LZ4 codec.</summary>
 	public static partial class LZ4Codec

--- a/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe32.Dirty.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe32.Dirty.cs
@@ -66,7 +66,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // ReSharper disable TooWideLocalVariableScope
 // ReSharper disable JoinDeclarationAndInitializer
 
-namespace LZ4n
+namespace Microsoft.Xna.Framework.Content.Pipeline.LZ4
 {
 	public static partial class LZ4Codec
 	{

--- a/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe32.Dirty.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe32.Dirty.cs
@@ -66,9 +66,9 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // ReSharper disable TooWideLocalVariableScope
 // ReSharper disable JoinDeclarationAndInitializer
 
-namespace Microsoft.Xna.Framework.Content.Pipeline.LZ4
+namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities.LZ4
 {
-	public static partial class LZ4Codec
+	internal static partial class LZ4Codec
 	{
 		#region LZ4_compressCtx_32
 

--- a/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe32HC.Dirty.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe32HC.Dirty.cs
@@ -64,7 +64,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // ReSharper disable InconsistentNaming
 
-namespace LZ4n
+namespace Microsoft.Xna.Framework.Content.Pipeline.LZ4
 {
 	public static partial class LZ4Codec
 	{

--- a/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe32HC.Dirty.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe32HC.Dirty.cs
@@ -64,9 +64,9 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // ReSharper disable InconsistentNaming
 
-namespace Microsoft.Xna.Framework.Content.Pipeline.LZ4
+namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities.LZ4
 {
-	public static partial class LZ4Codec
+	internal static partial class LZ4Codec
 	{
 		// Update chains up to ip (excluded)
 		private static unsafe void LZ4HC_Insert_32(LZ4HC_Data_Structure hc4, byte* src_p)

--- a/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe64.Dirty.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe64.Dirty.cs
@@ -66,7 +66,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // ReSharper disable TooWideLocalVariableScope
 // ReSharper disable JoinDeclarationAndInitializer
 
-namespace LZ4n
+namespace Microsoft.Xna.Framework.Content.Pipeline.LZ4
 {
 	public static partial class LZ4Codec
 	{

--- a/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe64.Dirty.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe64.Dirty.cs
@@ -66,9 +66,9 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // ReSharper disable TooWideLocalVariableScope
 // ReSharper disable JoinDeclarationAndInitializer
 
-namespace Microsoft.Xna.Framework.Content.Pipeline.LZ4
+namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities.LZ4
 {
-	public static partial class LZ4Codec
+	internal static partial class LZ4Codec
 	{
 		#region LZ4_compressCtx_64
 

--- a/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe64HC.Dirty.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe64HC.Dirty.cs
@@ -64,7 +64,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // ReSharper disable InconsistentNaming
 
-namespace LZ4n
+namespace Microsoft.Xna.Framework.Content.Pipeline.LZ4
 {
 	public static partial class LZ4Codec
 	{

--- a/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe64HC.Dirty.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.Unsafe64HC.Dirty.cs
@@ -64,9 +64,9 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // ReSharper disable InconsistentNaming
 
-namespace Microsoft.Xna.Framework.Content.Pipeline.LZ4
+namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities.LZ4
 {
-	public static partial class LZ4Codec
+	internal static partial class LZ4Codec
 	{
 		// Update chains up to ip (excluded)
 		private static unsafe void LZ4HC_Insert_64(LZ4HC_Data_Structure hc4, byte* src_p)

--- a/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.cs
@@ -35,13 +35,8 @@ NOTE:
 	Use 'LZ4s' conditional define to differentiate
 */
 
-// ReSharper disable InconsistentNaming
 
-#if LZ4s
-namespace LZ4s
-#else
-namespace LZ4n
-#endif
+namespace Microsoft.Xna.Framework.Content.Pipeline.LZ4
 {
 	public static partial class LZ4Codec
 	{

--- a/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/LZ4/LZ4Codec.cs
@@ -36,9 +36,9 @@ NOTE:
 */
 
 
-namespace Microsoft.Xna.Framework.Content.Pipeline.LZ4
+namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities.LZ4
 {
-	public static partial class LZ4Codec
+	internal static partial class LZ4Codec
 	{
 		#region configuration
 

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -1,53 +1,14 @@
-#region License
-/*
-Microsoft Public License (Ms-PL)
-MonoGame - Copyright © 2009 The MonoGame Team
-
-All rights reserved.
-
-This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
-accept the license, do not use the software.
-
-1. Definitions
-The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
-U.S. copyright law.
-
-A "contribution" is the original software, or any additions or changes to the software.
-A "contributor" is any person that distributes its contribution under this license.
-"Licensed patents" are a contributor's patent claims that read directly on its contribution.
-
-2. Grant of Rights
-(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-
-3. Conditions and Limitations
-(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
-your patent license from such contributor to the software ends automatically.
-(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
-notices that are present in the software.
-(D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
-a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
-code form, you may only do so under a license that complies with this license.
-(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
-or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
-permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
-purpose and non-infringement.
-*/
-#endregion License
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.IO;
 using System.Collections.Generic;
-using System.Reflection;
-using System.Text;
-using Lz4;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using Path = System.IO.Path;
 using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using Microsoft.Xna.Framework.Content.Pipeline.LZ4;
+using Microsoft.Xna.Framework.Graphics;
 
 #if !WINRT
 using Microsoft.Xna.Framework.Audio;
@@ -100,7 +61,7 @@ namespace Microsoft.Xna.Framework.Content
                 for (int i = ContentManagers.Count - 1; i >= 0; --i)
                 {
                     var contentRef = ContentManagers[i];
-                    if (Object.ReferenceEquals(contentRef.Target, contentManager))
+                    if (ReferenceEquals(contentRef.Target, contentManager))
                         contains = true;
                     if (!contentRef.IsAlive)
                         ContentManagers.RemoveAt(i);
@@ -119,7 +80,7 @@ namespace Microsoft.Xna.Framework.Content
                 for (int i = ContentManagers.Count - 1; i >= 0; --i)
                 {
                     var contentRef = ContentManagers[i];
-                    if (!contentRef.IsAlive || Object.ReferenceEquals(contentRef.Target, contentManager))
+                    if (!contentRef.IsAlive || ReferenceEquals(contentRef.Target, contentManager))
                         ContentManagers.RemoveAt(i);
                 }
             }

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
-using Microsoft.Xna.Framework.Content.Pipeline.LZ4;
+using Microsoft.Xna.Framework.Utilities;
 using Microsoft.Xna.Framework.Graphics;
 
 #if !WINRT

--- a/MonoGame.Framework/Utilities/Lz4Stream/Lz4DecoderStream.cs
+++ b/MonoGame.Framework/Utilities/Lz4Stream/Lz4DecoderStream.cs
@@ -5,7 +5,7 @@
 using System;
 using System.IO;
 
-namespace Lz4
+namespace Microsoft.Xna.Framework.Content.Pipeline.LZ4
 {
 	public class Lz4DecoderStream : Stream
 	{

--- a/MonoGame.Framework/Utilities/Lz4Stream/Lz4DecoderStream.cs
+++ b/MonoGame.Framework/Utilities/Lz4Stream/Lz4DecoderStream.cs
@@ -1,13 +1,17 @@
-﻿#define CHECK_ARGS
+﻿// MIT License - Copyright (C) The Mono.Xna Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+#define CHECK_ARGS
 #define CHECK_EOF
 //#define LOCAL_SHADOW
 
 using System;
 using System.IO;
 
-namespace Microsoft.Xna.Framework.Content.Pipeline.LZ4
+namespace Microsoft.Xna.Framework.Utilities
 {
-	public class Lz4DecoderStream : Stream
+	internal class Lz4DecoderStream : Stream
 	{
 		public Lz4DecoderStream()
 		{

--- a/MonoGame.Framework/Utilities/Lz4Stream/Lz4DecoderStream.cs
+++ b/MonoGame.Framework/Utilities/Lz4Stream/Lz4DecoderStream.cs
@@ -1,4 +1,4 @@
-﻿// MIT License - Copyright (C) The Mono.Xna Team
+﻿// MonoGame - Copyright (C) The MonoGame Team
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 


### PR DESCRIPTION
Instead of separation from main framework I suggest insertion the LZ4 namespace into Content.Pipeline itself. Than it will not be an eyesore in documentation.