### PR TITLE
Handle null shared resources in IntermediateSerializer

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateReader.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateReader.cs
@@ -138,6 +138,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
                 str = Xml.ReadElementContentAsString();
             }
+
+            if (string.IsNullOrEmpty(str))
+                return;
             
             // Do we already have one for this?
             Action<object> prevFixup;
@@ -174,8 +177,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
             // Execute the fixups.
             foreach (var fixup in _resourceFixups)
             {
-                var resouce = resources[fixup.Key];
-                fixup.Value(resouce);
+                object resource;
+                if (!resources.TryGetValue(fixup.Key, out resource))
+                    throw new InvalidContentException("Missing shared resource \"" + fixup.Key + "\".");
+                fixup.Value(resource);
             }
         }
 

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateWriter.cs
@@ -148,6 +148,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         private string GetSharedResourceID(object value)
         {
+            if (value == null)
+                return null;
+
             string id;
             if (!_sharedResources.TryGetValue(value, out id))
                 _sharedResources.Add(value, id = "#Resource" + (_sharedResources.Count + 1));

--- a/Test/Assets/Xml/16_SharedResources.xml
+++ b/Test/Assets/Xml/16_SharedResources.xml
@@ -2,17 +2,38 @@
 <XnaContent>
   <Asset Type="SharedResources">
     <Head>#Resource1</Head>
+    <LinkedArray>
+      <Item>
+        <Next>#Resource2</Next>
+      </Item>
+      <Item>
+        <Next>#Resource3</Next>
+      </Item>
+    </LinkedArray>
   </Asset>
   <Resources>
     <Resource ID="#Resource1" Type="Linked">
       <Value>1</Value>
-      <Next>#Resource2</Next>
+      <Next>#Resource4</Next>
     </Resource>
-    <Resource ID="#Resource2" Type="Linked">
+    <Resource ID="#Resource2" Type="Linked2[]">
+      <Item>
+        <Next>#Resource3</Next>
+      </Item>
+      <Item>
+        <Next />
+      </Item>
+    </Resource>
+    <Resource ID="#Resource3" Type="Linked2[]">
+      <Item>
+        <Next>#Resource2</Next>
+      </Item>
+    </Resource>
+    <Resource ID="#Resource4" Type="Linked">
       <Value>2</Value>
-      <Next>#Resource3</Next>
+      <Next>#Resource5</Next>
     </Resource>
-    <Resource ID="#Resource3" Type="Linked">
+    <Resource ID="#Resource5" Type="Linked">
       <Value>3</Value>
       <Next>#Resource1</Next>
     </Resource>

--- a/Test/ContentPipeline/AssetTestClasses.cs
+++ b/Test/ContentPipeline/AssetTestClasses.cs
@@ -253,6 +253,8 @@ public class SharedResources
 {
     [ContentSerializer(SharedResource = true)]
     public Linked Head;
+
+    public Linked2[] LinkedArray;
 }
 
 public class Linked
@@ -262,6 +264,13 @@ public class Linked
     [ContentSerializer(SharedResource = true)]
     public Linked Next;
 }
+
+public class Linked2
+{
+    [ContentSerializer(SharedResource = true)]
+    public Linked2[] Next;
+}
+
 #endregion
 
 #region CircularReferences

--- a/Test/ContentPipeline/IntermediateDeserializerTest.cs
+++ b/Test/ContentPipeline/IntermediateDeserializerTest.cs
@@ -376,6 +376,14 @@ namespace MonoGame.Tests.ContentPipeline
                 Assert.NotNull(sharedResources.Head.Next.Next);
                 Assert.AreEqual(3, sharedResources.Head.Next.Next.Value);
                 Assert.AreSame(sharedResources.Head, sharedResources.Head.Next.Next.Next);
+
+                Assert.NotNull(sharedResources.LinkedArray);
+                Assert.AreEqual(2, sharedResources.LinkedArray.Length);
+                Assert.IsNotNull(sharedResources.LinkedArray[0].Next);
+                Assert.AreEqual(2, sharedResources.LinkedArray[0].Next.Length);
+                Assert.IsNotNull(sharedResources.LinkedArray[1].Next);
+                Assert.AreEqual(1, sharedResources.LinkedArray[1].Next.Length);
+                Assert.AreSame(sharedResources.LinkedArray[0].Next, sharedResources.LinkedArray[1].Next[0].Next);
             });
         }
 

--- a/Test/ContentPipeline/IntermediateSerializerTest.cs
+++ b/Test/ContentPipeline/IntermediateSerializerTest.cs
@@ -337,9 +337,20 @@ namespace MonoGame.Tests.ContentPipeline
             resource2.Next = resource3;
             resource3.Next = resource1;
 
+            var resourceArray1 = new Linked2();
+            var resourceArray2 = new Linked2();
+            var resourceArray3 = new Linked2();
+            resourceArray1.Next = new[] { resourceArray2, resourceArray3 };
+            resourceArray2.Next = new[] { resourceArray1 };
+
             SerializeAndAssert("16_SharedResources.xml", new SharedResources
             {
-                Head = resource1
+                Head = resource1,
+                LinkedArray = new[]
+                {
+                    resourceArray1,
+                    resourceArray2
+                }
             });
         }
 


### PR DESCRIPTION
and throw better exception when shared resource is not found during deserialization.