### PR TITLE
Close MediaLibrary cursor on Android (dispose isn't enough)

### DIFF
--- a/MonoGame.Framework/Media/MediaLibrary.Android.cs
+++ b/MonoGame.Framework/Media/MediaLibrary.Android.cs
@@ -107,6 +107,8 @@ namespace Microsoft.Xna.Framework.Media
 
                     } while (musicCursor.MoveToNext()); 
                 }
+
+                musicCursor.Close();
             }
 
             albumCollection = new AlbumCollection(albumList);


### PR DESCRIPTION
Fixes errors in logcat like this:

>02-02 23:05:39.770: E/CursorLeakDetecter(28387): android.database.sqlite.DatabaseObjectNotClosedException: Application did not close the cursor or database object that was opened here
02-02 23:05:39.770: E/CursorLeakDetecter(28387): at android.content.ContentResolver.query(ContentResolver.java:399)
02-02 23:05:39.770: E/CursorLeakDetecter(28387): at android.content.ContentResolver.query(ContentResolver.java:316)
02-02 23:05:39.770: E/CursorLeakDetecter(28387): at dalvik.system.NativeStart.run(Native Method)