### PR TITLE
Move GraphicsResource list to GraphicsDevice

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -97,6 +97,14 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         internal Dictionary<int, Effect> EffectCache;
 
+        // Resources may be added to and removed from the list from many threads.
+        private readonly object _resourcesLock = new object();
+
+        // Use WeakReference for the global resources list as we do not know when a resource
+        // may be disposed and collected. We do not want to prevent a resource from being
+        // collected by holding a strong reference to it in this list.
+        private readonly List<WeakReference> _resources = new List<WeakReference>();
+
 		// TODO Graphics Device events need implementing
 		public event EventHandler<EventArgs> DeviceLost;
 		public event EventHandler<EventArgs> DeviceReset;
@@ -419,7 +427,16 @@ namespace Microsoft.Xna.Framework.Graphics
                 if (disposing)
                 {
                     // Dispose of all remaining graphics resources before disposing of the graphics device
-                    GraphicsResource.DisposeAll();
+                    lock (_resourcesLock)
+                    {
+                        foreach (var resource in _resources.ToArray())
+                        {
+                            var target = resource.Target as IDisposable;
+                            if (target != null)
+                                target.Dispose();
+                        }
+                        _resources.Clear();
+                    }
 
                     // Clear the effect cache.
                     EffectCache.Clear();
@@ -428,6 +445,22 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
 
                 _isDisposed = true;
+            }
+        }
+
+        internal void AddResourceReference(WeakReference resourceReference)
+        {
+            lock (_resourcesLock)
+            {
+                _resources.Add(resourceReference);
+            }
+        }
+
+        internal void RemoveResourceReference(WeakReference resourceReference)
+        {
+            lock (_resourcesLock)
+            {
+                _resources.Remove(resourceReference);
             }
         }
 
@@ -476,7 +509,18 @@ namespace Microsoft.Xna.Framework.Graphics
             if (DeviceResetting != null)
                 DeviceResetting(this, EventArgs.Empty);
 
-            GraphicsResource.DoGraphicsDeviceResetting();
+            lock (_resourcesLock)
+            {
+                foreach (var resource in _resources)
+                {
+                    var target = resource.Target as GraphicsResource;
+                    if (target != null)
+                        target.GraphicsDeviceResetting();
+                }
+
+                // Remove references to resources that have been garbage collected.
+                _resources.RemoveAll(wr => !wr.IsAlive);
+            }
         }
 
         /// <summary>

--- a/MonoGame.Framework/Graphics/GraphicsResource.cs
+++ b/MonoGame.Framework/Graphics/GraphicsResource.cs
@@ -39,21 +39,13 @@
 #endregion License
 
 using System;
-using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
     public abstract class GraphicsResource : IDisposable
     {
         bool disposed;
-        
-        // Resources may be added to and removed from the list from many threads.
-        static object resourcesLock = new object();
-
-        // Use WeakReference for the global resources list as we do not know when a resource
-        // may be disposed and collected. We do not want to prevent a resource from being
-        // collected by holding a strong reference to it in this list.
-        static List<WeakReference> resources = new List<WeakReference>();
 
         // The GraphicsDevice property should only be accessed in Dispose(bool) if the disposing
         // parameter is true. If disposing is false, the GraphicsDevice may or may not be
@@ -64,11 +56,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal GraphicsResource()
         {
-            lock (resourcesLock)
-            {
-                _selfReference = new WeakReference(this);
-                resources.Add(_selfReference);
-            }
+            
         }
 
         ~GraphicsResource()
@@ -86,39 +74,6 @@ namespace Microsoft.Xna.Framework.Graphics
         internal protected virtual void GraphicsDeviceResetting()
         {
 
-        }
-
-        internal static void DoGraphicsDeviceResetting()
-        {
-            lock (resourcesLock)
-            {
-                foreach (var resource in resources)
-                {
-                    var target = resource.Target;
-                    if (target != null)
-                        (target as GraphicsResource).GraphicsDeviceResetting();
-                }
-
-                // Remove references to resources that have been garbage collected.
-                resources.RemoveAll(wr => !wr.IsAlive);
-            }
-        }
-
-        /// <summary>
-        /// Dispose all graphics resources remaining in the global resources list.
-        /// </summary>
-        internal static void DisposeAll()
-        {
-            lock (resourcesLock)
-            {
-                foreach (var resource in resources.ToArray())
-                {
-                    var target = resource.Target;
-                    if (target != null)
-                        (target as IDisposable).Dispose();
-                }
-                resources.Clear();
-            }
         }
 
         public void Dispose()
@@ -152,10 +107,8 @@ namespace Microsoft.Xna.Framework.Graphics
                     Disposing(this, EventArgs.Empty);
 
                 // Remove from the global list of graphics resources
-                lock (resourcesLock)
-                {
-                    resources.Remove(_selfReference);
-                }
+                if (graphicsDevice != null)
+                    graphicsDevice.RemoveResourceReference(_selfReference);
 
                 _selfReference = null;
                 graphicsDevice = null;
@@ -174,7 +127,23 @@ namespace Microsoft.Xna.Framework.Graphics
 
             internal set
             {
+                Debug.Assert(value != null);
+
+                if (graphicsDevice == value)
+                    return;
+
+                // VertexDeclaration objects can be bound to multiple GraphicsDevice objects
+                // during their lifetime. But only one GraphicsDevice should retain ownership.
+                if (graphicsDevice != null)
+                {
+                    graphicsDevice.RemoveResourceReference(_selfReference);
+                    _selfReference = null;
+                }
+
                 graphicsDevice = value;
+
+                _selfReference = new WeakReference(this);
+                graphicsDevice.AddResourceReference(_selfReference);
             }
 		}
 		

--- a/Tools/2MGFX/MonoGame.Framework/GraphicsDevice.cs
+++ b/Tools/2MGFX/MonoGame.Framework/GraphicsDevice.cs
@@ -1,7 +1,18 @@
-﻿namespace Microsoft.Xna.Framework.Graphics
+﻿using System;
+
+namespace Microsoft.Xna.Framework.Graphics
 {
     // Dummy class for 2MGFX to compile.
     public class GraphicsDevice
     {
+        internal void AddResourceReference(WeakReference resourceReference)
+        {
+            
+        }
+
+        internal void RemoveResourceReference(WeakReference resourceReference)
+        {
+            
+        }
     }
 }


### PR DESCRIPTION
This changes the existing behaviour somewhat: before this change, the `GraphicsResource` **constructor** added objects to the static `GraphicsResource.resources` list. After this change, objects are only added to the `GraphicsDevice._resources` list when their `GraphicsDevice` property is set.

Most classes that derive from `GraphicsResource` set the `GraphicsDevice` in their constructor. So there's no actual change there. AFAIK, the only classes that do something different are the state classes - `BlendState`, `DepthStencilState`, `RasterizerState`, `SamplerState` - and `VertexDeclaration`. These classes have their `GraphicsDevice` properties set when they are first bound to a device. So they won't be added to the "to dispose" list until they are bound to a device - but I think that's fine, because there's also nothing to dispose of until they are bound to a device.

In the case of `VertexDeclaration`, it has a similar **potential** issue to the one I've just fixed for the static state objects. But I *think* that's okay, because we don't actually create any device-specific objects in `VertexDeclaration` objects themselves, as far as I can tell.

Anyway, it's enough of a change that I'd appreciate one or two people having a good look at this.