### PR TITLE
Content pipeline fixes - getter-only properties and polymorphic generic types

### DIFF
--- a/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
+++ b/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
@@ -365,6 +365,7 @@
     <Compile Include="Serialization\Intermediate\MatrixSerializer.cs" />
     <Compile Include="Serialization\Intermediate\NamedValueDictionarySerializer.cs" />    
     <Compile Include="Serialization\Intermediate\NamespaceAliasHelper.cs" />
+    <Compile Include="Serialization\Intermediate\NonGenericIListSerializer.cs" />
 	<Compile Include="Serialization\Intermediate\NullableSerializer.cs" />
     <Compile Include="Serialization\Intermediate\PlaneSerializer.cs" />
     <Compile Include="Serialization\Intermediate\PointSerializer.cs" />

--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -544,6 +544,9 @@
 	<Content Include="Assets\Xml\21_CustomFormatting.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Assets\Xml\22_GetterOnlyProperties.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
 
     <Content Include="Assets\Fonts\Default.xnb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -547,6 +547,9 @@
     <Content Include="Assets\Xml\22_GetterOnlyProperties.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Assets\Xml\23_GetterOnlyPolymorphicArrayProperties.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
 
     <Content Include="Assets\Fonts\Default.xnb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentCompiler.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/ContentCompiler.cs
@@ -99,6 +99,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
                     if (args.Length == 0)
                         continue;
 
+                    if (!kvp.Value.IsGenericTypeDefinition)
+                        continue;
+
                     if (!args[0].IsGenericType)
                         continue;
 

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ArraySerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ArraySerializer.cs
@@ -34,6 +34,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override T[] Deserialize(IntermediateReader input, ContentSerializerAttribute format, T[] existingInstance)
         {
+            if (existingInstance != null)
+                throw new InvalidOperationException("You cannot deserialize an array into a getter-only property.");
             var result = _listSerializer.Deserialize(input, format, null);
             return result.ToArray();
         }

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateSerializer.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -158,6 +159,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
             else if (type.IsEnum)
             {
                 serializer = new EnumSerializer(type);
+            }
+            else if (typeof(IList).IsAssignableFrom(type))
+            {
+                // Special handling for non-generic IList types. By the time we get here,
+                // generic collection types will already have been handled by one of the known serializers.
+                serializer = new NonGenericIListSerializer(type);
             }
             else
             {

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateSerializer.cs
@@ -242,6 +242,21 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
                 typeName = typeName.Replace(pair.Key, pair.Value);
             var expandedName = typeName;
 
+            // If this a generic type, handle it separately.
+            if (typeName.EndsWith("]"))
+            {
+                var openBracketIndex = typeName.IndexOf("[");
+
+                var typeNameWithoutArguments = typeName.Substring(0, openBracketIndex);
+
+                var genericArgumentsString = typeName.Substring(openBracketIndex + 1, typeName.Length - openBracketIndex - 2);
+                var genericArgumentsArray = genericArgumentsString.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                var genericArguments = genericArgumentsArray.Select(FindType).ToArray();
+
+                foundType = FindType(typeNameWithoutArguments + "`" + genericArguments.Length);
+                return (foundType == null) ? null : foundType.MakeGenericType(genericArguments);
+            }
+
             foundType = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
                          from type in assembly.GetTypes()
                          where type.FullName == typeName || type.Name == typeName
@@ -256,7 +271,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
         /// <summary>
         /// Gets the (potentially) aliased name for any type.
         /// </summary>
-        internal string GetTypeName(Type type)
+        internal string GetFullTypeName(Type type)
         {
             string typeName;
 
@@ -269,7 +284,35 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
                 return typeName;
 
             // Fallback to full type name.
-            return type.FullName;
+            var typeNamespace = type.Namespace;
+            if (!string.IsNullOrEmpty(typeNamespace))
+                typeName = typeNamespace + ".";
+            typeName += GetTypeName(type);
+
+            return typeName;
+        }
+
+        /// <summary>
+        /// Returns the name of the type, without the namespace.
+        /// For generic types, we add the type parameters in square brackets.
+        /// i.e. List&lt;int&gt; becomes List[int]
+        /// </summary>
+        internal string GetTypeName(Type type)
+        {
+            if (type.IsGenericType)
+            {
+                var typeName = type.Name;
+                int genericBacktickIndex = typeName.IndexOf("`");
+                if (genericBacktickIndex >= 0)
+                    typeName = typeName.Substring(0, genericBacktickIndex);
+
+                var result = typeName + "[";
+                result += string.Join(",", type.GetGenericArguments().Select(GetFullTypeName));
+                result += "]";
+                return result;
+            }
+
+            return type.Name;
         }
 
         internal bool AlreadyScanned(object value)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateSerializer.cs
@@ -319,6 +319,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
                 return result;
             }
 
+            if (type.IsArray)
+                return GetTypeName(type.GetElementType()) + "[]";
+
+            if (type.IsNested)
+                return type.DeclaringType.Name + "+" + type.Name;
+
             return type.Name;
         }
 

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateWriter.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         public void WriteTypeName(Type type)
         {
-            Xml.WriteString(Serializer.GetTypeName(type));
+            Xml.WriteString(Serializer.GetFullTypeName(type));
         }
     }        
 }

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/NamespaceAliasHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/NamespaceAliasHelper.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
                 AliasedNamespace namespaceAlias;
                 if (_namespaceLookupReverse.TryGetValue(type.Namespace, out namespaceAlias))
                 {
-                    typeName = namespaceAlias.Alias + ":" + namespaceAlias.TypePrefix + type.Name;
+                    typeName = namespaceAlias.Alias + ":" + namespaceAlias.TypePrefix + _serializer.GetTypeName(type);
                     return true;
                 }
             }

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/NonGenericIListSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/NonGenericIListSerializer.cs
@@ -1,0 +1,56 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Collections;
+
+namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
+{
+    class NonGenericIListSerializer : ContentTypeSerializer
+    {
+        public NonGenericIListSerializer(Type targetType) :
+            base(targetType, targetType.Name)
+        {
+        }
+
+        public override bool CanDeserializeIntoExistingObject
+        {
+            get { return true; }
+        }
+
+        public override bool ObjectIsEmpty(object value)
+        {
+            return ((IList) value).Count == 0;
+        }
+
+        protected internal override object Deserialize(IntermediateReader input, ContentSerializerAttribute format, object existingInstance)
+        {
+            var result = (IList) (existingInstance ?? Activator.CreateInstance(TargetType));
+
+            // Create the item serializer attribute.
+            var itemFormat = new ContentSerializerAttribute();
+            itemFormat.ElementName = format.CollectionItemName;
+
+            // Read all the items.
+            while (input.MoveToElement(itemFormat.ElementName))
+            {
+                var value = input.ReadObject<object>(itemFormat);
+                result.Add(value);
+            }
+
+            return result;
+        }
+
+        protected internal override void Serialize(IntermediateWriter output, object value, ContentSerializerAttribute format)
+        {
+            // Create the item serializer attribute.
+            var itemFormat = new ContentSerializerAttribute();
+            itemFormat.ElementName = format.CollectionItemName;
+
+            // Read all the items.
+            foreach (var item in (IList) value)
+                output.WriteObject(item, itemFormat);
+        }
+    }
+}

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ReflectiveSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ReflectiveSerializer.cs
@@ -3,7 +3,6 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.CodeDom;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -136,7 +135,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         public override bool CanDeserializeIntoExistingObject
         {
-            get { return TargetType.IsClass; }
+            get { return TargetType.IsClass && TargetType.BaseType != null; }
         }
 
         protected internal override object Deserialize(IntermediateReader input, ContentSerializerAttribute format, object existingInstance)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ReflectiveSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ReflectiveSerializer.cs
@@ -60,10 +60,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
                     if (prop.GetGetMethod() == null)
                         return false;
 
-                    // If there is no public setter and the property is a system
-                    // type then we have no way for it to be deserialized.
-                    if (prop.GetSetMethod() == null &&
-                        prop.PropertyType.Namespace == "System")
+                    // If there is no public setter, and we don't have a type serializer 
+                    // that can deserialize into an existing object, then we have no way 
+                    // for it to be deserialized.
+                    if (prop.GetSetMethod() == null && !serializer.GetTypeSerializer(prop.PropertyType).CanDeserializeIntoExistingObject)
                         return false;
 
                     // Don't serialize or deserialize indexers.

--- a/MonoGame.Framework/Content/ContentExtensions.cs
+++ b/MonoGame.Framework/Content/ContentExtensions.cs
@@ -59,5 +59,14 @@ namespace Microsoft.Xna.Framework.Content
             return type.GetFields(attrs);
 #endif
         }
+
+        public static bool IsClass(this Type type)
+        {
+#if WINRT
+            return type.GetTypeInfo().IsClass;
+#else
+            return type.IsClass;
+#endif
+        }
     }
 }

--- a/MonoGame.Framework/Content/ContentReaders/DictionaryReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/DictionaryReader.cs
@@ -66,6 +66,11 @@ namespace Microsoft.Xna.Framework.Content
 			valueReader = manager.GetTypeReader(valueType);
         }
 
+        public override bool CanDeserializeIntoExistingObject
+        {
+            get { return true; }
+        }
+
         protected internal override Dictionary<TKey, TValue> Read(ContentReader input, Dictionary<TKey, TValue> existingInstance)
         {
             int count = input.ReadInt32();

--- a/MonoGame.Framework/Content/ContentReaders/ListReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ListReader.cs
@@ -48,6 +48,10 @@ namespace Microsoft.Xna.Framework.Content
 			elementReader = manager.GetTypeReader(readerType);
         }
 
+        public override bool CanDeserializeIntoExistingObject
+        {
+            get { return true; }
+        }
 
         protected internal override List<T> Read(ContentReader input, List<T> existingInstance)
         {

--- a/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Xna.Framework.Content
 
         public override bool CanDeserializeIntoExistingObject
         {
-            get { return TargetType.IsClass; }
+            get { return TargetType.IsClass(); }
         }
 
         protected internal override void Initialize(ContentTypeReaderManager manager)

--- a/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/ReflectiveReader.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using Microsoft.Xna.Framework.Utilities;
 
@@ -24,6 +25,11 @@ namespace Microsoft.Xna.Framework.Content
         internal ReflectiveReader() 
             : base(typeof(T))
         {
+        }
+
+        public override bool CanDeserializeIntoExistingObject
+        {
+            get { return TargetType.IsClass; }
         }
 
         protected internal override void Initialize(ContentTypeReaderManager manager)
@@ -70,15 +76,8 @@ namespace Microsoft.Xna.Framework.Content
                     return null;
 
                 // Skip over indexer properties.
-                if (property.Name == "Item")
-                {
-                    var getMethod = ReflectionHelpers.GetPropertyGetMethod(property);
-                    var setMethod = ReflectionHelpers.GetPropertySetMethod(property);
-
-                    if ((getMethod != null && getMethod.GetParameters().Length > 0) ||
-                        (setMethod != null && setMethod.GetParameters().Length > 0))
-                        return null;
-                }
+                if (property.GetIndexParameters().Any())
+                    return null;
             }
 
             // Are we explicitly asked to ignore this item?
@@ -95,10 +94,15 @@ namespace Microsoft.Xna.Framework.Content
                     if (!ReflectionHelpers.PropertyIsPublic(property))
                         return null;
 
-                    // If the read-only property has a type reader then
-                    // it is safe to deserialize into the existing type.
-                    if (!property.CanWrite && manager.GetTypeReader(property.PropertyType) == null)
-                        return null;
+                    // If the read-only property has a type reader,
+                    // and CanDeserializeIntoExistingObject is true,
+                    // then it is safe to deserialize into the existing object.
+                    if (!property.CanWrite)
+                    {
+                        var typeReader = manager.GetTypeReader(property.PropertyType);
+                        if (typeReader == null || !typeReader.CanDeserializeIntoExistingObject)
+                            return null;
+                    }
                 }
                 else
                 {

--- a/MonoGame.Framework/Content/ContentTypeReader.cs
+++ b/MonoGame.Framework/Content/ContentTypeReader.cs
@@ -56,6 +56,11 @@ namespace Microsoft.Xna.Framework.Content
 
         #region Public Properties
 
+        public virtual bool CanDeserializeIntoExistingObject
+        {
+            get { return false; }
+        }
+
         public Type TargetType
         {
             get { return this.targetType; }

--- a/MonoGame.Framework/Utilities/ReflectionHelpers.cs
+++ b/MonoGame.Framework/Utilities/ReflectionHelpers.cs
@@ -98,7 +98,9 @@ namespace Microsoft.Xna.Framework.Utilities
 		}
 
         /// <summary>
-        /// Returns true if the get and set methods of the given property exist and are public
+        /// Returns true if the get method of the given property exist and are public.
+        /// Note that we allow a getter-only property to be serialized (and deserialized),
+        /// *if* CanDeserializeIntoExistingObject is true for the property type.
         /// </summary>
         public static bool PropertyIsPublic(PropertyInfo property)
         {
@@ -109,10 +111,6 @@ namespace Microsoft.Xna.Framework.Utilities
 
             var getMethod = GetPropertyGetMethod(property);
             if (getMethod == null || !getMethod.IsPublic)
-                return false;
-
-            var setMethod = GetPropertySetMethod(property);
-            if (setMethod == null || !setMethod.IsPublic)
                 return false;
 
             return true;

--- a/Test/Assets/Xml/05_RenamingXmlElements.xml
+++ b/Test/Assets/Xml/05_RenamingXmlElements.xml
@@ -3,5 +3,8 @@
   <Asset Type="RenamingXmlElements">
     <ShawnSaysHello>world</ShawnSaysHello>
     <ElvesAreCool>23</ElvesAreCool>
+    <Speed>80.2</Speed>
+    <Organic>true</Organic>
+    <Dimensions>32 32</Dimensions>
   </Asset>
 </XnaContent>

--- a/Test/Assets/Xml/13_PolymorphicTypes.xml
+++ b/Test/Assets/Xml/13_PolymorphicTypes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<XnaContent>
+<XnaContent xmlns:Generic="System.Collections.Generic">
   <Asset Type="PolymorphicTypes">
     <Hello Type="string">World</Hello>
     <Elf Type="int">23</Elf>
@@ -25,5 +25,20 @@
         <Value>true</Value>
       </Item>
     </UntypedArray>
+    <IntCollection Type="Generic:List[int]">1 4 6</IntCollection>
+    <UntypedDictionary Type="Generic:Dictionary[int,PolymorphicA]">
+      <Item>
+        <Key>1</Key>
+        <Value>
+          <Value>true</Value>
+        </Value>
+      </Item>
+      <Item>
+        <Key>5</Key>
+        <Value>
+          <Value>false</Value>
+        </Value>
+      </Item>
+    </UntypedDictionary>
   </Asset>
 </XnaContent>

--- a/Test/Assets/Xml/22_GetterOnlyProperties.xml
+++ b/Test/Assets/Xml/22_GetterOnlyProperties.xml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<XnaContent>
+  <Asset Type="GetterOnlyProperties">
+    <IntList>1 2 3</IntList>
+    <IntStringDictionary>
+      <Item>
+        <Key>1</Key>
+        <Value>Foo</Value>
+      </Item>
+      <Item>
+        <Key>5</Key>
+        <Value>Bar</Value>
+      </Item>
+    </IntStringDictionary>
+    <CustomClass>
+      <A>42</A>
+    </CustomClass>
+  </Asset>
+</XnaContent>

--- a/Test/Assets/Xml/23_GetterOnlyPolymorphicArrayProperties.xml
+++ b/Test/Assets/Xml/23_GetterOnlyPolymorphicArrayProperties.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<XnaContent>
+  <Asset Type="GetterOnlyPolymorphicArrayProperties">
+    <CustomClassArrayAsIList Type="GetterOnlyPolymorphicArrayProperties+AnotherClass[]">
+      <Item>
+        <A>42</A>
+      </Item>
+    </CustomClassArrayAsIList>
+  </Asset>
+</XnaContent>

--- a/Test/ContentPipeline/AssetTestClasses.cs
+++ b/Test/ContentPipeline/AssetTestClasses.cs
@@ -232,6 +232,8 @@ public class PolymorphicTypes
     public object Elf;
     public PolymorphicA[] TypedArray;
     public Array UntypedArray;
+    public ICollection<int> IntCollection;
+    public object UntypedDictionary;
 }
 #endregion
 

--- a/Test/ContentPipeline/AssetTestClasses.cs
+++ b/Test/ContentPipeline/AssetTestClasses.cs
@@ -9,7 +9,6 @@ using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
-using System.Runtime.Remoting.Messaging;
 
 #region The Basics
 public class TheBasics
@@ -318,6 +317,7 @@ class GetterOnlyProperties
     private readonly List<int> _intList;
     private readonly Dictionary<int, string> _intStringDictionary;
     private readonly AnotherClass _customClass;
+    private readonly AnotherClass[] _customClassArray;
     private readonly AnotherStruct _customStruct;
 
     public int IntValue
@@ -352,6 +352,11 @@ class GetterOnlyProperties
         get { return _customClass; }
     }
 
+    public AnotherClass[] CustomClassArray
+    {
+        get { return _customClassArray; }
+    }
+
     public struct AnotherStruct
     {
         public int A;
@@ -368,6 +373,7 @@ class GetterOnlyProperties
         IntStringDictionaryWithPrivateSetter = new Dictionary<int, string>();
         _intStringDictionary = new Dictionary<int, string>();
         _customClass = new AnotherClass();
+        _customClassArray = new [] { new AnotherClass { A = 42 } };
         _customStruct = new AnotherStruct();
     }
 }

--- a/Test/ContentPipeline/AssetTestClasses.cs
+++ b/Test/ContentPipeline/AssetTestClasses.cs
@@ -9,6 +9,7 @@ using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
+using System.Runtime.Remoting.Messaging;
 
 #region The Basics
 public class TheBasics
@@ -306,6 +307,67 @@ class ExtendedFontDescription : FontDescription
 class SystemTypes
 {
     public TimeSpan TimeSpan;
+}
+#endregion
+
+#region GetterOnlyProperties
+class GetterOnlyProperties
+{
+    private readonly List<int> _intList;
+    private readonly Dictionary<int, string> _intStringDictionary;
+    private readonly AnotherClass _customClass;
+    private readonly AnotherStruct _customStruct;
+
+    public int IntValue
+    {
+        get { return 0; }
+    }
+
+    public Vector2 Dimensions
+    {
+        get { return new Vector2(16, 16); }
+    }
+
+    public List<int> IntList
+    {
+        get { return _intList; }
+    }
+
+    public Dictionary<int, string> IntStringDictionaryWithPrivateSetter { get; private set; }
+
+    public Dictionary<int, string> IntStringDictionary
+    {
+        get { return _intStringDictionary; }
+    }
+
+    public class AnotherClass
+    {
+        public int A;
+    }
+
+    public AnotherClass CustomClass
+    {
+        get { return _customClass; }
+    }
+
+    public struct AnotherStruct
+    {
+        public int A;
+    }
+
+    public AnotherStruct CustomStruct
+    {
+        get { return _customStruct; }
+    }
+
+    public GetterOnlyProperties()
+    {
+        _intList = new List<int>();
+        IntStringDictionaryWithPrivateSetter = new Dictionary<int, string>();
+        _intStringDictionary = new Dictionary<int, string>();
+        _customClass = new AnotherClass();
+        _customStruct = new AnotherStruct();
+    }
 }
 #endregion
 

--- a/Test/ContentPipeline/AssetTestClasses.cs
+++ b/Test/ContentPipeline/AssetTestClasses.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Collections;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Content.Pipeline;
@@ -352,7 +353,17 @@ class GetterOnlyProperties
         get { return _customClass; }
     }
 
+    public object UntypedCustomClass
+    {
+        get { return _customClass; }
+    }
+
     public AnotherClass[] CustomClassArray
+    {
+        get { return _customClassArray; }
+    }
+
+    public object UntypedCustomClassArray
     {
         get { return _customClassArray; }
     }
@@ -375,6 +386,28 @@ class GetterOnlyProperties
         _customClass = new AnotherClass();
         _customClassArray = new [] { new AnotherClass { A = 42 } };
         _customStruct = new AnotherStruct();
+    }
+}
+#endregion
+
+#region GetterOnlyPolymorphicArrayProperties
+class GetterOnlyPolymorphicArrayProperties
+{
+    private readonly AnotherClass[] _customClassArray;
+
+    public class AnotherClass
+    {
+        public int A;
+    }
+
+    public IList CustomClassArrayAsIList
+    {
+        get { return _customClassArray; }
+    }
+
+    public GetterOnlyPolymorphicArrayProperties()
+    {
+        _customClassArray = new[] { new AnotherClass { A = 42 } };
     }
 }
 #endregion

--- a/Test/ContentPipeline/AssetTestClasses.cs
+++ b/Test/ContentPipeline/AssetTestClasses.cs
@@ -97,6 +97,25 @@ public class RenamingXmlElements
 
     [ContentSerializer(ElementName = "ElvesAreCool")]
     public int elf;
+
+    [ContentSerializer(ElementName = "Speed")]
+    public float speed;
+
+    [ContentSerializer(ElementName = "Organic")]
+    public bool isOrganic;
+
+    [ContentSerializer(ElementName = "Dimensions")]
+    private Vector2 dimensions;
+
+    public Vector2 Dimensions
+    {
+        get { return dimensions; }
+    }
+
+    internal void SetDimensions(Vector2 value)
+    {
+        dimensions = value;
+    }
 }
 #endregion
 

--- a/Test/ContentPipeline/IntermediateDeserializerTest.cs
+++ b/Test/ContentPipeline/IntermediateDeserializerTest.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Web;
 using System.Xml;
 using Microsoft.Xna.Framework;
@@ -308,6 +309,19 @@ namespace MonoGame.Tests.ContentPipeline
                 Assert.AreEqual(true, ((PolymorphicB)polymorphicTypes.UntypedArray.GetValue(1)).Value);
                 Assert.IsAssignableFrom<PolymorphicC>(polymorphicTypes.UntypedArray.GetValue(2));
                 Assert.AreEqual(true, ((PolymorphicC)polymorphicTypes.UntypedArray.GetValue(2)).Value);
+
+                Assert.NotNull(polymorphicTypes.IntCollection);
+                Assert.IsInstanceOf<List<int>>(polymorphicTypes.IntCollection);
+                Assert.AreEqual(3, polymorphicTypes.IntCollection.Count);
+                Assert.AreEqual(1, polymorphicTypes.IntCollection.ElementAt(0));
+                Assert.AreEqual(4, polymorphicTypes.IntCollection.ElementAt(1));
+                Assert.AreEqual(6, polymorphicTypes.IntCollection.ElementAt(2));
+
+                Assert.NotNull(polymorphicTypes.UntypedDictionary);
+                Assert.IsInstanceOf<Dictionary<int, PolymorphicA>>(polymorphicTypes.UntypedDictionary);
+                Assert.AreEqual(2, ((Dictionary<int, PolymorphicA>) polymorphicTypes.UntypedDictionary).Count);
+                Assert.AreEqual(true, ((Dictionary<int, PolymorphicA>) polymorphicTypes.UntypedDictionary)[1].Value);
+                Assert.AreEqual(false, ((Dictionary<int, PolymorphicA>) polymorphicTypes.UntypedDictionary)[5].Value);
             });
         }
 

--- a/Test/ContentPipeline/IntermediateDeserializerTest.cs
+++ b/Test/ContentPipeline/IntermediateDeserializerTest.cs
@@ -161,6 +161,9 @@ namespace MonoGame.Tests.ContentPipeline
             {
                 Assert.AreEqual("world", renaming.hello);
                 Assert.AreEqual(23, renaming.elf);
+                Assert.AreEqual(80.2f, renaming.speed);
+                Assert.AreEqual(true, renaming.isOrganic);
+                Assert.AreEqual(new Vector2(32, 32), renaming.Dimensions);
             });
         }
 

--- a/Test/ContentPipeline/IntermediateDeserializerTest.cs
+++ b/Test/ContentPipeline/IntermediateDeserializerTest.cs
@@ -500,5 +500,19 @@ namespace MonoGame.Tests.ContentPipeline
                 Assert.AreEqual(42, getterOnlyProps.CustomClass.A);
             });
         }
+
+        [Test]
+        public void GetterOnlyPolymorphicArrayProperties()
+        {
+            var filePath = Paths.Xml("23_GetterOnlyPolymorphicArrayProperties.xml");
+            using (var reader = XmlReader.Create(filePath))
+            {
+                // This should throw an InvalidContentException as the
+                // xml tries to deserialize into an IList property
+                // but the property value is actually an Array.
+                Assert.Throws<InvalidOperationException>(() =>
+                    IntermediateSerializer.Deserialize<GetterOnlyPolymorphicArrayProperties>(reader, filePath));
+            }
+        }
     }
 }

--- a/Test/ContentPipeline/IntermediateDeserializerTest.cs
+++ b/Test/ContentPipeline/IntermediateDeserializerTest.cs
@@ -469,5 +469,22 @@ namespace MonoGame.Tests.ContentPipeline
                 Assert.AreEqual(new Vector2(0, 7), customFormatting.Vector2ListSpaced[2]);
             });
         }
+
+        [Test]
+        public void GetterOnlyProperties()
+        {
+            DeserializeCompileAndLoad<GetterOnlyProperties>("22_GetterOnlyProperties.xml", getterOnlyProps =>
+            {
+                Assert.AreEqual(3, getterOnlyProps.IntList.Count);
+                Assert.AreEqual(1, getterOnlyProps.IntList[0]);
+                Assert.AreEqual(2, getterOnlyProps.IntList[1]);
+                Assert.AreEqual(3, getterOnlyProps.IntList[2]);
+                Assert.AreEqual(0, getterOnlyProps.IntStringDictionaryWithPrivateSetter.Count);
+                Assert.AreEqual(2, getterOnlyProps.IntStringDictionary.Count);
+                Assert.AreEqual("Foo", getterOnlyProps.IntStringDictionary[1]);
+                Assert.AreEqual("Bar", getterOnlyProps.IntStringDictionary[5]);
+                Assert.AreEqual(42, getterOnlyProps.CustomClass.A);
+            });
+        }
     }
 }

--- a/Test/ContentPipeline/IntermediateSerializerTest.cs
+++ b/Test/ContentPipeline/IntermediateSerializerTest.cs
@@ -400,5 +400,24 @@ namespace MonoGame.Tests.ContentPipeline
                 TimeSpan = TimeSpan.FromSeconds(42.5f)
             });
         }
+
+        // Test 21 (CustomFormatting) specifically tests IntermediateDeserializer,
+        // and isn't relevant for IntermediateSerializer.
+
+        [Test]
+        public void GetterOnlyProperties()
+        {
+            var value = new GetterOnlyProperties();
+            value.IntList.Add(1);
+            value.IntList.Add(2);
+            value.IntList.Add(3);
+            value.IntStringDictionary.Add(1, "Foo");
+            value.IntStringDictionary.Add(5, "Bar");
+            value.IntStringDictionaryWithPrivateSetter.Add(2, "Baz");
+            value.IntStringDictionaryWithPrivateSetter.Add(6, "Shawn");
+            value.CustomClass.A = 42;
+
+            SerializeAndAssert("22_GetterOnlyProperties.xml", value);
+        }
     }
 }

--- a/Test/ContentPipeline/IntermediateSerializerTest.cs
+++ b/Test/ContentPipeline/IntermediateSerializerTest.cs
@@ -266,6 +266,14 @@ namespace MonoGame.Tests.ContentPipeline
                     new PolymorphicA { Value = true },
                     new PolymorphicB { Value = true },
                     new PolymorphicC { Value = true }
+                },
+
+                IntCollection = new List<int> { 1, 4, 6 },
+
+                UntypedDictionary = new Dictionary<int, PolymorphicA>
+                {
+                    { 1, new PolymorphicA { Value = true } },
+                    { 5, new PolymorphicA { Value = false } }
                 }
             });
         }

--- a/Test/ContentPipeline/IntermediateSerializerTest.cs
+++ b/Test/ContentPipeline/IntermediateSerializerTest.cs
@@ -145,11 +145,15 @@ namespace MonoGame.Tests.ContentPipeline
         [Test]
         public void RenamingXmlElements()
         {
-            SerializeAndAssert("05_RenamingXmlElements.xml", new RenamingXmlElements
+            var value = new RenamingXmlElements
             {
                 hello = "world",
-                elf = 23
-            });
+                elf = 23,
+                speed = 80.2f,
+                isOrganic = true
+            };
+            value.SetDimensions(new Vector2(32, 32));
+            SerializeAndAssert("05_RenamingXmlElements.xml", value);
         }
 
         [Test]

--- a/Test/ContentPipeline/IntermediateSerializerTest.cs
+++ b/Test/ContentPipeline/IntermediateSerializerTest.cs
@@ -427,5 +427,12 @@ namespace MonoGame.Tests.ContentPipeline
 
             SerializeAndAssert("22_GetterOnlyProperties.xml", value);
         }
+
+        [Test]
+        public void GetterOnlyPolymorphicArrayProperties()
+        {
+            var value = new GetterOnlyPolymorphicArrayProperties();
+            SerializeAndAssert("23_GetterOnlyPolymorphicArrayProperties.xml", value);
+        }
     }
 }

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -578,6 +578,9 @@
     <Content Include="Assets\Xml\21_CustomFormatting.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Assets\Xml\22_GetterOnlyProperties.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Assets\Xml\19_FontDescription.xml">

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -581,6 +581,9 @@
     <Content Include="Assets\Xml\22_GetterOnlyProperties.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Assets\Xml\23_GetterOnlyPolymorphicArrayProperties.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Assets\Xml\19_FontDescription.xml">


### PR DESCRIPTION
* Added `ContentTypeReader.CanDeserializeIntoExistingObject`, to match `ContentTypeWriter` and `ContentTypeSerializer` properties of the same name
* Fixed a bug in `ContentCompiler.GetTypeWriter` if it was called multiple times for different closed generic types based on the same open generic type
* Added support for polymorphic generic types in `IntermediateSerializer` - i.e. storing a `List<string>` in property of type `object`
* Implemented "proper" check in `ReflectiveSerializer` for whether we can deserialize into an existing object, instead of basing it on being one of the `System.*` types - fixes 2nd issue in #3404 (note that this was already done properly in `ReflectiveWriter`, and in fact there would be some value in sharing some of the code to check whether properties can be serialized)
* Used `property.GetIndexParameters()` in `ReflectiveReader` instead of the more complicated previous check
* Added tests, or improved existing tests, for most of the above

These issues are fairly closely related, so hopefully it's okay bundling them into one PR. (Actually, the fix for the first problem uncovered another bug, and the fix for that uncovered a subsequent bug, etc.)