### PR TITLE
Fixed key combo incorrect behavior

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -719,7 +719,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 using (var dxgiFactory = dxgiAdapter.GetParent<SharpDX.DXGI.Factory1>())
                 {
                     _swapChain = new SwapChain(dxgiFactory, dxgiDevice, desc);
-
+                    dxgiFactory.MakeWindowAssociation(PresentationParameters.DeviceWindowHandle, WindowAssociationFlags.IgnoreAll);
                     // If VSync is disabled, Ensure that DXGI does not queue more than one frame at a time. This 
                     // both reduces latency and ensures that the application will only render 
                     // after each VSync, minimizing power consumption.


### PR DESCRIPTION
I finally found the fix for https://github.com/mono/MonoGame/issues/3501. The users of MonoGame are able to write their own key combo instead of fight with predefined one. Without this fix DXGI will intercept some key pressing(Alt+enter or printscreen for example) and do something uncontrollable for developers.