### PR TITLE
Improves BoundingBox/Plane intersection performance

### DIFF
--- a/MonoGame.Framework/BoundingBox.cs
+++ b/MonoGame.Framework/BoundingBox.cs
@@ -472,14 +472,14 @@ namespace Microsoft.Xna.Framework
                 negativeVertex.Z = Max.Z;
             }
 
-            var distance = Vector3.Dot(plane.Normal, negativeVertex) + plane.D;
+            var distance = plane.Normal.X * negativeVertex.X + plane.Normal.Y * negativeVertex.Y + plane.Normal.Z * negativeVertex.Z + plane.D;
             if (distance > 0)
             {
                 result = PlaneIntersectionType.Front;
                 return;
             }
 
-            distance = Vector3.Dot(plane.Normal, positiveVertex) + plane.D;
+            distance = plane.Normal.X * positiveVertex.X + plane.Normal.Y * positiveVertex.Y + plane.Normal.Z * positiveVertex.Z + plane.D;
             if (distance < 0)
             {
                 result = PlaneIntersectionType.Back;

--- a/MonoGame.Framework/BoundingBox.cs
+++ b/MonoGame.Framework/BoundingBox.cs
@@ -472,6 +472,7 @@ namespace Microsoft.Xna.Framework
                 negativeVertex.Z = Max.Z;
             }
 
+            // Inline Vector3.Dot(plane.Normal, negativeVertex) + plane.D;
             var distance = plane.Normal.X * negativeVertex.X + plane.Normal.Y * negativeVertex.Y + plane.Normal.Z * negativeVertex.Z + plane.D;
             if (distance > 0)
             {
@@ -479,6 +480,7 @@ namespace Microsoft.Xna.Framework
                 return;
             }
 
+            // Inline Vector3.Dot(plane.Normal, positiveVertex) + plane.D;
             distance = plane.Normal.X * positiveVertex.X + plane.Normal.Y * positiveVertex.Y + plane.Normal.Z * positiveVertex.Z + plane.D;
             if (distance < 0)
             {


### PR DESCRIPTION
Inlining Vector3.Dot calls inside BoundingBox.Intersects results in significant performance improvement , especially when performing frustum culling on mobile devices.

I thought about using [`[MethodImpl(MethodImplOptions.AggressiveInlining)]`](https://msdn.microsoft.com/en-us/library/system.runtime.compilerservices.methodimploptions(v=VS.110).aspx) attribute but it would require to switch MonoGame to use .NET4.5 and it would not guaranty that it would be inlined anyway. I believe it is safer to simply inline/unroll MonoGame core math algorithms to ensure the best possible performance on all platforms.
