### PR TITLE
Added test cases for empty XML datatypes

### DIFF
--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -612,6 +612,9 @@
     <Content Include="Assets\Xml\24_GenericTypes.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+	<Content Include="Assets\Xml\25_DeserialiseDefaults.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
 
     <Content Include="Assets\Fonts\Default.xnb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/BoolSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/BoolSerializer.cs
@@ -17,11 +17,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override bool Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return XmlConvert.ToBoolean(inputs[index++]);
-            }
-            return new bool();
+            if (inputs.Length == 0)
+                return new bool();
+
+            return XmlConvert.ToBoolean(inputs[index++]);
         }
 
         protected internal override void Serialize(bool value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/BoolSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/BoolSerializer.cs
@@ -17,7 +17,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override bool Deserialize(string[] inputs, ref int index)
         {
-            return XmlConvert.ToBoolean(inputs[index++]);
+            if (inputs.Length > 0)
+            {
+                return XmlConvert.ToBoolean(inputs[index++]);
+            }
+            return new bool();
         }
 
         protected internal override void Serialize(bool value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ByteSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ByteSerializer.cs
@@ -17,11 +17,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override byte Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return XmlConvert.ToByte(inputs[index++]);
-            }
-            return new byte();
+            if (inputs.Length == 0)
+                return new byte();
+
+            return XmlConvert.ToByte(inputs[index++]);
         }
 
         protected internal override void Serialize(byte value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ByteSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ByteSerializer.cs
@@ -17,7 +17,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override byte Deserialize(string[] inputs, ref int index)
         {
-            return XmlConvert.ToByte(inputs[index++]);
+            if (inputs.Length > 0)
+            {
+                return XmlConvert.ToByte(inputs[index++]);
+            }
+            return new byte();
         }
 
         protected internal override void Serialize(byte value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/CharSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/CharSerializer.cs
@@ -17,21 +17,20 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override char Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                var str = inputs[index++];
-                if (str.Length == 1)
-                    return XmlConvert.ToChar(str);
+            if (inputs.Length == 0)
+                return new char();
 
-                // Try parsing it as a UTF code.
-                int val;
-                if (int.TryParse(str, out val))
-                    return char.ConvertFromUtf32(val)[0];
+            var str = inputs[index++];
+            if (str.Length == 1)
+                return XmlConvert.ToChar(str);
 
-                // Last ditch effort to decode it as XML escape value.
-                return XmlConvert.ToChar(XmlConvert.DecodeName(str));
-            }
-            return new char();
+            // Try parsing it as a UTF code.
+            int val;
+            if (int.TryParse(str, out val))
+                return char.ConvertFromUtf32(val)[0];
+
+            // Last ditch effort to decode it as XML escape value.
+            return XmlConvert.ToChar(XmlConvert.DecodeName(str));
         }
 
         protected internal override void Serialize(char value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/CharSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/CharSerializer.cs
@@ -17,17 +17,21 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override char Deserialize(string[] inputs, ref int index)
         {
-            var str = inputs[index++];
-            if (str.Length == 1)
-                return XmlConvert.ToChar(str);
+            if (inputs.Length > 0)
+            {
+                var str = inputs[index++];
+                if (str.Length == 1)
+                    return XmlConvert.ToChar(str);
 
-            // Try parsing it as a UTF code.
-            int val;
-            if (int.TryParse(str, out val))
-                return char.ConvertFromUtf32(val)[0];
+                // Try parsing it as a UTF code.
+                int val;
+                if (int.TryParse(str, out val))
+                    return char.ConvertFromUtf32(val)[0];
 
-            // Last ditch effort to decode it as XML escape value.
-            return XmlConvert.ToChar(XmlConvert.DecodeName(str));
+                // Last ditch effort to decode it as XML escape value.
+                return XmlConvert.ToChar(XmlConvert.DecodeName(str));
+            }
+            return new char();
         }
 
         protected internal override void Serialize(char value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ColorSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ColorSerializer.cs
@@ -18,16 +18,16 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override Color Deserialize(string[] inputs, ref int index)
         {
+            if (inputs.Length == 0)
+                return new Color();
+
             // NOTE: The value is serialized in ARGB format.
-            if (inputs.Length > 0)
-            {
-                var value = uint.Parse(inputs[index++], NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-                return new Color((int)(value >> 16 & 0xFF),
-                                    (int)(value >> 8 & 0xFF),
-                                    (int)(value >> 0 & 0xFF),
-                                    (int)(value >> 24 & 0xFF));
-            }
-            return new Color();
+
+            var value = uint.Parse(inputs[index++], NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+            return new Color((int)(value >> 16 & 0xFF),
+                                (int)(value >> 8 & 0xFF),
+                                (int)(value >> 0 & 0xFF),
+                                (int)(value >> 24 & 0xFF));
         }
 
         protected internal override void Serialize(Color value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ColorSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ColorSerializer.cs
@@ -19,11 +19,15 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
         protected internal override Color Deserialize(string[] inputs, ref int index)
         {
             // NOTE: The value is serialized in ARGB format.
-            var value = uint.Parse(inputs[index++], NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-            return new Color(   (int)(value >> 16 & 0xFF),
-                                (int)(value >> 8 & 0xFF),
-                                (int)(value >> 0 & 0xFF),
-                                (int)(value >> 24 & 0xFF));
+            if (inputs.Length > 0)
+            {
+                var value = uint.Parse(inputs[index++], NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+                return new Color((int)(value >> 16 & 0xFF),
+                                    (int)(value >> 8 & 0xFF),
+                                    (int)(value >> 0 & 0xFF),
+                                    (int)(value >> 24 & 0xFF));
+            }
+            return new Color();
         }
 
         protected internal override void Serialize(Color value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/DoubleSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/DoubleSerializer.cs
@@ -17,7 +17,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override double Deserialize(string[] inputs, ref int index)
         {
-            return XmlConvert.ToDouble(inputs[index++]);
+            if (inputs.Length > 0)
+            {
+                return XmlConvert.ToDouble(inputs[index++]);
+            }
+            return new double();
         }
 
         protected internal override void Serialize(double value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/DoubleSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/DoubleSerializer.cs
@@ -17,11 +17,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override double Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return XmlConvert.ToDouble(inputs[index++]);
-            }
-            return new double();
+            if (inputs.Length == 0)
+                return new double();
+
+            return XmlConvert.ToDouble(inputs[index++]);
         }
 
         protected internal override void Serialize(double value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ElementSerializerT.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ElementSerializerT.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         private static string[] ReadElements(IntermediateReader input)
         {
-            if (input.Xml.IsEmptyElement)
+            if (input.Xml.IsEmptyElement || !input.Xml.HasValue)
                 return new string[0];
 
             string str = string.Empty;
@@ -56,7 +56,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
         protected internal void Deserialize(IntermediateReader input, List<T> results)
         {
             var elements = ReadElements(input);
-                            
+
             for (var index = 0; index < elements.Length;)
             {
                 if (elements.Length - index < _elementCount)
@@ -71,7 +71,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
         {
             var elements = ReadElements(input);
 
-            if (elements.Length < _elementCount)
+            if (elements.Length > 0 && elements.Length < _elementCount)
                 ThrowElementCountException();
 
             var index = 0;

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/FloatSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/FloatSerializer.cs
@@ -17,12 +17,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override float Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return XmlConvert.ToSingle(inputs[index++]);
+            if (inputs.Length == 0)
+                return new float();
 
-            }
-            return new float();
+            return XmlConvert.ToSingle(inputs[index++]);
+
         }
 
         protected internal override void Serialize(float value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/FloatSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/FloatSerializer.cs
@@ -17,7 +17,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override float Deserialize(string[] inputs, ref int index)
         {
-            return XmlConvert.ToSingle(inputs[index++]);
+            if (inputs.Length > 0)
+            {
+                return XmlConvert.ToSingle(inputs[index++]);
+
+            }
+            return new float();
         }
 
         protected internal override void Serialize(float value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntSerializer.cs
@@ -17,7 +17,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override int Deserialize(string[] inputs, ref int index)
         {
-            return XmlConvert.ToInt32(inputs[index++]);
+            if (inputs.Length > 0)
+            {
+                return XmlConvert.ToInt32(inputs[index++]);
+            }
+            return new int();
         }
 
         protected internal override void Serialize(int value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntSerializer.cs
@@ -17,11 +17,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override int Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return XmlConvert.ToInt32(inputs[index++]);
-            }
-            return new int();
+            if (inputs.Length == 0)
+                return new int();
+
+            return XmlConvert.ToInt32(inputs[index++]);
         }
 
         protected internal override void Serialize(int value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/LongSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/LongSerializer.cs
@@ -17,11 +17,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override long Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return XmlConvert.ToInt64(inputs[index++]);
-            }
-            return new long();
+            if (inputs.Length == 0)
+                return new long();
+
+            return XmlConvert.ToInt64(inputs[index++]);
         }
 
         protected internal override void Serialize(long value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/LongSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/LongSerializer.cs
@@ -17,7 +17,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override long Deserialize(string[] inputs, ref int index)
         {
-            return XmlConvert.ToInt64(inputs[index++]);
+            if (inputs.Length > 0)
+            {
+                return XmlConvert.ToInt64(inputs[index++]);
+            }
+            return new long();
         }
 
         protected internal override void Serialize(long value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/MatrixSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/MatrixSerializer.cs
@@ -17,26 +17,25 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override Matrix Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return new Matrix(XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]));
-            }
-            return Matrix.Identity;
+            if (inputs.Length == 0)
+                return Matrix.Identity;
+
+            return new Matrix(XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]));
         }
 
         protected internal override void Serialize(Matrix value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/MatrixSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/MatrixSerializer.cs
@@ -17,22 +17,26 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override Matrix Deserialize(string[] inputs, ref int index)
         {
-            return new Matrix(XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]));
+            if (inputs.Length > 0)
+            {
+                return new Matrix(XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]));
+            }
+            return Matrix.Identity;
         }
 
         protected internal override void Serialize(Matrix value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/PlaneSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/PlaneSerializer.cs
@@ -17,14 +17,13 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override Plane Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return new Plane(XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]));
-            }
-            return new Plane();
+            if (inputs.Length == 0)
+                return new Plane();
+
+            return new Plane(XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]));
         }
 
         protected internal override void Serialize(Plane value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/PlaneSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/PlaneSerializer.cs
@@ -17,10 +17,14 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override Plane Deserialize(string[] inputs, ref int index)
         {
-            return new Plane(   XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]));
+            if (inputs.Length > 0)
+            {
+                return new Plane(XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]));
+            }
+            return new Plane();
         }
 
         protected internal override void Serialize(Plane value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/PointSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/PointSerializer.cs
@@ -17,8 +17,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override Point Deserialize(string[] inputs, ref int index)
         {
-            return new Point(   XmlConvert.ToInt32(inputs[index++]),
-                                XmlConvert.ToInt32(inputs[index++]));
+            if (inputs.Length > 0)
+            {
+                return new Point(XmlConvert.ToInt32(inputs[index++]),
+                                    XmlConvert.ToInt32(inputs[index++]));
+            }
+            return Point.Zero;
         }
 
         protected internal override void Serialize(Point value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/PointSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/PointSerializer.cs
@@ -17,12 +17,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override Point Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return new Point(XmlConvert.ToInt32(inputs[index++]),
-                                    XmlConvert.ToInt32(inputs[index++]));
-            }
-            return Point.Zero;
+            if (inputs.Length == 0)
+                return Point.Zero;
+
+            return new Point(XmlConvert.ToInt32(inputs[index++]),
+                                XmlConvert.ToInt32(inputs[index++]));
         }
 
         protected internal override void Serialize(Point value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/QuaternionSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/QuaternionSerializer.cs
@@ -17,14 +17,13 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override Quaternion Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return new Quaternion(XmlConvert.ToSingle(inputs[index++]),
-                                        XmlConvert.ToSingle(inputs[index++]),
-                                        XmlConvert.ToSingle(inputs[index++]),
-                                        XmlConvert.ToSingle(inputs[index++]));
-            }
-            return Quaternion.Identity;
+            if (inputs.Length == 0)
+                return Quaternion.Identity;
+
+            return new Quaternion(XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]));
         }
 
         protected internal override void Serialize(Quaternion value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/QuaternionSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/QuaternionSerializer.cs
@@ -17,10 +17,14 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override Quaternion Deserialize(string[] inputs, ref int index)
         {
-            return new Quaternion(  XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]));
+            if (inputs.Length > 0)
+            {
+                return new Quaternion(XmlConvert.ToSingle(inputs[index++]),
+                                        XmlConvert.ToSingle(inputs[index++]),
+                                        XmlConvert.ToSingle(inputs[index++]),
+                                        XmlConvert.ToSingle(inputs[index++]));
+            }
+            return Quaternion.Identity;
         }
 
         protected internal override void Serialize(Quaternion value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/RectangleSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/RectangleSerializer.cs
@@ -17,14 +17,13 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override Rectangle Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return new Rectangle(XmlConvert.ToInt32(inputs[index++]),
-                                         XmlConvert.ToInt32(inputs[index++]),
-                                         XmlConvert.ToInt32(inputs[index++]),
-                                         XmlConvert.ToInt32(inputs[index++]));
-            }
-            return Rectangle.Empty;
+            if (inputs.Length == 0)
+                return Rectangle.Empty;
+
+            return new Rectangle(XmlConvert.ToInt32(inputs[index++]),
+                                     XmlConvert.ToInt32(inputs[index++]),
+                                     XmlConvert.ToInt32(inputs[index++]),
+                                     XmlConvert.ToInt32(inputs[index++]));
         }
 
         protected internal override void Serialize(Rectangle value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/RectangleSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/RectangleSerializer.cs
@@ -17,10 +17,14 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override Rectangle Deserialize(string[] inputs, ref int index)
         {
-            return new Rectangle(   XmlConvert.ToInt32(inputs[index++]),
-                                    XmlConvert.ToInt32(inputs[index++]),
-                                    XmlConvert.ToInt32(inputs[index++]),
-                                    XmlConvert.ToInt32(inputs[index++]));
+            if (inputs.Length > 0)
+            {
+                return new Rectangle(XmlConvert.ToInt32(inputs[index++]),
+                                         XmlConvert.ToInt32(inputs[index++]),
+                                         XmlConvert.ToInt32(inputs[index++]),
+                                         XmlConvert.ToInt32(inputs[index++]));
+            }
+            return Rectangle.Empty;
         }
 
         protected internal override void Serialize(Rectangle value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/SByteSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/SByteSerializer.cs
@@ -17,11 +17,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override sbyte Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return XmlConvert.ToSByte(inputs[index++]);
-            }
-            return new sbyte();
+            if (inputs.Length == 0)
+                return new sbyte();
+
+            return XmlConvert.ToSByte(inputs[index++]);
         }
 
         protected internal override void Serialize(sbyte value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/SByteSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/SByteSerializer.cs
@@ -17,7 +17,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override sbyte Deserialize(string[] inputs, ref int index)
         {
-            return XmlConvert.ToSByte(inputs[index++]);
+            if (inputs.Length > 0)
+            {
+                return XmlConvert.ToSByte(inputs[index++]);
+            }
+            return new sbyte();
         }
 
         protected internal override void Serialize(sbyte value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ShortSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ShortSerializer.cs
@@ -17,7 +17,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override short Deserialize(string[] inputs, ref int index)
         {
-            return XmlConvert.ToInt16(inputs[index++]);
+            if (inputs.Length > 0)
+            {
+                return XmlConvert.ToInt16(inputs[index++]);
+            }
+            return new short();
         }
 
         protected internal override void Serialize(short value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ShortSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ShortSerializer.cs
@@ -17,11 +17,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override short Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return XmlConvert.ToInt16(inputs[index++]);
-            }
-            return new short();
+            if (inputs.Length == 0)
+                return new short();
+
+            return XmlConvert.ToInt16(inputs[index++]);
         }
 
         protected internal override void Serialize(short value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/TimeSpanSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/TimeSpanSerializer.cs
@@ -18,7 +18,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override TimeSpan Deserialize(string[] inputs, ref int index)
         {
-            return XmlConvert.ToTimeSpan(inputs[index++]);
+            if (inputs.Length > 0)
+            {
+                return XmlConvert.ToTimeSpan(inputs[index++]);
+            }
+            return new TimeSpan();
         }
 
         protected internal override void Serialize(TimeSpan value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/TimeSpanSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/TimeSpanSerializer.cs
@@ -18,11 +18,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override TimeSpan Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return XmlConvert.ToTimeSpan(inputs[index++]);
-            }
-            return new TimeSpan();
+            if (inputs.Length == 0)
+                return new TimeSpan();
+
+            return XmlConvert.ToTimeSpan(inputs[index++]);
         }
 
         protected internal override void Serialize(TimeSpan value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/UIntSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/UIntSerializer.cs
@@ -17,11 +17,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override uint Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return XmlConvert.ToUInt32(inputs[index++]);
-            }
-            return new uint();
+            if (inputs.Length == 0)
+                return new uint();
+
+            return XmlConvert.ToUInt32(inputs[index++]);
         }
 
         protected internal override void Serialize(uint value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/UIntSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/UIntSerializer.cs
@@ -17,7 +17,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override uint Deserialize(string[] inputs, ref int index)
         {
-            return XmlConvert.ToUInt32(inputs[index++]);
+            if (inputs.Length > 0)
+            {
+                return XmlConvert.ToUInt32(inputs[index++]);
+            }
+            return new uint();
         }
 
         protected internal override void Serialize(uint value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ULongSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ULongSerializer.cs
@@ -17,7 +17,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override ulong Deserialize(string[] inputs, ref int index)
         {
-            return XmlConvert.ToUInt64(inputs[index++]);
+            if (inputs.Length > 0)
+            {
+                return XmlConvert.ToUInt64(inputs[index++]);
+            }
+            return new ulong();
         }
 
         protected internal override void Serialize(ulong value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ULongSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ULongSerializer.cs
@@ -17,11 +17,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override ulong Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return XmlConvert.ToUInt64(inputs[index++]);
-            }
-            return new ulong();
+            if (inputs.Length == 0)
+                return new ulong();
+
+            return XmlConvert.ToUInt64(inputs[index++]);
         }
 
         protected internal override void Serialize(ulong value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/UShortSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/UShortSerializer.cs
@@ -17,7 +17,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override ushort Deserialize(string[] inputs, ref int index)
         {
-            return XmlConvert.ToUInt16(inputs[index++]);
+            if (inputs.Length > 0)
+            {
+                return XmlConvert.ToUInt16(inputs[index++]);
+            }
+            return new ushort();
         }
 
         protected internal override void Serialize(ushort value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/UShortSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/UShortSerializer.cs
@@ -17,11 +17,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override ushort Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return XmlConvert.ToUInt16(inputs[index++]);
-            }
-            return new ushort();
+            if (inputs.Length == 0)
+                return new ushort();
+
+            return XmlConvert.ToUInt16(inputs[index++]);
         }
 
         protected internal override void Serialize(ushort value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/Vector2Serializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/Vector2Serializer.cs
@@ -17,12 +17,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override Vector2 Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return new Vector2(XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]));
-            }
-            return Vector2.Zero;
+            if (inputs.Length == 0)
+                return Vector2.Zero;
+
+            return new Vector2(XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]));
 
         }
 

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/Vector2Serializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/Vector2Serializer.cs
@@ -17,8 +17,13 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override Vector2 Deserialize(string[] inputs, ref int index)
         {
-            return new Vector2( XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]));
+            if (inputs.Length > 0)
+            {
+                return new Vector2(XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]));
+            }
+            return Vector2.Zero;
+
         }
 
         protected internal override void Serialize(Vector2 value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/Vector3Serializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/Vector3Serializer.cs
@@ -17,9 +17,13 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override Vector3 Deserialize(string[] inputs, ref int index)
         {
-            return new Vector3( XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]));
+            if (inputs.Length > 0)
+            {
+                return new Vector3(XmlConvert.ToSingle(inputs[index++]),
+                                     XmlConvert.ToSingle(inputs[index++]),
+                                     XmlConvert.ToSingle(inputs[index++]));
+            }
+            return Vector3.Zero;
         }
 
         protected internal override void Serialize(Vector3 value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/Vector3Serializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/Vector3Serializer.cs
@@ -17,13 +17,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override Vector3 Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return new Vector3(XmlConvert.ToSingle(inputs[index++]),
-                                     XmlConvert.ToSingle(inputs[index++]),
-                                     XmlConvert.ToSingle(inputs[index++]));
-            }
-            return Vector3.Zero;
+            if (inputs.Length == 0)
+                return Vector3.Zero;
+
+            return new Vector3(XmlConvert.ToSingle(inputs[index++]),
+                                 XmlConvert.ToSingle(inputs[index++]),
+                                 XmlConvert.ToSingle(inputs[index++]));
         }
 
         protected internal override void Serialize(Vector3 value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/Vector4Serializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/Vector4Serializer.cs
@@ -17,10 +17,14 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override Vector4 Deserialize(string[] inputs, ref int index)
         {
-            return new Vector4( XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]),
-                                XmlConvert.ToSingle(inputs[index++]));
+            if (inputs.Length > 0)
+            {
+                return new Vector4(XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]),
+                                    XmlConvert.ToSingle(inputs[index++]));
+            }
+            return Vector4.Zero;
         }
 
         protected internal override void Serialize(Vector4 value, List<string> results)

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/Vector4Serializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/Vector4Serializer.cs
@@ -17,14 +17,13 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
         protected internal override Vector4 Deserialize(string[] inputs, ref int index)
         {
-            if (inputs.Length > 0)
-            {
-                return new Vector4(XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]),
-                                    XmlConvert.ToSingle(inputs[index++]));
-            }
-            return Vector4.Zero;
+            if (inputs.Length == 0)
+                return Vector4.Zero;
+
+            return new Vector4(XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]),
+                                XmlConvert.ToSingle(inputs[index++]));
         }
 
         protected internal override void Serialize(Vector4 value, List<string> results)

--- a/Test/Assets/Xml/25_DeserialiseDefaults.xml
+++ b/Test/Assets/Xml/25_DeserialiseDefaults.xml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<XnaContent>
+  <!-- A fully qualified type -->
+  <Asset Type="MonoGame.Tests.ContentPipeline.DeserialiseDefaults">
+    <EmptyVector2 />
+    <Empty2Vector2></Empty2Vector2>
+    <EmptyPoint></EmptyPoint>
+    <EmptyRectangle></EmptyRectangle>
+    <EmptyVector3></EmptyVector3>
+    <EmptyVector4></EmptyVector4>
+    <EmptyQuaternion></EmptyQuaternion>
+    <EmptyPlane></EmptyPlane>
+    <EmptyMatrix></EmptyMatrix>
+    <EmptyString></EmptyString>
+    <EmptyBool></EmptyBool>
+    <EmptyInt></EmptyInt>
+    <EmptyFloat></EmptyFloat>
+    <EmptyByte></EmptyByte>
+    <EmptyChar></EmptyChar>
+    <EmptyColor></EmptyColor>
+    <EmptyDouble></EmptyDouble>
+    <EmptyLong></EmptyLong>
+    <EmptySbyte></EmptySbyte>
+    <EmptyShort></EmptyShort>
+    <EmptyTimeSpan></EmptyTimeSpan>
+    <EmptyUint></EmptyUint>
+    <EmptyUshort></EmptyUshort>
+  </Asset>
+</XnaContent>

--- a/Test/ContentPipeline/AssetTestClasses.cs
+++ b/Test/ContentPipeline/AssetTestClasses.cs
@@ -196,7 +196,7 @@ public class PrimitiveTypes
     public ulong ULong;
     public float Float;
     public double Double;
-    public char? NullChar;                        
+    public char? NullChar;
     public char? NotNullChar;
 }
 #endregion
@@ -487,6 +487,35 @@ namespace MonoGame.Tests.ContentPipeline
         public byte A;
         public List<Vector2> Vector2ListSpaced = new List<Vector2>();
         public string EmptyString;
+    }
+    #endregion
+
+    #region DeserialiseStructDefaults
+    public class DeserialiseDefaults
+    {
+        public Vector2 EmptyVector2;
+        public Vector2 Empty2Vector2;
+        public Point EmptyPoint;
+        public Rectangle EmptyRectangle;
+        public Vector3 EmptyVector3;
+        public Vector4 EmptyVector4;
+        public Quaternion EmptyQuaternion;
+        public Plane EmptyPlane;
+        public Matrix EmptyMatrix;
+        public string EmptyString;
+        public bool EmptyBool;
+        public int EmptyInt;
+        public float EmptyFloat;
+        public byte EmptyByte;
+        public char EmptyChar;
+        public Color EmptyColor;
+        public double EmptyDouble;
+        public long EmptyLong;
+        public sbyte EmptySbyte;
+        public short EmptyShort;
+        public TimeSpan EmptyTimeSpan;
+        public uint EmptyUint;
+        public ushort EmptyUshort;
     }
     #endregion
 }

--- a/Test/ContentPipeline/IntermediateDeserializerTest.cs
+++ b/Test/ContentPipeline/IntermediateDeserializerTest.cs
@@ -94,7 +94,7 @@ namespace MonoGame.Tests.ContentPipeline
                                 false, Directory.GetCurrentDirectory(), "referenceRelocationPath" });
 #else
             var compiler = new ContentCompiler();
-            compiler.Compile(xnbStream, result, TargetPlatform.Windows, GraphicsProfile.Reach, 
+            compiler.Compile(xnbStream, result, TargetPlatform.Windows, GraphicsProfile.Reach,
                                 false, "rootDirectory", "referenceRelocationPath");
 #endif
 
@@ -148,7 +148,7 @@ namespace MonoGame.Tests.ContentPipeline
             using (var reader = XmlReader.Create(filePath))
             {
                 // This should throw an InvalidContentException as the
-                // xml tries to set the <elf> element which has a 
+                // xml tries to set the <elf> element which has a
                 // [ContentSerializerIgnore] attribute.
                 Assert.Throws<InvalidContentException>(() =>
                     IntermediateSerializer.Deserialize<object>(reader, filePath));
@@ -195,7 +195,7 @@ namespace MonoGame.Tests.ContentPipeline
             using (var reader = XmlReader.Create(filePath))
             {
                 // This should throw an InvalidContentException as the
-                // xml tries to set the <elf> element which has a 
+                // xml tries to set the <elf> element which has a
                 // [ContentSerializerIgnore] attribute.
                 Assert.Throws<InvalidContentException>(() =>
                     IntermediateSerializer.Deserialize<object>(reader, filePath));
@@ -233,7 +233,7 @@ namespace MonoGame.Tests.ContentPipeline
                 Assert.AreEqual(new Color(0x91, 0x6B, 0x46, 0xFF), collections.ColorArray[1]);
                 Assert.AreEqual(new Color(0x91, 0x7B, 0x46, 0xFF), collections.ColorArray[2]);
                 Assert.AreEqual(new Color(0x88, 0x65, 0x43, 0xFF), collections.ColorArray[3]);
-            });            
+            });
         }
 
         [Test]
@@ -438,7 +438,7 @@ namespace MonoGame.Tests.ContentPipeline
                 Assert.AreEqual(true, fontDesc.UseKerning);
                 Assert.AreEqual(FontDescriptionStyle.Bold, fontDesc.Style);
                 Assert.AreEqual('*', fontDesc.DefaultCharacter);
-                        
+
                 var expectedCharacters = new List<char>();
                 for (var c = HttpUtility.HtmlDecode("&#32;")[0]; c <= HttpUtility.HtmlDecode("&#126;")[0]; c++)
                     expectedCharacters.Add(c);
@@ -535,6 +535,17 @@ namespace MonoGame.Tests.ContentPipeline
                 Assert.AreEqual(3, genericTypes.A.Value);
                 Assert.IsNotNull(genericTypes.B);
                 Assert.AreEqual(4.2f, genericTypes.B.Value);
+            });
+        }
+
+        [Test]
+        public void DeserialiseDefaults()
+        {
+            DeserializeCompileAndLoad<DeserialiseDefaults>("25_DeserialiseDefaults.xml", deserialiseDefaults =>
+            {
+                Assert.AreEqual(Vector2.Zero, deserialiseDefaults.EmptyVector2);
+                Assert.AreEqual(Vector2.Zero, deserialiseDefaults.Empty2Vector2);
+
             });
         }
     }

--- a/Test/ContentPipeline/IntermediateDeserializerTest.cs
+++ b/Test/ContentPipeline/IntermediateDeserializerTest.cs
@@ -545,6 +545,27 @@ namespace MonoGame.Tests.ContentPipeline
             {
                 Assert.AreEqual(Vector2.Zero, deserialiseDefaults.EmptyVector2);
                 Assert.AreEqual(Vector2.Zero, deserialiseDefaults.Empty2Vector2);
+                Assert.AreEqual(Point.Zero, deserialiseDefaults.EmptyPoint);
+                Assert.AreEqual(Rectangle.Empty, deserialiseDefaults.EmptyRectangle);
+                Assert.AreEqual(Vector3.Zero, deserialiseDefaults.EmptyVector3);
+                Assert.AreEqual(Vector4.Zero, deserialiseDefaults.EmptyVector4);
+                Assert.AreEqual(Quaternion.Identity, deserialiseDefaults.EmptyQuaternion);
+                Assert.AreEqual(new Plane(), deserialiseDefaults.EmptyPlane);
+                Assert.AreEqual(Matrix.Identity, deserialiseDefaults.EmptyMatrix);
+                Assert.AreEqual(String.Empty, deserialiseDefaults.EmptyString);
+                Assert.AreEqual(new bool(), deserialiseDefaults.EmptyBool);
+                Assert.AreEqual(new int(), deserialiseDefaults.EmptyInt);
+                Assert.AreEqual(new float(), deserialiseDefaults.EmptyFloat);
+                Assert.AreEqual(new byte(), deserialiseDefaults.EmptyByte);
+                Assert.AreEqual(new char(), deserialiseDefaults.EmptyChar);
+                Assert.AreEqual(new Color(), deserialiseDefaults.EmptyColor);
+                Assert.AreEqual(new double(), deserialiseDefaults.EmptyDouble);
+                Assert.AreEqual(new long(), deserialiseDefaults.EmptyLong);
+                Assert.AreEqual(new sbyte(), deserialiseDefaults.EmptySbyte);
+                Assert.AreEqual(new short(), deserialiseDefaults.EmptyShort);
+                Assert.AreEqual(new TimeSpan(), deserialiseDefaults.EmptyTimeSpan);
+                Assert.AreEqual(new uint(), deserialiseDefaults.EmptyUint);
+                Assert.AreEqual(new ushort(), deserialiseDefaults.EmptyUshort);
 
             });
         }


### PR DESCRIPTION
Updated deserialisation to support empty XML elements for all datatypes

E.g. 
```xml
<Vector2/>
<float/>
```
 and 
```xml
<Vector2></Vector2>
<float></float>
```

Tested all data type variants that have intermediate serialisers