### PR TITLE
Use struct enumerator in EffectPassCollection

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/EffectPassCollection.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectPassCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -44,6 +45,11 @@ namespace Microsoft.Xna.Framework.Graphics
             get { return _passes.Length; }
         }
 
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(_passes);
+        }
+            
         IEnumerator<EffectPass> IEnumerable<EffectPass>.GetEnumerator()
         {
             return ((IEnumerable<EffectPass>)_passes).GetEnumerator();
@@ -52,6 +58,59 @@ namespace Microsoft.Xna.Framework.Graphics
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
             return _passes.GetEnumerator();
+        }
+
+        public struct Enumerator : IEnumerator<EffectPass>
+        {
+            private readonly EffectPass[] _array;
+            private int _index;
+            private EffectPass _current;
+
+            internal Enumerator(EffectPass[] array)
+            {
+                _array = array;
+                _index = 0;
+                _current = null;
+            }
+
+            public bool MoveNext()
+            {
+                if (_index < _array.Length)
+                {
+                    _current = _array[_index];
+                    _index++;
+                    return true;
+                }
+                _index = _array.Length + 1;
+                _current = null;
+                return false;
+            }
+
+            public EffectPass Current
+            {
+                get { return _current; }
+            }
+
+            public void Dispose()
+            {
+
+            }
+
+            object System.Collections.IEnumerator.Current
+            {
+                get
+                {
+                    if (_index == _array.Length + 1)
+                        throw new InvalidOperationException();
+                    return Current;
+                }
+            }
+
+            void System.Collections.IEnumerator.Reset()
+            {
+                _index = 0;
+                _current = null;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #3498.

Instead of duplicating the `List<T>.Enumerator` struct, I just re-used it.