### PR TITLE
GraphicsDevice Draw call parameter validation

### DIFF
--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -126,6 +126,7 @@
     <Compile Include="Framework\Visual\BlendStateTest.cs" />
     <Compile Include="Framework\Visual\DepthStencilStateTest.cs" />
     <Compile Include="Framework\Visual\EffectTest.cs" />
+    <Compile Include="Framework\Visual\GraphicsDeviceTest.cs" />
     <Compile Include="Framework\Visual\RasterizerStateTest.cs" />
     <Compile Include="Framework\Visual\SamplerStateTest.cs" />
     <Compile Include="Framework\Visual\ScissorRectangleTest.cs" />

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -1260,7 +1260,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
-        private void PlatformDrawUserIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int numVertices, int[] indexData, int indexOffset, int primitiveCount, VertexDeclaration vertexDeclaration) where T : struct, IVertexType
+        private void PlatformDrawUserIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int numVertices, int[] indexData, int indexOffset, int primitiveCount, VertexDeclaration vertexDeclaration) where T : struct
         {
             var indexCount = GetElementCountArray(primitiveType, primitiveCount);
             var startVertex = SetUserVertexBuffer(vertexData, vertexOffset, numVertices, vertexDeclaration);

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -911,7 +911,7 @@ namespace Microsoft.Xna.Framework.Graphics
             vbHandle.Free();
         }
 
-        private void PlatformDrawUserIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int numVertices, int[] indexData, int indexOffset, int primitiveCount, VertexDeclaration vertexDeclaration) where T : struct, IVertexType
+        private void PlatformDrawUserIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int numVertices, int[] indexData, int indexOffset, int primitiveCount, VertexDeclaration vertexDeclaration) where T : struct
         {
             ApplyState(true);
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.PSM.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.PSM.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Xna.Framework.Graphics
             throw new NotImplementedException("Not implemented");
         }
 
-        private void PlatformDrawUserIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int numVertices, int[] indexData, int indexOffset, int primitiveCount, VertexDeclaration vertexDeclaration) where T : struct, IVertexType
+        private void PlatformDrawUserIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int numVertices, int[] indexData, int indexOffset, int primitiveCount, VertexDeclaration vertexDeclaration) where T : struct
         {
             throw new NotImplementedException("Not implemented");
         }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.Web.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.Web.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
         }
 
-        private void PlatformDrawUserIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int numVertices, int[] indexData, int indexOffset, int primitiveCount, VertexDeclaration vertexDeclaration) where T : struct, IVertexType
+        private void PlatformDrawUserIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int numVertices, int[] indexData, int indexOffset, int primitiveCount, VertexDeclaration vertexDeclaration) where T : struct
         {
         }
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -812,9 +812,25 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public void DrawUserPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int primitiveCount, VertexDeclaration vertexDeclaration) where T : struct
         {
-            Debug.Assert(vertexData != null && vertexData.Length > 0, "The vertexData must not be null or zero length!");
+            if (vertexData == null)
+                throw new ArgumentNullException("vertexData");
+
+            if (vertexData.Length == 0)
+                throw new ArgumentOutOfRangeException("vertexData");
+
+            if (vertexOffset < 0 || vertexOffset >= vertexData.Length)
+                throw new ArgumentOutOfRangeException("vertexOffset");
+
+            if (primitiveCount <= 0)
+                throw new ArgumentOutOfRangeException("primitiveCount");
 
             var vertexCount = GetElementCountArray(primitiveType, primitiveCount);
+
+            if (vertexOffset + vertexCount > vertexData.Length)
+                throw new ArgumentOutOfRangeException("primitiveCount");
+
+            if (vertexDeclaration == null)
+                throw new ArgumentNullException("vertexDeclaration");
 
             PlatformDrawUserPrimitives<T>(primitiveType, vertexData, vertexOffset, vertexDeclaration, vertexCount);
         }
@@ -835,9 +851,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public void DrawUserIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int numVertices, short[] indexData, int indexOffset, int primitiveCount, VertexDeclaration vertexDeclaration) where T : struct
         {
-            Debug.Assert(vertexData != null && vertexData.Length > 0, "The vertexData must not be null or zero length!");
-            Debug.Assert(indexData != null && indexData.Length > 0, "The indexData must not be null or zero length!");
-
+            ValidateDrawUserIndexedPrimitivesArguments(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, vertexDeclaration);
             PlatformDrawUserIndexedPrimitives<T>(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, vertexDeclaration);
         }
 
@@ -846,12 +860,42 @@ namespace Microsoft.Xna.Framework.Graphics
             DrawUserIndexedPrimitives<T>(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, VertexDeclarationCache<T>.VertexDeclaration);
         }
 
-        public void DrawUserIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int numVertices, int[] indexData, int indexOffset, int primitiveCount, VertexDeclaration vertexDeclaration) where T : struct, IVertexType
+        public void DrawUserIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int numVertices, int[] indexData, int indexOffset, int primitiveCount, VertexDeclaration vertexDeclaration) where T : struct
         {
-            Debug.Assert(vertexData != null && vertexData.Length > 0, "The vertexData must not be null or zero length!");
-            Debug.Assert(indexData != null && indexData.Length > 0, "The indexData must not be null or zero length!");
-
+            ValidateDrawUserIndexedPrimitivesArguments(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, vertexDeclaration);
             PlatformDrawUserIndexedPrimitives<T>(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, vertexDeclaration);
+        }
+
+        private static void ValidateDrawUserIndexedPrimitivesArguments<TVertexData, TIndexData>(PrimitiveType primitiveType, TVertexData[] vertexData, int vertexOffset, int numVertices, TIndexData[] indexData, int indexOffset, int primitiveCount, VertexDeclaration vertexDeclaration)
+            where TVertexData : struct
+            where TIndexData : struct
+        {
+            if (vertexData == null || vertexData.Length == 0)
+                throw new ArgumentNullException("vertexData");
+
+            if (vertexOffset < 0 || vertexOffset >= vertexData.Length)
+                throw new ArgumentOutOfRangeException("vertexOffset");
+
+            if (numVertices <= 0 || numVertices > vertexData.Length)
+                throw new ArgumentOutOfRangeException("numVertices");
+
+            if (vertexOffset + numVertices > vertexData.Length)
+                throw new ArgumentOutOfRangeException("numVertices");
+
+            if (indexData == null || indexData.Length == 0)
+                throw new ArgumentNullException("indexData");
+
+            if (indexOffset < 0 || indexOffset >= indexData.Length)
+                throw new ArgumentOutOfRangeException("indexOffset");
+
+            if (primitiveCount <= 0)
+                throw new ArgumentOutOfRangeException("primitiveCount");
+
+            if (indexOffset + GetElementCountArray(primitiveType, primitiveCount) > indexData.Length)
+                throw new ArgumentOutOfRangeException("primitiveCount");
+
+            if (vertexDeclaration == null)
+                throw new ArgumentNullException("vertexDeclaration");
         }
 
         private static int GetElementCountArray(PrimitiveType primitiveType, int primitiveCount)

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -867,25 +867,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public void DrawUserIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int numVertices, short[] indexData, int indexOffset, int primitiveCount, VertexDeclaration vertexDeclaration) where T : struct
         {
-            ValidateDrawUserIndexedPrimitivesArguments(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, vertexDeclaration);
-            PlatformDrawUserIndexedPrimitives<T>(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, vertexDeclaration);
-        }
+            // These parameter checks are a duplicate of the checks in the int[] overload of DrawUserIndexedPrimitives.
+            // Inlined here for efficiency.
 
-        public void DrawUserIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int numVertices, int[] indexData, int indexOffset, int primitiveCount) where T : struct, IVertexType
-        {
-            DrawUserIndexedPrimitives<T>(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, VertexDeclarationCache<T>.VertexDeclaration);
-        }
-
-        public void DrawUserIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int numVertices, int[] indexData, int indexOffset, int primitiveCount, VertexDeclaration vertexDeclaration) where T : struct
-        {
-            ValidateDrawUserIndexedPrimitivesArguments(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, vertexDeclaration);
-            PlatformDrawUserIndexedPrimitives<T>(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, vertexDeclaration);
-        }
-
-        private static void ValidateDrawUserIndexedPrimitivesArguments<TVertexData, TIndexData>(PrimitiveType primitiveType, TVertexData[] vertexData, int vertexOffset, int numVertices, TIndexData[] indexData, int indexOffset, int primitiveCount, VertexDeclaration vertexDeclaration)
-            where TVertexData : struct
-            where TIndexData : struct
-        {
             if (vertexData == null || vertexData.Length == 0)
                 throw new ArgumentNullException("vertexData");
 
@@ -912,6 +896,48 @@ namespace Microsoft.Xna.Framework.Graphics
 
             if (vertexDeclaration == null)
                 throw new ArgumentNullException("vertexDeclaration");
+
+            PlatformDrawUserIndexedPrimitives<T>(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, vertexDeclaration);
+        }
+
+        public void DrawUserIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int numVertices, int[] indexData, int indexOffset, int primitiveCount) where T : struct, IVertexType
+        {
+            DrawUserIndexedPrimitives<T>(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, VertexDeclarationCache<T>.VertexDeclaration);
+        }
+
+        public void DrawUserIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int numVertices, int[] indexData, int indexOffset, int primitiveCount, VertexDeclaration vertexDeclaration) where T : struct
+        {
+            // These parameter checks are a duplicate of the checks in the short[] overload of DrawUserIndexedPrimitives.
+            // Inlined here for efficiency.
+
+            if (vertexData == null || vertexData.Length == 0)
+                throw new ArgumentNullException("vertexData");
+
+            if (vertexOffset < 0 || vertexOffset >= vertexData.Length)
+                throw new ArgumentOutOfRangeException("vertexOffset");
+
+            if (numVertices <= 0 || numVertices > vertexData.Length)
+                throw new ArgumentOutOfRangeException("numVertices");
+
+            if (vertexOffset + numVertices > vertexData.Length)
+                throw new ArgumentOutOfRangeException("numVertices");
+
+            if (indexData == null || indexData.Length == 0)
+                throw new ArgumentNullException("indexData");
+
+            if (indexOffset < 0 || indexOffset >= indexData.Length)
+                throw new ArgumentOutOfRangeException("indexOffset");
+
+            if (primitiveCount <= 0)
+                throw new ArgumentOutOfRangeException("primitiveCount");
+
+            if (indexOffset + GetElementCountArray(primitiveType, primitiveCount) > indexData.Length)
+                throw new ArgumentOutOfRangeException("primitiveCount");
+
+            if (vertexDeclaration == null)
+                throw new ArgumentNullException("vertexDeclaration");
+
+            PlatformDrawUserIndexedPrimitives<T>(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, vertexDeclaration);
         }
 
         private static int GetElementCountArray(PrimitiveType primitiveType, int primitiveCount)

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -793,8 +793,17 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <remarks>Note that minVertexIndex and numVertices are unused in MonoGame and will be ignored.</remarks>
         public void DrawIndexedPrimitives(PrimitiveType primitiveType, int baseVertex, int minVertexIndex, int numVertices, int startIndex, int primitiveCount)
         {
-            Debug.Assert(_vertexBuffer != null, "The vertex buffer is null!");
-            Debug.Assert(_indexBuffer != null, "The index buffer is null!");
+            if (_vertexShader == null)
+                throw new InvalidOperationException("Vertex shader must be set before calling DrawIndexedPrimitives.");
+
+            if (_vertexBuffer == null)
+                throw new InvalidOperationException("Vertex buffer must be set before calling DrawIndexedPrimitives.");
+
+            if (_indexBuffer == null)
+                throw new InvalidOperationException("Index buffer must be set before calling DrawIndexedPrimitives.");
+
+            if (primitiveCount <= 0)
+                throw new ArgumentOutOfRangeException("primitiveCount");
 
             // NOTE: minVertexIndex and numVertices are only hints of the
             // range of vertex data which will be indexed.
@@ -838,7 +847,7 @@ namespace Microsoft.Xna.Framework.Graphics
         public void DrawPrimitives(PrimitiveType primitiveType, int vertexStart, int primitiveCount)
         {
             if (_vertexShader == null)
-                throw new InvalidOperationException("Must set a vertex shader before calling DrawPrimitives.");
+                throw new InvalidOperationException("Vertex shader must be set before calling DrawPrimitives.");
 
             if (_vertexBuffer == null)
                 throw new InvalidOperationException("Vertex buffer must be set before calling DrawPrimitives.");

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -837,7 +837,14 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public void DrawPrimitives(PrimitiveType primitiveType, int vertexStart, int primitiveCount)
         {
-            Debug.Assert(_vertexBuffer != null, "The vertex buffer is null!");
+            if (_vertexShader == null)
+                throw new InvalidOperationException("Must set a vertex shader before calling DrawPrimitives.");
+
+            if (_vertexBuffer == null)
+                throw new InvalidOperationException("Vertex buffer must be set before calling DrawPrimitives.");
+
+            if (primitiveCount <= 0)
+                throw new ArgumentOutOfRangeException("primitiveCount");
 
             var vertexCount = GetElementCountArray(primitiveType, primitiveCount);
 

--- a/Test/Framework/Visual/GraphicsDeviceTest.cs
+++ b/Test/Framework/Visual/GraphicsDeviceTest.cs
@@ -14,6 +14,42 @@ namespace MonoGame.Tests.Visual
     internal class GraphicsDeviceTest : VisualTestFixtureBase
     {
         [Test]
+        public void DrawPrimitivesParameterValidation()
+        {
+            Game.DrawWith += (sender, e) =>
+            {
+                var vertexBuffer = new VertexBuffer(
+                    Game.GraphicsDevice, VertexPositionColorTexture.VertexDeclaration,
+                    3, BufferUsage.None);
+
+                // No vertex shader or pixel shader.
+                Assert.Throws<InvalidOperationException>(() => Game.GraphicsDevice.DrawPrimitives(PrimitiveType.TriangleList, 0, 1));
+
+                new BasicEffect(Game.GraphicsDevice).CurrentTechnique.Passes[0].Apply();
+
+                // No vertexBuffer.
+                Assert.Throws<InvalidOperationException>(() => Game.GraphicsDevice.DrawPrimitives(PrimitiveType.TriangleList, 0, 1));
+
+                Game.GraphicsDevice.SetVertexBuffer(vertexBuffer);
+
+                // Success - "normal" usage.
+                Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawPrimitives(PrimitiveType.TriangleList, 0, 1));
+
+                // vertexStart too small / large.
+                Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawPrimitives(PrimitiveType.TriangleList, -1, 1));
+                Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawPrimitives(PrimitiveType.TriangleList, 3, 1));
+
+                // primitiveCount too small / large.
+                Assert.Throws<ArgumentOutOfRangeException>(() => Game.GraphicsDevice.DrawPrimitives(PrimitiveType.TriangleList, 0, 0));
+                Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawPrimitives(PrimitiveType.TriangleList, 0, 2));
+
+                // vertexStart + primitiveCount too large.
+                Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawPrimitives(PrimitiveType.TriangleList, 1, 1));
+            };
+            Game.Run();
+        }
+
+        [Test]
         public void DrawUserPrimitivesParameterValidation()
         {
             Game.DrawWith += (sender, e) =>
@@ -26,10 +62,13 @@ namespace MonoGame.Tests.Visual
                 };
                 var vertexDataEmpty = new VertexPositionColorTexture[0];
 
+                // No vertex shader or pixel shader.
+                Assert.Throws<InvalidOperationException>(() => Game.GraphicsDevice.DrawUserPrimitives(PrimitiveType.TriangleList, vertexDataNonEmpty, 0, 1));
+
                 new BasicEffect(Game.GraphicsDevice).CurrentTechnique.Passes[0].Apply();
 
-
-                // Failure cases.
+                // Success - "normal" usage.
+                Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawUserPrimitives(PrimitiveType.TriangleList, vertexDataNonEmpty, 0, 1));
 
                 // Null vertexData.
                 DoDrawUserPrimitivesAsserts(null, 0, 1, d => Assert.Throws<ArgumentNullException>(d));
@@ -50,12 +89,6 @@ namespace MonoGame.Tests.Visual
 
                 // Null vertexDeclaration.
                 Assert.Throws<ArgumentNullException>(() => Game.GraphicsDevice.DrawUserPrimitives(PrimitiveType.TriangleList, vertexDataNonEmpty, 0, 1, null));
-
-
-                // Success cases.
-
-                // "Normal" usage.
-                Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawUserPrimitives(PrimitiveType.TriangleList, vertexDataNonEmpty, 0, 1));
             };
             Game.Run();
         }
@@ -82,8 +115,13 @@ namespace MonoGame.Tests.Visual
                 var indexDataNonEmpty = new short[] { 0, 1, 2 };
                 var indexDataEmpty = new short[0];
 
+                // No vertex shader or pixel shader.
+                Assert.Throws<InvalidOperationException>(() => Game.GraphicsDevice.DrawUserIndexedPrimitives(PrimitiveType.TriangleList, vertexDataNonEmpty, 0, 3, indexDataNonEmpty, 0, 1));
+
                 new BasicEffect(Game.GraphicsDevice).CurrentTechnique.Passes[0].Apply();
 
+                // Success - "normal" usage.
+                Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawUserIndexedPrimitives(PrimitiveType.TriangleList, vertexDataNonEmpty, 0, 3, indexDataNonEmpty, 0, 1));
 
                 // Failure cases.
 
@@ -124,12 +162,6 @@ namespace MonoGame.Tests.Visual
 
                 // Null vertexDeclaration.
                 Assert.Throws<ArgumentNullException>(() => Game.GraphicsDevice.DrawUserIndexedPrimitives(PrimitiveType.TriangleList, vertexDataNonEmpty, 0, 3, indexDataNonEmpty, 0, 1, null));
-
-
-                // Success cases.
-
-                // "Normal" usage.
-                Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawUserIndexedPrimitives(PrimitiveType.TriangleList, vertexDataNonEmpty, 0, 3, indexDataNonEmpty, 0, 1));
 
                 // Smaller vertex stride in VertexDeclaration than in actual vertices.
 

--- a/Test/Framework/Visual/GraphicsDeviceTest.cs
+++ b/Test/Framework/Visual/GraphicsDeviceTest.cs
@@ -1,0 +1,161 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using NUnit.Framework;
+
+namespace MonoGame.Tests.Visual
+{
+    [TestFixture]
+    internal class GraphicsDeviceTest : VisualTestFixtureBase
+    {
+        [Test]
+        public void DrawUserPrimitivesParameterValidation()
+        {
+            Game.DrawWith += (sender, e) =>
+            {
+                var vertexDataNonEmpty = new[]
+                {
+                    new VertexPositionColorTexture(Vector3.Zero, Color.White, Vector2.Zero),
+                    new VertexPositionColorTexture(Vector3.Zero, Color.White, Vector2.Zero),
+                    new VertexPositionColorTexture(Vector3.Zero, Color.White, Vector2.Zero)
+                };
+                var vertexDataEmpty = new VertexPositionColorTexture[0];
+
+                new BasicEffect(Game.GraphicsDevice).CurrentTechnique.Passes[0].Apply();
+
+
+                // Failure cases.
+
+                // Null vertexData.
+                DoDrawUserPrimitivesAsserts(null, 0, 1, d => Assert.Throws<ArgumentNullException>(d));
+
+                // Empty vertexData.
+                DoDrawUserPrimitivesAsserts(vertexDataEmpty, 0, 1, d => Assert.Throws<ArgumentOutOfRangeException>(d));
+
+                // vertexOffset too small / large.
+                DoDrawUserPrimitivesAsserts(vertexDataNonEmpty, -1, 1, d => Assert.Throws<ArgumentOutOfRangeException>(d));
+                DoDrawUserPrimitivesAsserts(vertexDataNonEmpty, 3, 1, d => Assert.Throws<ArgumentOutOfRangeException>(d));
+
+                // primitiveCount too small / large.
+                DoDrawUserPrimitivesAsserts(vertexDataNonEmpty, 0, 0, d => Assert.Throws<ArgumentOutOfRangeException>(d));
+                DoDrawUserPrimitivesAsserts(vertexDataNonEmpty, 0, 2, d => Assert.Throws<ArgumentOutOfRangeException>(d));
+
+                // vertexOffset + primitiveCount too large.
+                DoDrawUserPrimitivesAsserts(vertexDataNonEmpty, 1, 1, d => Assert.Throws<ArgumentOutOfRangeException>(d));
+
+                // Null vertexDeclaration.
+                Assert.Throws<ArgumentNullException>(() => Game.GraphicsDevice.DrawUserPrimitives(PrimitiveType.TriangleList, vertexDataNonEmpty, 0, 1, null));
+
+
+                // Success cases.
+
+                // "Normal" usage.
+                Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawUserPrimitives(PrimitiveType.TriangleList, vertexDataNonEmpty, 0, 1));
+            };
+            Game.Run();
+        }
+
+        private void DoDrawUserPrimitivesAsserts(VertexPositionColorTexture[] vertexData, int vertexOffset, int primitiveCount, Action<TestDelegate> assertMethod)
+        {
+            assertMethod(() => Game.GraphicsDevice.DrawUserPrimitives(PrimitiveType.TriangleList, vertexData, vertexOffset, primitiveCount));
+            assertMethod(() => Game.GraphicsDevice.DrawUserPrimitives(PrimitiveType.TriangleList, vertexData, vertexOffset, primitiveCount, VertexPositionColorTexture.VertexDeclaration));
+        }
+
+        [Test]
+        public void DrawUserIndexedPrimitivesParameterValidation()
+        {
+            Game.DrawWith += (sender, e) =>
+            {
+                var vertexDataNonEmpty = new[]
+                {
+                    new VertexPositionColorTexture(Vector3.Zero, Color.White, Vector2.Zero),
+                    new VertexPositionColorTexture(Vector3.Zero, Color.White, Vector2.Zero),
+                    new VertexPositionColorTexture(Vector3.Zero, Color.White, Vector2.Zero)
+                };
+                var vertexDataEmpty = new VertexPositionColorTexture[0];
+
+                var indexDataNonEmpty = new short[] { 0, 1, 2 };
+                var indexDataEmpty = new short[0];
+
+                new BasicEffect(Game.GraphicsDevice).CurrentTechnique.Passes[0].Apply();
+
+
+                // Failure cases.
+
+                // Null vertexData.
+                DoDrawUserIndexedPrimitivesAsserts(null, 0, 3, indexDataNonEmpty, 0, 1, d => Assert.Throws<ArgumentNullException>(d));
+
+                // Empty vertexData.
+                DoDrawUserIndexedPrimitivesAsserts(vertexDataEmpty, 0, 3, indexDataNonEmpty, 0, 1, d => Assert.Throws<ArgumentNullException>(d));
+
+                // vertexOffset too small / large.
+                DoDrawUserIndexedPrimitivesAsserts(vertexDataNonEmpty, -1, 3, indexDataNonEmpty, 0, 1, d => Assert.Throws<ArgumentOutOfRangeException>(d));
+                DoDrawUserIndexedPrimitivesAsserts(vertexDataNonEmpty, 3, 3, indexDataNonEmpty, 0, 1, d => Assert.Throws<ArgumentOutOfRangeException>(d));
+
+                // numVertices too small / large.
+                DoDrawUserIndexedPrimitivesAsserts(vertexDataNonEmpty, 0, 0, indexDataNonEmpty, 0, 1, d => Assert.Throws<ArgumentOutOfRangeException>(d));
+                DoDrawUserIndexedPrimitivesAsserts(vertexDataNonEmpty, 0, 4, indexDataNonEmpty, 0, 1, d => Assert.Throws<ArgumentOutOfRangeException>(d));
+
+                // vertexOffset + numVertices too large.
+                DoDrawUserIndexedPrimitivesAsserts(vertexDataNonEmpty, 1, 3, indexDataNonEmpty, 0, 1, d => Assert.Throws<ArgumentOutOfRangeException>(d));
+
+                // Null indexData.
+                DoDrawUserIndexedPrimitivesAsserts(vertexDataNonEmpty, 0, 3, null, 0, 1, d => Assert.Throws<ArgumentNullException>(d));
+
+                // Empty indexData.
+                DoDrawUserIndexedPrimitivesAsserts(vertexDataNonEmpty, 0, 3, indexDataEmpty, 0, 1, d => Assert.Throws<ArgumentNullException>(d));
+
+                // indexOffset too small / large.
+                DoDrawUserIndexedPrimitivesAsserts(vertexDataNonEmpty, 0, 3, indexDataNonEmpty, -1, 1, d => Assert.Throws<ArgumentOutOfRangeException>(d));
+                DoDrawUserIndexedPrimitivesAsserts(vertexDataNonEmpty, 0, 3, indexDataNonEmpty, 1, 1, d => Assert.Throws<ArgumentOutOfRangeException>(d));
+
+                // primitiveCount too small / large.
+                DoDrawUserIndexedPrimitivesAsserts(vertexDataNonEmpty, 0, 3, indexDataNonEmpty, 0, -1, d => Assert.Throws<ArgumentOutOfRangeException>(d));
+                DoDrawUserIndexedPrimitivesAsserts(vertexDataNonEmpty, 0, 3, indexDataNonEmpty, 0, 0, d => Assert.Throws<ArgumentOutOfRangeException>(d));
+                DoDrawUserIndexedPrimitivesAsserts(vertexDataNonEmpty, 0, 3, indexDataNonEmpty, 0, 2, d => Assert.Throws<ArgumentOutOfRangeException>(d));
+
+                // indexOffset + primitiveCount too large.
+                DoDrawUserIndexedPrimitivesAsserts(vertexDataNonEmpty, 0, 3, indexDataNonEmpty, 1, 1, d => Assert.Throws<ArgumentOutOfRangeException>(d));
+
+                // Null vertexDeclaration.
+                Assert.Throws<ArgumentNullException>(() => Game.GraphicsDevice.DrawUserIndexedPrimitives(PrimitiveType.TriangleList, vertexDataNonEmpty, 0, 3, indexDataNonEmpty, 0, 1, null));
+
+
+                // Success cases.
+
+                // "Normal" usage.
+                Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawUserIndexedPrimitives(PrimitiveType.TriangleList, vertexDataNonEmpty, 0, 3, indexDataNonEmpty, 0, 1));
+
+                // Smaller vertex stride in VertexDeclaration than in actual vertices.
+
+                // XNA is inconsistent; in DrawUserIndexedPrimitives, it allows vertexStride to be less than the actual size of the data,
+                // but in VertexBuffer.SetData, XNA requires vertexStride to greater than or equal to the actual size of the data.
+                // Since we use a DynamicVertexBuffer to implement DrawUserIndexedPrimitives, we use the same validation in both places.
+                // The same applies to DrawUserPrimitives.
+#if XNA
+                Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawUserIndexedPrimitives(PrimitiveType.TriangleList, vertexDataNonEmpty, 0, 3, indexDataNonEmpty, 0, 1, VertexPositionColor.VertexDeclaration));
+                Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawUserIndexedPrimitives(PrimitiveType.TriangleList, vertexDataNonEmpty, 0, 3, indexDataNonEmpty.Select(x => (int) x).ToArray(), 0, 1, VertexPositionColor.VertexDeclaration));
+#else
+                Assert.Throws<ArgumentOutOfRangeException>(() => Game.GraphicsDevice.DrawUserIndexedPrimitives(PrimitiveType.TriangleList, vertexDataNonEmpty, 0, 3, indexDataNonEmpty, 0, 1, VertexPositionColor.VertexDeclaration));
+                Assert.Throws<ArgumentOutOfRangeException>(() => Game.GraphicsDevice.DrawUserIndexedPrimitives(PrimitiveType.TriangleList, vertexDataNonEmpty, 0, 3, indexDataNonEmpty.Select(x => (int) x).ToArray(), 0, 1, VertexPositionColor.VertexDeclaration));
+#endif
+            };
+            Game.Run();
+        }
+
+        private void DoDrawUserIndexedPrimitivesAsserts(VertexPositionColorTexture[] vertexData, int vertexOffset, int numVertices, short[] indexData, int indexOffset, int primitiveCount, Action<TestDelegate> assertMethod)
+        {
+            assertMethod(() => Game.GraphicsDevice.DrawUserIndexedPrimitives(PrimitiveType.TriangleList, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount));
+            assertMethod(() => Game.GraphicsDevice.DrawUserIndexedPrimitives(PrimitiveType.TriangleList, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, VertexPositionColorTexture.VertexDeclaration));
+
+            var intIndexData = (indexData == null) ? null : indexData.Select(x => (int) x).ToArray();
+            assertMethod(() => Game.GraphicsDevice.DrawUserIndexedPrimitives(PrimitiveType.TriangleList, vertexData, vertexOffset, numVertices, intIndexData, indexOffset, primitiveCount));
+            assertMethod(() => Game.GraphicsDevice.DrawUserIndexedPrimitives(PrimitiveType.TriangleList, vertexData, vertexOffset, numVertices, intIndexData, indexOffset, primitiveCount, VertexPositionColorTexture.VertexDeclaration));
+        }
+    }
+}

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Framework\Visual\BlendStateTest.cs" />
     <Compile Include="Framework\Visual\DepthStencilStateTest.cs" />
     <Compile Include="Framework\Visual\EffectTest.cs" />
+    <Compile Include="Framework\Visual\GraphicsDeviceTest.cs" />
     <Compile Include="Framework\Visual\IndexBufferTest.cs" />
     <Compile Include="Framework\Visual\RasterizerStateTest.cs" />
     <Compile Include="Framework\Visual\SamplerStateTest.cs" />


### PR DESCRIPTION
Adds parameter validation for:

* `DrawPrimitives`
* `DrawIndexedPrimitives`
* `DrawUserPrimitives`
* `DrawUserIndexedPrimitives`

I don't know if this is controversial - we have parameter validation elsewhere in MG, but until now the `Draw*` methods didn't have it. Obviously there is a (tiny) performance overhead. As @tomspilman has said elsewhere, it's a pity that VS doesn't make it easy to switch between debug / release assemblies, which would be the best of both worlds.

I don't think `Debug.Assert` is a viable replacement, since (I assume) very few developers build MG from source (or at least, that will be true once there are more frequent MG releases), and so very few developers are using the debug assemblies.

**EDIT** Forgot to say that #3125 was the trigger for this PR. However, from what I've found, XNA doesn't actually throw an exception when the `VertexDeclaration` size doesn't match the vertex data size in `DrawUser[Indexed]Primitives`. That's verified in a unit test.