### PR TITLE
- Mono workaround: Uri.LocalPath is not always same with .net platform

### DIFF
--- a/MonoGame.Framework/TitleContainer.cs
+++ b/MonoGame.Framework/TitleContainer.cs
@@ -116,7 +116,15 @@ namespace Microsoft.Xna.Framework
         // this same logic is duplicated all over the code base.
         internal static string GetFilename(string name)
         {
-            return FileHelpers.NormalizeFilePathSeparators(new Uri("file:///" + name).LocalPath.Substring(1));
+            var path = new Uri("file:///" + name).LocalPath.Replace("///", "")
+                                                 .Replace("//", "")
+                                                 .Replace(@"\\\", "")
+                                                 .Replace(@"\\", "");
+
+            if (path.StartsWith("/"))
+                path = path.Remove(0, 1);
+
+            return FileHelpers.NormalizeFilePathSeparators(path);
         }
     }
 }


### PR DESCRIPTION
as with version of mono 3.12.0 
Uri.LocalPath returns "///" or "//" before actual LocalPath.

```
Mono: ///Content/Spirtes/a.xnb
Windows: Content/Spirtes/a.xnb
```

So i did eliminated in order to "///" then "//" to prevent unwanted "/" left.