### PR TITLE
Fullscreen for WinDX

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -632,11 +632,14 @@ namespace Microsoft.Xna.Framework
         internal void applyChanges(GraphicsDeviceManager manager)
         {
 			Platform.BeginScreenDeviceChange(GraphicsDevice.PresentationParameters.IsFullScreen);
+
+#if !(WINDOWS && DIRECTX)
+
             if (GraphicsDevice.PresentationParameters.IsFullScreen)
                 Platform.EnterFullScreen();
             else
                 Platform.ExitFullScreen();
-
+#endif
             var viewport = new Viewport(0, 0,
 			                            GraphicsDevice.PresentationParameters.BackBufferWidth,
 			                            GraphicsDevice.PresentationParameters.BackBufferHeight);

--- a/MonoGame.Framework/GamePlatform.cs
+++ b/MonoGame.Framework/GamePlatform.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Xna.Framework
         protected TimeSpan _inactiveSleepTime = TimeSpan.FromMilliseconds(20.0);
         protected bool _needsToResetElapsedTime = false;
         bool disposed;
+        protected bool _alreadyInFullScreenMode = false;
+        protected bool _alreadyInWindowedMode = false;
         protected bool IsDisposed { get { return disposed; } }
 
         #endregion

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -591,7 +591,7 @@ namespace Microsoft.Xna.Framework.Graphics
             _d3dContext = _d3dDevice.ImmediateContext.QueryInterface<SharpDX.Direct3D11.DeviceContext>();
         }
 
-        internal void CreateSizeDependentResources()
+        internal void CreateSizeDependentResources(bool useFullscreenParameter = false)
         {
             _d3dContext.OutputMerger.SetTargets((SharpDX.Direct3D11.DepthStencilView)null,
                                                 (SharpDX.Direct3D11.RenderTargetView)null);
@@ -666,6 +666,12 @@ namespace Microsoft.Xna.Framework.Graphics
                                             format,
                                             SwapChainFlags.None);
 
+                // This force to switch to fullscreen mode when hardware mode enabled(working in WindowsDX mode).
+                if (useFullscreenParameter)
+                {
+                    _swapChain.SetFullscreenState(PresentationParameters.IsFullScreen, null);
+                }
+
                 // Update Vsync setting.
                 using (var dxgiDevice = _d3dDevice.QueryInterface<SharpDX.DXGI.Device1>())
                 {
@@ -687,7 +693,11 @@ namespace Microsoft.Xna.Framework.Graphics
                     ModeDescription =
                     {
                         Format = format,
+#if WINRT
                         Scaling = DisplayModeScaling.Stretched,
+#else
+                        Scaling = DisplayModeScaling.Unspecified,
+#endif
                         Width = PresentationParameters.BackBufferWidth,
                         Height = PresentationParameters.BackBufferHeight,                        
                     },
@@ -697,7 +707,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     Usage = SharpDX.DXGI.Usage.RenderTargetOutput,
                     BufferCount = 2,
                     SwapEffect = SharpDXHelper.ToSwapEffect(PresentationParameters.PresentationInterval),
-                    IsWindowed = true,
+                    IsWindowed = useFullscreenParameter ? PresentationParameters.IsFullScreen : true
                 };
 
                 // Once the desired swap chain description is configured, it must be created on the same adapter as our D3D Device

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -457,7 +457,7 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// Gets or sets the boolean which defines how window switches from windowed to fullscreen state.
         /// "Hard" mode(true) is slow to switch, but more effecient for performance, while "soft" mode(false) is vice versa.
-        /// The default value is <c>true</c>. Can only be changed in game's constructor.
+        /// The default value is <c>true</c>. Can only be changed before graphics device is created (in game's constructor).
         /// </summary>
         public bool HardwareModeSwitch
         {
@@ -465,7 +465,7 @@ namespace Microsoft.Xna.Framework
             set
             {
                 if (_graphicsDevice == null) _hardwareModeSwitch = value;
-                else throw new InvalidOperationException("This property can only be changed in constructor.");
+                else throw new InvalidOperationException("This property can only be changed before graphics device is created(in game constructor).");
             }
         }
 

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -35,6 +35,11 @@ namespace Microsoft.Xna.Framework
         private bool _synchronizedWithVerticalRetrace = true;
         private bool _drawBegun;
         bool disposed;
+        private bool _hardwareModeSwitch = true;
+
+#if WINDOWS && DIRECTX
+        private bool _firstLaunch = true;
+#endif
 
 #if !WINRT
         private bool _wantFullScreen = false;
@@ -226,7 +231,7 @@ namespace Microsoft.Xna.Framework
             _graphicsDevice.PresentationParameters.BackBufferHeight = _preferredBackBufferHeight;
             _graphicsDevice.PresentationParameters.DepthStencilFormat = _preferredDepthStencilFormat;
             _graphicsDevice.PresentationParameters.PresentationInterval = _synchronizedWithVerticalRetrace ? PresentInterval.Default : PresentInterval.Immediate;
-            _graphicsDevice.PresentationParameters.IsFullScreen = false;
+            _graphicsDevice.PresentationParameters.IsFullScreen = _wantFullScreen;
 
             // TODO: We probably should be resetting the whole 
             // device if this changes as we are targeting a different
@@ -286,6 +291,22 @@ namespace Microsoft.Xna.Framework
             //
             TouchPanel.DisplayWidth = _graphicsDevice.PresentationParameters.BackBufferWidth;
             TouchPanel.DisplayHeight = _graphicsDevice.PresentationParameters.BackBufferHeight;
+
+#if WINDOWS && DIRECTX
+
+            if (!_firstLaunch)
+            {
+                if (IsFullScreen)
+                {
+                    _game.Platform.EnterFullScreen();
+                }
+                else
+                {
+                   _game.Platform.ExitFullScreen();
+                }
+            }
+            _firstLaunch = false;
+#endif
         }
 
         private void Initialize()
@@ -368,6 +389,10 @@ namespace Microsoft.Xna.Framework
         public void ToggleFullScreen()
         {
             IsFullScreen = !IsFullScreen;
+
+#if WINDOWS && DIRECTX
+            ApplyChanges();
+#endif
         }
 
 #if WINDOWS_STOREAPP
@@ -394,14 +419,15 @@ namespace Microsoft.Xna.Framework
 #else
                 if (_graphicsDevice != null)
                     return _graphicsDevice.PresentationParameters.IsFullScreen;
-                else
-                    return _wantFullScreen;
+                return _wantFullScreen;
 #endif
             }
             set
             {
 #if WINRT
                 // Just ignore this as it is not relevant on Windows 8
+#elif WINDOWS && DIRECTX
+                _wantFullScreen = value;
 #else
                 _wantFullScreen = value;
                 if (_graphicsDevice != null)
@@ -427,6 +453,17 @@ namespace Microsoft.Xna.Framework
                 Game.Activity.Window.SetFlags(WindowManagerFlags.ForceNotFullscreen, WindowManagerFlags.ForceNotFullscreen);
         }
 #endif
+
+        /// <summary>
+        /// Gets or sets the boolean which defines how window would be switched from windowed to fullscreen state.
+        /// "Hard" mode(true) is slow to switch but more effecient for performance, while "soft" mode(false) is vice versa.
+        /// The default value is <c>true</c>.
+        /// </summary>
+        public bool HardwareModeSwitch
+        {
+            get { return _hardwareModeSwitch;}
+            set { if (_graphicsDevice == null) _hardwareModeSwitch = value; }
+        }
 
         public bool PreferMultiSampling
         {

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -455,14 +455,18 @@ namespace Microsoft.Xna.Framework
 #endif
 
         /// <summary>
-        /// Gets or sets the boolean which defines how window would be switched from windowed to fullscreen state.
-        /// "Hard" mode(true) is slow to switch but more effecient for performance, while "soft" mode(false) is vice versa.
-        /// The default value is <c>true</c>.
+        /// Gets or sets the boolean which defines how window switches from windowed to fullscreen state.
+        /// "Hard" mode(true) is slow to switch, but more effecient for performance, while "soft" mode(false) is vice versa.
+        /// The default value is <c>true</c>. Can only be changed in game's constructor.
         /// </summary>
         public bool HardwareModeSwitch
         {
             get { return _hardwareModeSwitch;}
-            set { if (_graphicsDevice == null) _hardwareModeSwitch = value; }
+            set
+            {
+                if (_graphicsDevice == null) _hardwareModeSwitch = value;
+                else throw new InvalidOperationException("This property can only be changed in constructor.");
+            }
         }
 
         public bool PreferMultiSampling

--- a/MonoGame.Framework/Windows/WinFormsGameForm.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameForm.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Xna.Framework.Windows
         public const int WM_POINTERUP = 0x0247;
         public const int WM_POINTERDOWN = 0x0246;
         public const int WM_POINTERUPDATE = 0x0245;
-
+        public const int WM_KEYDOWN = 0x0100;
         public const int WM_TABLET_QUERYSYSTEMGESTURESTA = (0x02C0 + 12);
 
         public const int WM_SYSCOMMAND = 0x0112;
@@ -66,7 +66,23 @@ namespace Microsoft.Xna.Framework.Windows
                         m.Result = new IntPtr(flags);
                         return;
                     }
+#if (WINDOWS && DIRECTX)
+                case WM_KEYDOWN:
+                    switch (m.WParam.ToInt32())
+                    {
+                        case 0x5B:  // Left Windows Key
 
+                            if (this.WindowState == FormWindowState.Maximized)
+                            {
+                                this.WindowState = FormWindowState.Minimized;
+                            }
+ 		 
+                            break;
+                        case 0x5C: // Right Windows Key
+                            goto case 0x5B;
+                    }
+                    break;
+#endif
                 case WM_SYSCOMMAND:
 
                     var wParam = m.WParam.ToInt32();

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -120,6 +120,18 @@ namespace MonoGame.Framework
             _window.Initialize(Game.graphicsDeviceManager.PreferredBackBufferWidth, Game.graphicsDeviceManager.PreferredBackBufferHeight);
 
             base.BeforeInitialize();
+
+            #if (WINDOWS && DIRECTX)
+
+            if (Game.graphicsDeviceManager.IsFullScreen)
+            {
+                EnterFullScreen();
+            }
+            else
+            {
+                ExitFullScreen();
+            }
+#endif
         }
 
         public override void RunLoop()
@@ -151,10 +163,55 @@ namespace MonoGame.Framework
 
         public override void EnterFullScreen()
         {
+#if (WINDOWS && DIRECTX)
+            if (_alreadyInFullScreenMode)
+            {
+                return;
+            }
+
+            if (Game.graphicsDeviceManager.HardwareModeSwitch)
+            {
+                 Game.GraphicsDevice.PresentationParameters.IsFullScreen = true;
+                 Game.GraphicsDevice.CreateSizeDependentResources(true);
+                 Game.GraphicsDevice.ApplyRenderTargets(null);
+                _window._form.WindowState = FormWindowState.Maximized;
+            }
+            else
+            {
+                _window.IsBorderless = true;
+                _window._form.WindowState = FormWindowState.Maximized;
+            }
+
+            _alreadyInWindowedMode = false;
+            _alreadyInFullScreenMode = true;
+#endif
         }
 
         public override void ExitFullScreen()
         {
+#if (WINDOWS && DIRECTX)
+            if (_alreadyInWindowedMode)
+            {
+               return;
+            }
+
+            if (Game.graphicsDeviceManager.HardwareModeSwitch)
+            {
+                _window._form.WindowState = FormWindowState.Normal;
+                Game.GraphicsDevice.PresentationParameters.IsFullScreen = false;
+                Game.GraphicsDevice.CreateSizeDependentResources(true);
+                Game.GraphicsDevice.ApplyRenderTargets(null);
+            }
+            else
+            {
+                _window._form.WindowState = FormWindowState.Normal;
+                _window.IsBorderless = false;
+            }
+            ResetWindowBounds();
+
+            _alreadyInWindowedMode = true;
+            _alreadyInFullScreenMode = false;
+#endif
         }
 
         public void ResetWindowBounds()

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -205,6 +205,20 @@ namespace MonoGame.Framework
 
         private void OnActivated(object sender, EventArgs eventArgs)
         {
+#if (WINDOWS && DIRECTX)
+            if (Game.GraphicsDevice != null)
+            {
+                if (Game.graphicsDeviceManager.HardwareModeSwitch)
+                {
+                    if (!_platform.IsActive && Game.GraphicsDevice.PresentationParameters.IsFullScreen)
+                   {
+                       Game.GraphicsDevice.PresentationParameters.IsFullScreen = true;
+                       Game.GraphicsDevice.CreateSizeDependentResources(true);
+                        Game.GraphicsDevice.ApplyRenderTargets(null);
+                   }
+                }
+          }
+#endif
             _platform.IsActive = true;
         }
 
@@ -343,9 +357,11 @@ namespace MonoGame.Framework
 
                 var newWidth = _form.ClientRectangle.Width;
                 var newHeight = _form.ClientRectangle.Height;
+
+#if !(WINDOWS && DIRECTX)
                 manager.PreferredBackBufferWidth = newWidth;
                 manager.PreferredBackBufferHeight = newHeight;
-
+#endif
                 if (manager.GraphicsDevice == null)
                     return;
             }


### PR DESCRIPTION
Rebase/remake of https://github.com/mono/MonoGame/pull/3310

-Enables IsFullscreen at constructor*
-Enables IsFullscreen in any other methods with ApplyChanges*
-Enables ToggleFullscreen*

*Only for WindowsDX platform

-Added HardwareModeSwitch to GraphicsDeviceManager how to switch fullscreen("soft"(false, simple shrink up window and remove borders) or "hard"(true, hardware switch on device itself)).