### PR TITLE
New enum docs.

### DIFF
--- a/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
@@ -58,18 +58,18 @@ namespace Microsoft.Xna.Framework.Content
 			
 			SurfaceFormat surfaceFormat;
 			if (reader.version < 5) {
-				SurfaceFormat_Legacy legacyFormat = (SurfaceFormat_Legacy)reader.ReadInt32 ();
+				SurfaceFormatLegacy legacyFormat = (SurfaceFormatLegacy)reader.ReadInt32 ();
 				switch(legacyFormat) {
-				case SurfaceFormat_Legacy.Dxt1:
+				case SurfaceFormatLegacy.Dxt1:
 					surfaceFormat = SurfaceFormat.Dxt1;
 					break;
-				case SurfaceFormat_Legacy.Dxt3:
+				case SurfaceFormatLegacy.Dxt3:
 					surfaceFormat = SurfaceFormat.Dxt3;
 					break;
-				case SurfaceFormat_Legacy.Dxt5:
+				case SurfaceFormatLegacy.Dxt5:
 					surfaceFormat = SurfaceFormat.Dxt5;
 					break;
-				case SurfaceFormat_Legacy.Color:
+				case SurfaceFormatLegacy.Color:
 					surfaceFormat = SurfaceFormat.Color;
 					break;
 				default:

--- a/MonoGame.Framework/Graphics/SpriteEffects.cs
+++ b/MonoGame.Framework/Graphics/SpriteEffects.cs
@@ -1,53 +1,28 @@
-#region License
-/*
-Microsoft Public License (Ms-PL)
-MonoGame - Copyright © 2009 The MonoGame Team
-
-All rights reserved.
-
-This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
-accept the license, do not use the software.
-
-1. Definitions
-The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
-U.S. copyright law.
-
-A "contribution" is the original software, or any additions or changes to the software.
-A "contributor" is any person that distributes its contribution under this license.
-"Licensed patents" are a contributor's patent claims that read directly on its contribution.
-
-2. Grant of Rights
-(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-
-3. Conditions and Limitations
-(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
-your patent license from such contributor to the software ends automatically.
-(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
-notices that are present in the software.
-(D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
-a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
-code form, you may only do so under a license that complies with this license.
-(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
-or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
-permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
-purpose and non-infringement.
-*/
-#endregion License
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
 
 using System;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Defines sprite visual options for rotation.
+    /// </summary>
     [Flags]
     public enum SpriteEffects
     {
+        /// <summary>
+        /// No options specified.
+        /// </summary>
 		None = 0,
+        /// <summary>
+        /// Rotate 180 degrees around the Y axis before rendering.
+        /// </summary>
         FlipHorizontally = 1,
+        /// <summary>
+        /// Rotate 180 degrees around the X axis before rendering.
+        /// </summary>
         FlipVertically = 2        
     }
 }
-

--- a/MonoGame.Framework/Graphics/SpriteEffects.cs
+++ b/MonoGame.Framework/Graphics/SpriteEffects.cs
@@ -7,7 +7,7 @@ using System;
 namespace Microsoft.Xna.Framework.Graphics
 {
     /// <summary>
-    /// Defines sprite visual options for rotation.
+    /// Defines sprite visual options for mirroring.
     /// </summary>
     [Flags]
     public enum SpriteEffects
@@ -17,12 +17,12 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
 		None = 0,
         /// <summary>
-        /// Rotate 180 degrees around the Y axis before rendering.
+        /// Render the sprite reversed along the X axis.
         /// </summary>
         FlipHorizontally = 1,
         /// <summary>
-        /// Rotate 180 degrees around the X axis before rendering.
+        /// Render the sprite reversed along the Y axis.
         /// </summary>
-        FlipVertically = 2        
+        FlipVertically = 2
     }
 }

--- a/MonoGame.Framework/Graphics/States/TextureAddressMode.cs
+++ b/MonoGame.Framework/Graphics/States/TextureAddressMode.cs
@@ -1,52 +1,25 @@
-// #region License
-// /*
-// Microsoft Public License (Ms-PL)
-// MonoGame - Copyright © 2009 The MonoGame Team
-// 
-// All rights reserved.
-// 
-// This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
-// accept the license, do not use the software.
-// 
-// 1. Definitions
-// The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
-// U.S. copyright law.
-// 
-// A "contribution" is the original software, or any additions or changes to the software.
-// A "contributor" is any person that distributes its contribution under this license.
-// "Licensed patents" are a contributor's patent claims that read directly on its contribution.
-// 
-// 2. Grant of Rights
-// (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-// each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-// (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-// each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-// 
-// 3. Conditions and Limitations
-// (A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-// (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
-// your patent license from such contributor to the software ends automatically.
-// (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
-// notices that are present in the software.
-// (D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
-// a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
-// code form, you may only do so under a license that complies with this license.
-// (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
-// or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
-// permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
-// purpose and non-infringement.
-// */
-// #endregion License
-// 
-using System;
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Defines modes for addressing texels using texture coordinates that are outside of the range of 0.0 to 1.0.
+    /// </summary>
 	public enum TextureAddressMode
 	{
+        /// <summary>
+        /// Texels outside range will form the tile at every integer junction.
+        /// </summary>
 		Wrap,
+        /// <summary>
+        /// Texels outside range will be setted to color of 0.0 or 1.0 texel.
+        /// </summary>
 		Clamp,
-		Mirror,
+        /// <summary>
+        /// Same as <see cref="TextureAddressMode.Wrap"/> but tiles will also flipped at every integer junction.
+        /// </summary>
+		Mirror
 	}
 }
-

--- a/MonoGame.Framework/Graphics/States/TextureFilter.cs
+++ b/MonoGame.Framework/Graphics/States/TextureFilter.cs
@@ -1,58 +1,49 @@
-// #region License
-// /*
-// Microsoft Public License (Ms-PL)
-// MonoGame - Copyright © 2009 The MonoGame Team
-// 
-// All rights reserved.
-// 
-// This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
-// accept the license, do not use the software.
-// 
-// 1. Definitions
-// The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
-// U.S. copyright law.
-// 
-// A "contribution" is the original software, or any additions or changes to the software.
-// A "contributor" is any person that distributes its contribution under this license.
-// "Licensed patents" are a contributor's patent claims that read directly on its contribution.
-// 
-// 2. Grant of Rights
-// (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-// each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-// (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-// each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-// 
-// 3. Conditions and Limitations
-// (A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-// (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
-// your patent license from such contributor to the software ends automatically.
-// (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
-// notices that are present in the software.
-// (D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
-// a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
-// code form, you may only do so under a license that complies with this license.
-// (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
-// or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
-// permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
-// purpose and non-infringement.
-// */
-// #endregion License
-// 
-using System;
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Defines filtering types for texture sampler.
+    /// </summary>
 	public enum TextureFilter
 	{
-		Linear,			// 	Use linear filtering.
-		Point,			// 	Use point filtering.
-		Anisotropic,	// 	Use anisotropic filtering.
-		LinearMipPoint,	// 	Use linear filtering to shrink or expand, and point filtering between mipmap levels (mip).
-		PointMipLinear,	// 	Use point filtering to shrink (minify) or expand (magnify), and linear filtering between mipmap levels.
-		MinLinearMagPointMipLinear,	// 	Use linear filtering to shrink, point filtering to expand, and linear filtering between mipmap levels.
-		MinLinearMagPointMipPoint,	// 	Use linear filtering to shrink, point filtering to expand, and point filtering between mipmap levels.
-		MinPointMagLinearMipLinear,	// 	Use point filtering to shrink, linear filtering to expand, and linear filtering between mipmap levels.
-		MinPointMagLinearMipPoint,	// 	Use point filtering to shrink, linear filtering to expand, and point filtering between mipmap levels.
+        /// <summary>
+        /// Use linear filtering.
+        /// </summary>
+		Linear,
+        /// <summary>
+        /// Use point filtering.
+        /// </summary>
+		Point,
+        /// <summary>
+        /// Use anisotropic filtering.
+        /// </summary>
+		Anisotropic,	
+        /// <summary>
+        /// Use linear filtering to shrink or expand, and point filtering between mipmap levels (mip).
+        /// </summary>
+		LinearMipPoint,
+        /// <summary>
+        /// Use point filtering to shrink (minify) or expand (magnify), and linear filtering between mipmap levels.
+        /// </summary>
+		PointMipLinear,
+        /// <summary>
+        /// Use linear filtering to shrink, point filtering to expand, and linear filtering between mipmap levels.
+        /// </summary>
+		MinLinearMagPointMipLinear,
+        /// <summary>
+        /// Use linear filtering to shrink, point filtering to expand, and point filtering between mipmap levels.
+        /// </summary>
+		MinLinearMagPointMipPoint,
+        /// <summary>
+        /// Use point filtering to shrink, linear filtering to expand, and linear filtering between mipmap levels.
+        /// </summary>
+		MinPointMagLinearMipLinear,
+        /// <summary>
+        /// Use point filtering to shrink, linear filtering to expand, and point filtering between mipmap levels.
+        /// </summary>
+		MinPointMagLinearMipPoint
 	}
 }
-

--- a/MonoGame.Framework/Graphics/SurfaceFormat.cs
+++ b/MonoGame.Framework/Graphics/SurfaceFormat.cs
@@ -1,91 +1,139 @@
-#region License
-/*
-Microsoft Public License (Ms-PL)
-MonoGame - Copyright © 2009 The MonoGame Team
-
-All rights reserved.
-
-This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
-accept the license, do not use the software.
-
-1. Definitions
-The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
-U.S. copyright law.
-
-A "contribution" is the original software, or any additions or changes to the software.
-A "contributor" is any person that distributes its contribution under this license.
-"Licensed patents" are a contributor's patent claims that read directly on its contribution.
-
-2. Grant of Rights
-(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-
-3. Conditions and Limitations
-(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
-your patent license from such contributor to the software ends automatically.
-(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
-notices that are present in the software.
-(D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
-a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
-code form, you may only do so under a license that complies with this license.
-(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
-or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
-permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
-purpose and non-infringement.
-*/
-#endregion License
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-    using System;
-
+    /// <summary>
+    /// Defines types of surface formats.
+    /// </summary>
+    /// <remarks>
+    /// Good explanation of compressed formats for mobile devices (aimed at Android, but describes PVRTC)
+    /// http://developer.motorola.com/docstools/library/understanding-texture-compression/
+    /// </remarks>
     public enum SurfaceFormat
     {
+        /// <summary>
+        /// Unsigned 32-bit ARGB pixel format for store 8 bits per channel. 
+        /// </summary>
         Color = 0,
+        /// <summary>
+        /// Unsigned 16-bit BGR pixel format for store 5 bits for blue, 6 bits for green, and 5 bits for red.   
+        /// </summary>
         Bgr565 = 1,
+        /// <summary>
+        /// Unsigned 16-bit BGRA pixel format where 5 bits reserved for each color and last bit is reserved for alpha.
+        /// </summary>
         Bgra5551 = 2,
+        /// <summary>
+        /// Unsigned 16-bit BGRA pixel format for store 4 bits per channel.
+        /// </summary>
         Bgra4444 = 3,
+        /// <summary>
+        /// DXT1. Texture format with compression. Surface dimensions must be a multiple 4.
+        /// </summary>
         Dxt1 = 4,
-        Dxt3 = 5,
+        /// <summary>
+        /// DXT3. Texture format with compression. Surface dimensions must be a multiple 4.
+        /// </summary>
+        Dxt3 = 5, 
+        /// <summary>
+        /// DXT5. Texture format with compression. Surface dimensions must be a multiple 4.
+        /// </summary>
         Dxt5 = 6,
+        /// <summary>
+        /// Signed 16-bit bump-map format for store 8 bits for <c>u</c> and <c>v</c> data.
+        /// </summary>
         NormalizedByte2 = 7,
+        /// <summary>
+        /// Signed 16-bit bump-map format for store 8 bits per channel.
+        /// </summary>
         NormalizedByte4 = 8,
+        /// <summary>
+        /// Unsigned 32-bit RGBA pixel format for store 10 bits for each color and 2 bits for alpha.
+        /// </summary>
         Rgba1010102 = 9,
+        /// <summary>
+        /// Unsigned 32-bit RG pixel format using 16 bits per channel.
+        /// </summary>
         Rg32 = 10,
+        /// <summary>
+        /// Unsigned 64-bit RGBA pixel format using 16 bits per channel.
+        /// </summary>
         Rgba64 = 11,
+        /// <summary>
+        /// Unsigned A 8-bit format for store 8 bits to alpha channel.
+        /// </summary>
         Alpha8 = 12,
+        /// <summary>
+        /// IEEE 32-bit R float format for store 32 bits to red channel.
+        /// </summary>
         Single = 13,
+        /// <summary>
+        /// IEEE 64-bit RG float format for store 32 bits per channel.
+        /// </summary>
         Vector2 = 14,
+        /// <summary>
+        /// IEEE 128-bit RGBA float format for store 32 bits per channel.
+        /// </summary>
         Vector4 = 15,
+        /// <summary>
+        /// Float 16-bit R format for store 16 bits to red channel.   
+        /// </summary>
         HalfSingle = 16,
+        /// <summary>
+        /// Float 32-bit RG format for store 16 bits per channel. 
+        /// </summary>
         HalfVector2 = 17,
+        /// <summary>
+        /// Float 64-bit ARGB format for store 16 bits per channel. 
+        /// </summary>
         HalfVector4 = 18,
+        /// <summary>
+        /// Float pixel format for high dynamic range data.
+        /// </summary>
         HdrBlendable = 19,
 
-        // BGRA formats are required for compatibility with WPF D3DImage.
+        #region Extensions
+
+        /// <summary>
+        /// For compatibility with WPF D3DImage.
+        /// </summary>
         Bgr32 = 20,     // B8G8R8X8
-        Bgra32 = 21,    // B8G8R8A8
-        
-		// Good explanation of compressed formats for mobile devices (aimed at Android, but describes PVRTC)
-		// http://developer.motorola.com/docstools/library/understanding-texture-compression/
-
-		// PowerVR texture compression (iOS and Android)
+        /// <summary>
+        /// For compatibility with WPF D3DImage.
+        /// </summary>
+        Bgra32 = 21,    // B8G8R8A8    
+		/// <summary>
+        /// PowerVR texture compression format (iOS and Android).
+		/// </summary>
 		RgbPvrtc2Bpp = 50,
+        /// <summary>
+        /// PowerVR texture compression format (iOS and Android).
+        /// </summary>
 		RgbPvrtc4Bpp = 51,
+        /// <summary>
+        /// PowerVR texture compression format (iOS and Android).
+        /// </summary>
 		RgbaPvrtc2Bpp = 52,
+        /// <summary>
+        /// PowerVR texture compression format (iOS and Android).
+        /// </summary>
 		RgbaPvrtc4Bpp = 53,
-
-		// Ericcson Texture Compression (Android)
+		/// <summary>
+        /// Ericcson Texture Compression (Android)
+		/// </summary>
 		RgbEtc1 = 60,
+        /// <summary>
+        /// DXT1 version where 1-bit alpha is used.
+        /// </summary>
+        Dxt1a = 70
 
-        // DXT1 also has a 1-bit alpha form
-        Dxt1a = 70,
+        #endregion
     }
     
-    public enum SurfaceFormat_Legacy
+
+    internal enum SurfaceFormatLegacy
     {
         Unknown = -1,
         Color = 1,

--- a/MonoGame.Framework/Graphics/Vertices/VertexElementFormat.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexElementFormat.cs
@@ -1,18 +1,61 @@
-﻿namespace Microsoft.Xna.Framework.Graphics
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Defines vertex element formats.
+    /// </summary>
     public enum VertexElementFormat
     {
+        /// <summary>
+        /// Single 32-bit floating point number.
+        /// </summary>
         Single,
+        /// <summary>
+        /// Two component 32-bit floating point number.
+        /// </summary>
         Vector2,
-        Vector3,
-        Vector4,
-        Color,
-        Byte4,
+        /// <summary>
+        /// Three component 32-bit floating point number.
+        /// </summary>
+        Vector3, 
+        /// <summary>
+        /// Four component 32-bit floating point number.
+        /// </summary>
+        Vector4, 
+        /// <summary>
+        /// Four component, packed unsigned byte, mapped to 0 to 1 range. 
+        /// </summary>
+        Color,   
+        /// <summary>
+        /// Four component unsigned byte.
+        /// </summary>
+        Byte4,        
+        /// <summary>
+        /// Two component signed 16-bit integer.
+        /// </summary>
         Short2,
+        /// <summary>
+        /// Four component signed 16-bit integer.
+        /// </summary>
         Short4,
+        /// <summary>
+        /// Normalized, two component signed 16-bit integer.
+        /// </summary>
         NormalizedShort2,
+        /// <summary>
+        /// Normalized, four component signed 16-bit integer.
+        /// </summary>
         NormalizedShort4,
-        HalfVector2,
+        /// <summary>
+        /// Two component 16-bit floating point number.
+        /// </summary>
+        HalfVector2,  
+        /// <summary>
+        /// Four component 16-bit floating point number.
+        /// </summary>
         HalfVector4
     }
 }

--- a/MonoGame.Framework/Graphics/Vertices/VertexElementUsage.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexElementUsage.cs
@@ -1,19 +1,65 @@
-﻿namespace Microsoft.Xna.Framework.Graphics
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Defines usage for vertex elements.
+    /// </summary>
     public enum VertexElementUsage
     {
+        /// <summary>
+        /// Position data.
+        /// </summary>
         Position,
-        Color,
-        TextureCoordinate,
+        /// <summary>
+        /// Color data.
+        /// </summary>
+        Color,   
+        /// <summary>
+        /// Texture coordinate data or can be used for user-defined data.
+        /// </summary>
+        TextureCoordinate, 
+        /// <summary>
+        /// Normal data.
+        /// </summary>
         Normal,
+        /// <summary>
+        /// Binormal data.
+        /// </summary>
         Binormal,
+        /// <summary>
+        /// Tangent data.
+        /// </summary>
         Tangent,
+        /// <summary>
+        /// Blending indices data.
+        /// </summary>
         BlendIndices,
-        BlendWeight,
+        /// <summary>
+        /// Blending weight data.
+        /// </summary>
+        BlendWeight,     
+        /// <summary>
+        /// Depth data.
+        /// </summary>
         Depth,
-        Fog,
+        /// <summary>
+        /// Fog data.
+        /// </summary>
+        Fog,      
+        /// <summary>
+        /// Point size data. Usable for drawing point sprites.
+        /// </summary>
         PointSize,
-        Sample,
+        /// <summary>
+        /// Sampler data for specifies the displacement value to look up.
+        /// </summary>
+        Sample,     
+        /// <summary>
+        /// Single, positive float value, specifies a tessellation factor used in the tessellation unit to control the rate of tessellation.
+        /// </summary>
         TessellateFactor
     }
 }


### PR DESCRIPTION
Docs for 
-VertexElementUsage
-VertexElementFormat
-TextureFilter
-TextureAddressMode
-SurfaceFormat
Fix licenses for all of those enums.
SurfaceFormat_Legacy is renamed to SurfaceFormatLegacy and marked internal instead of public.
