### PR TITLE
Ignore indexers in ReflectiveSerializer, to match XNA behaviour

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ReflectiveSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ReflectiveSerializer.cs
@@ -65,6 +65,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
                     if (prop.GetSetMethod() == null &&
                         prop.PropertyType.Namespace == "System")
                         return false;
+
+                    // Don't serialize or deserialize indexers.
+                    if (prop.GetIndexParameters().Any())
+                        return false;
                 }
                 else if (field != null)
                 {

--- a/Test/Assets/Xml/09_Collections.xml
+++ b/Test/Assets/Xml/09_Collections.xml
@@ -12,5 +12,6 @@
       <Item>test</Item>
     </StringList>
     <IntArray>1 2 3 23 42</IntArray>
+    <ColorArray>FF886542 FF916B46 FF917B46 FF886543</ColorArray>
   </Asset>
 </XnaContent>

--- a/Test/ContentPipeline/AssetTestClasses.cs
+++ b/Test/ContentPipeline/AssetTestClasses.cs
@@ -135,6 +135,13 @@ public class Collections
     public List<string> StringList;
     public int[] IntArray;
     public Color[] ColorArray;
+
+    // Indexer - should be ignored by intermediate serializer.
+    public Color this[int i]
+    {
+        get { return ColorArray[i]; }
+        set { ColorArray[i] = value; }
+    }
 }
 #endregion
 

--- a/Test/ContentPipeline/AssetTestClasses.cs
+++ b/Test/ContentPipeline/AssetTestClasses.cs
@@ -134,6 +134,7 @@ public class Collections
     public string[] StringArray;
     public List<string> StringList;
     public int[] IntArray;
+    public Color[] ColorArray;
 }
 #endregion
 

--- a/Test/ContentPipeline/IntermediateDeserializerTest.cs
+++ b/Test/ContentPipeline/IntermediateDeserializerTest.cs
@@ -222,6 +222,13 @@ namespace MonoGame.Tests.ContentPipeline
                 Assert.AreEqual(3, collections.IntArray[2]);
                 Assert.AreEqual(23, collections.IntArray[3]);
                 Assert.AreEqual(42, collections.IntArray[4]);
+
+                Assert.NotNull(collections.ColorArray);
+                Assert.AreEqual(4, collections.ColorArray.Length);
+                Assert.AreEqual(new Color(0x88, 0x65, 0x42, 0xFF), collections.ColorArray[0]);
+                Assert.AreEqual(new Color(0x91, 0x6B, 0x46, 0xFF), collections.ColorArray[1]);
+                Assert.AreEqual(new Color(0x91, 0x7B, 0x46, 0xFF), collections.ColorArray[2]);
+                Assert.AreEqual(new Color(0x88, 0x65, 0x43, 0xFF), collections.ColorArray[3]);
             });            
         }
 

--- a/Test/ContentPipeline/IntermediateSerializerTest.cs
+++ b/Test/ContentPipeline/IntermediateSerializerTest.cs
@@ -191,7 +191,14 @@ namespace MonoGame.Tests.ContentPipeline
             {
                 StringArray = new[] { "Hello", "World" },
                 StringList = new List<string> { "This", "is", "a", "test" },
-                IntArray = new[] { 1, 2, 3, 23, 42 }
+                IntArray = new[] { 1, 2, 3, 23, 42 },
+                ColorArray = new[]
+                {
+                    new Color(0x88, 0x65, 0x42, 0xFF),
+                    new Color(0x91, 0x6B, 0x46, 0xFF),
+                    new Color(0x91, 0x7B, 0x46, 0xFF),
+                    new Color(0x88, 0x65, 0x43, 0xFF)
+                }
             });
         }
 


### PR DESCRIPTION
Fixes #3439.

I also added some Color collection tests, which I added while debugging this issue - there was no problem there, but we might as well keep the tests anyway.