### PR TITLE
WP8 Texture2D.FromStream ecception fix

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -175,9 +175,13 @@ namespace Microsoft.Xna.Framework.Graphics
             WriteableBitmap bitmap = null;
             Threading.BlockOnUIThread(() =>
             {
+                try
+                {
                     BitmapImage bitmapImage = new BitmapImage();
                     bitmapImage.SetSource(stream);
                     bitmap = new WriteableBitmap(bitmapImage);
+                }
+                catch { }
             });
 
             // Convert from ARGB to ABGR 


### PR DESCRIPTION
Catch disposed stream exceptions in WP8 Texture2D.FromStream. It cannot be caught elsewhere because it runs on a different thread.