### PR TITLE
Catch disposed stream exceptions in WP8 Texture2D.Reload

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -395,16 +395,20 @@ namespace Microsoft.Xna.Framework.Graphics
 #if WINDOWS_PHONE
             Deployment.Current.Dispatcher.BeginInvoke(() =>
             {
-                BitmapImage bitmapImage = new BitmapImage();
-                bitmapImage.SetSource(textureStream);
-                WriteableBitmap bitmap = new WriteableBitmap(bitmapImage);
+                try
+                {
+                    BitmapImage bitmapImage = new BitmapImage();
+                    bitmapImage.SetSource(textureStream);
+                    WriteableBitmap bitmap = new WriteableBitmap(bitmapImage);
 
-                // Convert from ARGB to ABGR 
-                ConvertToABGR(bitmap.PixelHeight, bitmap.PixelWidth, bitmap.Pixels);
+                    // Convert from ARGB to ABGR 
+                    ConvertToABGR(bitmap.PixelHeight, bitmap.PixelWidth, bitmap.Pixels);
 
-                this.SetData<int>(bitmap.Pixels);
+                    this.SetData<int>(bitmap.Pixels);
 
-                textureStream.Dispose();
+                    textureStream.Dispose();
+                }
+                catch { }
             });
 #endif
         }


### PR DESCRIPTION
Cannot be caught elsewhere because it runs on a different thread

Pretty much the same as https://github.com/mono/MonoGame/pull/3499