### PR TITLE
Type converters for vectors

### DIFF
--- a/Build/Projects/2MGFX.definition
+++ b/Build/Projects/2MGFX.definition
@@ -142,6 +142,21 @@
     <Compile Include="..\..\MonoGame.Framework\Vector4.cs">
       <Link>MonoGame.Framework\Vector4.cs</Link>
     </Compile>
+    <Compile Include="..\..\MonoGame.Framework\Design\Vector2TypeConverter.cs">
+      <Link>MonoGame.Framework\Design\Vector2TypeConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\..\MonoGame.Framework\Design\Vector3TypeConverter.cs">
+      <Link>MonoGame.Framework\Design\Vector3TypeConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\..\MonoGame.Framework\Design\Vector4TypeConverter.cs">
+      <Link>MonoGame.Framework\Design\Vector4TypeConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\..\MonoGame.Framework\Design\VectorConversion.cs">
+      <Link>MonoGame.Framework\Design\VectorConversion.cs</Link>
+    </Compile>
+    <Compile Include="..\..\MonoGame.Framework\Graphics\PackedVector\IPackedVector.cs">
+      <Link>MonoGame.Framework\Graphics\PackedVector\IPackedVector.cs</Link>
+    </Compile>    
     <Compile Include="..\..\MonoGame.Framework\Utilities\Hash.cs">
       <Link>MonoGame.Framework\Utilities\Hash.cs</Link>
     </Compile>

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -74,7 +74,7 @@
       <Platforms>Web</Platforms>
     </Uses>
     <Uses Name="_XNADesignProvided">
-      <Platforms>Windows,Linux,MacOS</Platforms>
+      <Platforms>Windows,WindowsGL,Linux,MacOS</Platforms>
     </Uses>
     <Uses Name="_FrameworkDispatcherProvided">
       <Platforms>Windows,WindowsGL,MacOS</Platforms>

--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -105,8 +105,10 @@
     <Compile Include="Framework\TouchLocationTest.cs" />
     <Compile Include="Framework\TouchPanelTest.cs" />
     <Compile Include="Framework\UtilitiesTest.cs" />
-	<Compile Include="Framework\Vector2Test.cs" />
-	
+    <Compile Include="Framework\Vector2Test.cs" />
+    <Compile Include="Framework\Vector3Test.cs" />
+    <Compile Include="Framework\Vector4Test.cs" />
+    
     <Compile Include="Framework\Components\DrawFrameNumberComponent.cs" />
     <Compile Include="Framework\Components\FlexibleGameComponent.cs" />
     <Compile Include="Framework\Components\FrameCompareComponent.cs" />

--- a/MonoGame.Framework/Design/Vector2TypeConverter.cs
+++ b/MonoGame.Framework/Design/Vector2TypeConverter.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Xna.Framework.Design
                 terms[0] = vec.X.ToString(culture);
                 terms[1] = vec.Y.ToString(culture);
 
-                return string.Join(culture.NumberFormat.NumberGroupSeparator, terms);
+                return string.Join("; ", terms);
             }
 
             return base.ConvertTo(context, culture, value, destinationType);
@@ -58,7 +58,7 @@ namespace Microsoft.Xna.Framework.Design
             if (sourceType == typeof(string))
             {
                 var str = (string)value;
-                var words = str.Split(culture.NumberFormat.NumberGroupSeparator.ToCharArray());
+                var words = str.Split(';');
 
                 vec.X = float.Parse(words[0]);
                 vec.Y = float.Parse(words[1]);

--- a/MonoGame.Framework/Design/Vector2TypeConverter.cs
+++ b/MonoGame.Framework/Design/Vector2TypeConverter.cs
@@ -33,10 +33,10 @@ namespace Microsoft.Xna.Framework.Design
             if (destinationType == typeof(string))
             {
                 var terms = new string[2];
-                terms[0] = vec.X.ToString(culture);
-                terms[1] = vec.Y.ToString(culture);
+                terms[0] = vec.X.ToString("R", culture);
+                terms[1] = vec.Y.ToString("R", culture);
 
-                return string.Join("; ", terms);
+                return string.Join(culture.TextInfo.ListSeparator + " ", terms);
             }
 
             return base.ConvertTo(context, culture, value, destinationType);
@@ -58,10 +58,10 @@ namespace Microsoft.Xna.Framework.Design
             if (sourceType == typeof(string))
             {
                 var str = (string)value;
-                var words = str.Split(';');
+                var words = str.Split(culture.TextInfo.ListSeparator.ToCharArray());
 
-                vec.X = float.Parse(words[0]);
-                vec.Y = float.Parse(words[1]);
+                vec.X = float.Parse(words[0], culture);
+                vec.Y = float.Parse(words[1], culture);
 
                 return vec;
             }

--- a/MonoGame.Framework/Design/Vector3TypeConverter.cs
+++ b/MonoGame.Framework/Design/Vector3TypeConverter.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Xna.Framework.Design
                 terms[1] = vec.Y.ToString(culture);
                 terms[2] = vec.Z.ToString(culture);
 
-                return string.Join(culture.NumberFormat.NumberGroupSeparator, terms);
+                return string.Join("; ", terms);
             }
 
             return base.ConvertTo(context, culture, value, destinationType);
@@ -59,7 +59,7 @@ namespace Microsoft.Xna.Framework.Design
             if (sourceType == typeof(string))
             {
                 var str = (string)value;
-                var words = str.Split(culture.NumberFormat.NumberGroupSeparator.ToCharArray());
+                var words = str.Split(';');
 
                 vec.X = float.Parse(words[0]);
                 vec.Y = float.Parse(words[1]);

--- a/MonoGame.Framework/Design/Vector3TypeConverter.cs
+++ b/MonoGame.Framework/Design/Vector3TypeConverter.cs
@@ -33,11 +33,11 @@ namespace Microsoft.Xna.Framework.Design
             if (destinationType == typeof(string))
             {                
                 var terms = new string[3];
-                terms[0] = vec.X.ToString(culture);
-                terms[1] = vec.Y.ToString(culture);
-                terms[2] = vec.Z.ToString(culture);
+                terms[0] = vec.X.ToString("R", culture);
+                terms[1] = vec.Y.ToString("R", culture);
+                terms[2] = vec.Z.ToString("R", culture);
 
-                return string.Join("; ", terms);
+                return string.Join(culture.TextInfo.ListSeparator + " ", terms);
             }
 
             return base.ConvertTo(context, culture, value, destinationType);
@@ -59,11 +59,11 @@ namespace Microsoft.Xna.Framework.Design
             if (sourceType == typeof(string))
             {
                 var str = (string)value;
-                var words = str.Split(';');
+                var words = str.Split(culture.TextInfo.ListSeparator.ToCharArray());
 
-                vec.X = float.Parse(words[0]);
-                vec.Y = float.Parse(words[1]);
-                vec.Z = float.Parse(words[2]);
+                vec.X = float.Parse(words[0], culture);
+                vec.Y = float.Parse(words[1], culture);
+                vec.Z = float.Parse(words[2], culture);
 
                 return vec;
             }

--- a/MonoGame.Framework/Design/Vector4TypeConverter.cs
+++ b/MonoGame.Framework/Design/Vector4TypeConverter.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Xna.Framework.Design
                 terms[2] = vec.Z.ToString(culture);
                 terms[3] = vec.W.ToString(culture);
 
-                return string.Join(culture.NumberFormat.NumberGroupSeparator, terms);
+                return string.Join("; ", terms);
             }
 
             return base.ConvertTo(context, culture, value, destinationType);
@@ -59,7 +59,7 @@ namespace Microsoft.Xna.Framework.Design
             if (sourceType == typeof(string))
             {
                 var str = (string)value;
-                var words = str.Split(culture.NumberFormat.NumberGroupSeparator.ToCharArray());
+                var words = str.Split(';');
 
                 vec.X = float.Parse(words[0]);
                 vec.Y = float.Parse(words[1]);

--- a/MonoGame.Framework/Design/Vector4TypeConverter.cs
+++ b/MonoGame.Framework/Design/Vector4TypeConverter.cs
@@ -32,12 +32,12 @@ namespace Microsoft.Xna.Framework.Design
             if (destinationType == typeof(string))
             {
                 var terms = new string[4];
-                terms[0] = vec.X.ToString(culture);
-                terms[1] = vec.Y.ToString(culture);
-                terms[2] = vec.Z.ToString(culture);
-                terms[3] = vec.W.ToString(culture);
+                terms[0] = vec.X.ToString("R", culture);
+                terms[1] = vec.Y.ToString("R", culture);
+                terms[2] = vec.Z.ToString("R", culture);
+                terms[3] = vec.W.ToString("R", culture);
 
-                return string.Join("; ", terms);
+                return string.Join(culture.TextInfo.ListSeparator + " ", terms);
             }
 
             return base.ConvertTo(context, culture, value, destinationType);
@@ -59,12 +59,12 @@ namespace Microsoft.Xna.Framework.Design
             if (sourceType == typeof(string))
             {
                 var str = (string)value;
-                var words = str.Split(';');
+                var words = str.Split(culture.TextInfo.ListSeparator.ToCharArray());
 
-                vec.X = float.Parse(words[0]);
-                vec.Y = float.Parse(words[1]);
-                vec.Z = float.Parse(words[2]);
-                vec.W = float.Parse(words[3]);
+                vec.X = float.Parse(words[0], culture);
+                vec.Y = float.Parse(words[1], culture);
+                vec.Z = float.Parse(words[2], culture);
+                vec.W = float.Parse(words[3], culture);
 
                 return vec;
             }

--- a/MonoGame.Framework/Design/Vector4TypeConverter.cs
+++ b/MonoGame.Framework/Design/Vector4TypeConverter.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Xna.Framework.Design
 
             if (destinationType == typeof(string))
             {
-                var terms = new string[3];
+                var terms = new string[4];
                 terms[0] = vec.X.ToString(culture);
                 terms[1] = vec.Y.ToString(culture);
                 terms[2] = vec.Z.ToString(culture);
@@ -64,7 +64,7 @@ namespace Microsoft.Xna.Framework.Design
                 vec.X = float.Parse(words[0]);
                 vec.Y = float.Parse(words[1]);
                 vec.Z = float.Parse(words[2]);
-                vec.Z = float.Parse(words[3]);
+                vec.W = float.Parse(words[3]);
 
                 return vec;
             }

--- a/MonoGame.Framework/Vector2.cs
+++ b/MonoGame.Framework/Vector2.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Xna.Framework
     /// <summary>
     /// Describes a 2D-vector.
     /// </summary>
+#if WINDOWS
+    [System.ComponentModel.TypeConverter(typeof(Microsoft.Xna.Framework.Design.Vector2TypeConverter))]
+#endif
     [DataContract]
     [DebuggerDisplay("{DebugDisplayString,nq}")]
     public struct Vector2 : IEquatable<Vector2>

--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -9,6 +9,9 @@ using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
 {
+#if WINDOWS
+    [System.ComponentModel.TypeConverter(typeof(Microsoft.Xna.Framework.Design.Vector3TypeConverter))]
+#endif
     [DataContract]
     [DebuggerDisplay("{DebugDisplayString,nq}")]
     public struct Vector3 : IEquatable<Vector3>

--- a/MonoGame.Framework/Vector4.cs
+++ b/MonoGame.Framework/Vector4.cs
@@ -9,6 +9,9 @@ using System.Diagnostics;
 
 namespace Microsoft.Xna.Framework
 {
+#if WINDOWS
+    [System.ComponentModel.TypeConverter(typeof(Microsoft.Xna.Framework.Design.Vector4TypeConverter))]
+#endif
     [DataContract]
     [DebuggerDisplay("{DebugDisplayString,nq}")]
     public struct Vector4 : IEquatable<Vector4>

--- a/Test/Framework/Vector2Test.cs
+++ b/Test/Framework/Vector2Test.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using NUnit.Framework;
+using System.ComponentModel;
+using System.Globalization;
 
 namespace MonoGame.Tests.Framework
 {
@@ -364,6 +366,26 @@ namespace MonoGame.Tests.Framework
         }
 
         [Test]
+        public void TypeConverter()
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(Vector2));
+            CultureInfo invariantCulture = CultureInfo.InvariantCulture;
+
+            Assert.AreEqual(new Vector2(32, 64), converter.ConvertFromString(null, invariantCulture, "32, 64"));
+            Assert.AreEqual(new Vector2(0.5f, 2.75f), converter.ConvertFromString(null, invariantCulture, "0.5, 2.75"));
+            Assert.AreEqual(new Vector2(1024.5f, 2048.75f), converter.ConvertFromString(null, invariantCulture, "1024.5, 2048.75"));
+            Assert.AreEqual("32, 64", converter.ConvertToString(null, invariantCulture, new Vector2(32, 64)));
+            Assert.AreEqual("0.5, 2.75", converter.ConvertToString(null, invariantCulture, new Vector2(0.5f, 2.75f)));
+            Assert.AreEqual("1024.5, 2048.75", converter.ConvertToString(null, invariantCulture, new Vector2(1024.5f, 2048.75f)));
+
+            CultureInfo otherCulture = new CultureInfo("el-GR");
+
+            Assert.AreEqual(new Vector2(1024.5f, 2048.75f), converter.ConvertFromString(null, otherCulture, "1024,5; 2048,75"));
+            Assert.AreEqual("1024,5; 2048,75", converter.ConvertToString(null, otherCulture, new Vector2(1024.5f, 2048.75f)));
+        }
+
+#if !XNA
+        [Test]
         public void ToPoint()
         {
             Assert.AreEqual(new Point(0, 0), new Vector2(0.1f, 0.1f).ToPoint());
@@ -374,5 +396,6 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual(new Point(1, 1), new Vector2(1.0f, 1.0f).ToPoint());
             Assert.AreEqual(new Point(19, 27), new Vector2(19.033f, 27.1f).ToPoint());
         }
+#endif     
     }
 }

--- a/Test/Framework/Vector3Test.cs
+++ b/Test/Framework/Vector3Test.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Xna.Framework;
+using NUnit.Framework;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace MonoGame.Tests.Framework
+{
+    class Vector3Test
+    {
+        [Test]
+        public void TypeConverter()
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(Vector3));
+            CultureInfo invariantCulture = CultureInfo.InvariantCulture;
+
+            Assert.AreEqual(new Vector3(32, 64, 128), converter.ConvertFromString(null, invariantCulture, "32, 64, 128"));
+            Assert.AreEqual(new Vector3(0.5f, 2.75f, 4.125f), converter.ConvertFromString(null, invariantCulture, "0.5, 2.75, 4.125"));
+            Assert.AreEqual(new Vector3(1024.5f, 2048.75f, 4096.125f), converter.ConvertFromString(null, invariantCulture, "1024.5, 2048.75, 4096.125"));
+            Assert.AreEqual("32, 64, 128", converter.ConvertToString(null, invariantCulture, new Vector3(32, 64, 128)));
+            Assert.AreEqual("0.5, 2.75, 4.125", converter.ConvertToString(null, invariantCulture, new Vector3(0.5f, 2.75f, 4.125f)));
+            Assert.AreEqual("1024.5, 2048.75, 4096.125", converter.ConvertToString(null, invariantCulture, new Vector3(1024.5f, 2048.75f, 4096.125f)));
+
+            CultureInfo otherCulture = new CultureInfo("el-GR");
+
+            Assert.AreEqual(new Vector3(1024.5f, 2048.75f, 4096.125f), converter.ConvertFromString(null, otherCulture, "1024,5; 2048,75; 4096,125"));
+            Assert.AreEqual("1024,5; 2048,75; 4096,125", converter.ConvertToString(null, otherCulture, new Vector3(1024.5f, 2048.75f, 4096.125f)));
+        }
+    }
+}

--- a/Test/Framework/Vector4Test.cs
+++ b/Test/Framework/Vector4Test.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Xna.Framework;
+using NUnit.Framework;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace MonoGame.Tests.Framework
+{
+    class Vector4Test
+    {
+        [Test]
+        public void TypeConverter()
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(Vector4));
+            CultureInfo invariantCulture = CultureInfo.InvariantCulture;
+            
+            Assert.AreEqual(new Vector4(32, 64, 128, 255), converter.ConvertFromString(null, invariantCulture, "32, 64, 128, 255"));
+            Assert.AreEqual(new Vector4(0.5f, 2.75f, 4.125f, 8.0625f), converter.ConvertFromString(null, invariantCulture, "0.5, 2.75, 4.125, 8.0625"));
+            Assert.AreEqual(new Vector4(1024.5f, 2048.75f, 4096.125f, 8192.0625f), converter.ConvertFromString(null, invariantCulture, "1024.5, 2048.75, 4096.125, 8192.0625"));
+            Assert.AreEqual("32, 64, 128, 255", converter.ConvertToString(null, invariantCulture, new Vector4(32, 64, 128, 255)));
+            Assert.AreEqual("0.5, 2.75, 4.125, 8.0625", converter.ConvertToString(null, invariantCulture, new Vector4(0.5f, 2.75f, 4.125f, 8.0625f)));
+            Assert.AreEqual("1024.5, 2048.75, 4096.125, 8192.0625", converter.ConvertToString(null, invariantCulture, new Vector4(1024.5f, 2048.75f, 4096.125f, 8192.0625f)));
+
+            CultureInfo otherCulture = new CultureInfo("el-GR");
+
+            Assert.AreEqual(new Vector4(1024.5f, 2048.75f, 4096.125f, 8192.0625f), converter.ConvertFromString(null, otherCulture, "1024,5; 2048,75; 4096,125; 8192,0625"));
+            Assert.AreEqual("1024,5; 2048,75; 4096,125; 8192,0625", converter.ConvertToString(null, otherCulture, new Vector4(1024.5f, 2048.75f, 4096.125f, 8192.0625f)));
+        }
+    }
+}

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -106,6 +106,9 @@
     <Compile Include="Framework\PackedVectorTest.cs" />
     <Compile Include="Framework\PlaneTest.cs" />
     <Compile Include="Framework\RectangleTest.cs" />
+    <Compile Include="Framework\Vector2Test.cs" />
+    <Compile Include="Framework\Vector3Test.cs" />
+    <Compile Include="Framework\Vector4Test.cs" />
     <Compile Include="Framework\Visual\IndexBufferTest.cs" />
     <Compile Include="Framework\Visual\VertexBufferTest.cs" />
     <Compile Include="Framework\Visual\ScissorRectangleTest.cs" />


### PR DESCRIPTION
-fix https://github.com/mono/MonoGame/issues/3484
-add conversion to Vector2/3/4. [Windows] only.
-Use ';' as a seperator. Identical to XNA and fix parsing problems with floats.