### PR TITLE
Fix logic for applying texture effect parameters

### DIFF
--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -224,6 +224,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
 
+    <Content Include="Assets\Effects\CustomSpriteBatchEffect.fx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Assets\Effects\DefinesTest.fx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/MonoGame.Framework/Graphics/Effect/EffectPass.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectPass.cs
@@ -18,8 +18,6 @@ namespace Microsoft.Xna.Framework.Graphics
         private readonly DepthStencilState _depthStencilState;
         private readonly RasterizerState _rasterizerState;
 
-        private ulong _stateKey;
-
 		public string Name { get; private set; }
 
         public EffectAnnotationCollection Annotations { get; private set; }
@@ -92,12 +90,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
 #if OPENGL || DIRECTX
 
-            // If our state key becomes larger than the 
-            // next state key then the keys have rolled 
-            // over and we need to reset.
-            if (_stateKey > EffectParameter.NextStateKey)
-                _stateKey = 0;
-
             if (_vertexShader != null)
             {
                 device.VertexShader = _vertexShader;
@@ -121,16 +113,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     var param = _effect.Parameters[sampler.parameter];
                     var texture = param.Data as Texture;
 										
-                    // If there is no texture *explicitly* assigned then skip it
-                    // and leave whatever set directly on the device.
-                    // Each time an effect parameter value is set, param.StateKey
-                    // will be incremented. So if our stored _stateKey - which is the cached
-                    // value from the previous time Apply() was called - is less than the 
-                    // current value of param.StateKey, we know that this texture parameter 
-                    // has been explicitly set to a value since the previous time Apply()
-                    // was called.
-                    if (param.StateKey >= _stateKey)
-						device.Textures[sampler.textureSlot] = texture;
+                    device.Textures[sampler.textureSlot] = texture;
 
                     // If there is a sampler state set it.
                     if (sampler.state != null)
@@ -145,10 +128,6 @@ namespace Microsoft.Xna.Framework.Graphics
                     device.SetConstantBuffer(ShaderStage.Pixel, c, cb);
                 }
             }
-
-            // Store current value of NextStateKey, so we can detect whether any texture
-            // parameter values are set between now and the next call to Apply().
-            _stateKey = EffectParameter.NextStateKey;
 
 #endif
 

--- a/MonoGame.Framework/Graphics/SpriteBatcher.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatcher.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     var shouldFlush = !ReferenceEquals(item.Texture, tex);
                     if (shouldFlush)
                     {
-                        FlushVertexArray(startIndex, index, effect);
+                        FlushVertexArray(startIndex, index, effect, tex);
 
                         tex = item.Texture;
                         startIndex = index = 0;
@@ -265,21 +265,22 @@ namespace Microsoft.Xna.Framework.Graphics
                     _freeBatchItemQueue.Enqueue(item);
                 }
                 // flush the remaining vertexArray data
-                FlushVertexArray(startIndex, index, effect);
+                FlushVertexArray(startIndex, index, effect, tex);
                 // Update our batch count to continue the process of culling down
                 // large batches
                 batchCount -= numBatchesToProcess;
             }
 			_batchItemList.Clear();
 		}
-				
+
         /// <summary>
         /// Sends the triangle list to the graphics device. Here is where the actual drawing starts.
         /// </summary>
         /// <param name="start">Start index of vertices to draw. Not used except to compute the count of vertices to draw.</param>
         /// <param name="end">End index of vertices to draw. Not used except to compute the count of vertices to draw.</param>
         /// <param name="effect">The custom effect to apply to the geometry</param>
-        private void FlushVertexArray(int start, int end, Effect effect)
+        /// <param name="texture">The texture to draw.</param>
+        private void FlushVertexArray(int start, int end, Effect effect, Texture texture)
         {
             if (start == end)
                 return;
@@ -292,12 +293,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 var passes = effect.CurrentTechnique.Passes;
                 foreach (var pass in passes)
                 {
-                    // Whatever happens in pass.Apply, make sure the texture being drawn
-                    // ends up in Textures[0].
-                    var texture = _device.Textures[0];
-
                     pass.Apply();
 
+                    // Whatever happens in pass.Apply, make sure the texture being drawn
+                    // ends up in Textures[0].
                     _device.Textures[0] = texture;
 
                     _device.DrawUserIndexedPrimitives(

--- a/MonoGame.Framework/Graphics/SpriteBatcher.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatcher.cs
@@ -292,7 +292,13 @@ namespace Microsoft.Xna.Framework.Graphics
                 var passes = effect.CurrentTechnique.Passes;
                 foreach (var pass in passes)
                 {
+                    // Whatever happens in pass.Apply, make sure the texture being drawn
+                    // ends up in Textures[0].
+                    var texture = _device.Textures[0];
+
                     pass.Apply();
+
+                    _device.Textures[0] = texture;
 
                     _device.DrawUserIndexedPrimitives(
                         PrimitiveType.TriangleList,

--- a/Test/Assets/Effects/CustomSpriteBatchEffect.fx
+++ b/Test/Assets/Effects/CustomSpriteBatchEffect.fx
@@ -1,0 +1,31 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+#include "include.fxh"
+
+Texture2D SourceTexture;
+Texture2D OtherTexture;
+
+sampler2D SourceSampler = sampler_state
+{
+    Texture = (SourceTexture);
+};
+
+sampler2D OtherSampler = sampler_state
+{
+    Texture = (OtherTexture);
+};
+
+float4 PS_Main(float2 uv : TEXCOORD0) : COLOR0
+{
+    return tex2D(SourceSampler, uv) + tex2D(OtherSampler, uv);
+}
+
+technique
+{
+    pass
+    {
+        PixelShader = compile PS_PROFILE PS_Main();
+    }
+}

--- a/Test/ContentPipeline/AssetTestUtility.cs
+++ b/Test/ContentPipeline/AssetTestUtility.cs
@@ -2,6 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System.IO;
 using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using Microsoft.Xna.Framework.Content.Pipeline.Processors;
@@ -15,9 +16,11 @@ namespace MonoGame.Tests.ContentPipeline
         {
             var effectProcessor = new EffectProcessor();
             var context = new TestProcessorContext(TargetPlatform.Windows, "notused.xnb");
+            var effectPath = Paths.Effect(pathParts);
             var compiledEffect = effectProcessor.Process(new EffectContent
             {
-                Identity = new ContentIdentity(Paths.Effect(pathParts))
+                EffectCode = File.ReadAllText(effectPath),
+                Identity = new ContentIdentity(effectPath)
             }, context);
 
             return new Effect(graphicsDevice, compiledEffect.GetEffectCode());

--- a/Test/ContentPipeline/TestProcessorContext.cs
+++ b/Test/ContentPipeline/TestProcessorContext.cs
@@ -21,7 +21,7 @@ namespace MonoGame.Tests.ContentPipeline
 
         public override string BuildConfiguration
         {
-            get { throw new NotImplementedException(); }
+            get { return "Debug"; }
         }
 
         public override string IntermediateDirectory
@@ -56,7 +56,7 @@ namespace MonoGame.Tests.ContentPipeline
 
         public override GraphicsProfile TargetProfile
         {
-            get { throw new NotImplementedException(); }
+            get { return GraphicsProfile.HiDef; }
         }
 
         public override void AddDependency(string filename)

--- a/Test/Framework/Visual/EffectTest.cs
+++ b/Test/Framework/Visual/EffectTest.cs
@@ -32,6 +32,35 @@ namespace MonoGame.Tests.Visual
         }
 
         [Test]
+        public void EffectPassShouldSetTextureOnSubsequentCalls()
+        {
+            Game.DrawWith += (sender, e) =>
+            {
+                var texture = new Texture2D(Game.GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
+                Game.GraphicsDevice.Textures[0] = null;
+
+                var effect = new BasicEffect(Game.GraphicsDevice);
+                effect.TextureEnabled = true;
+                effect.Texture = texture;
+
+                Assert.That(Game.GraphicsDevice.Textures[0], Is.Null);
+
+                var effectPass = effect.CurrentTechnique.Passes[0];
+                effectPass.Apply();
+
+                Assert.That(Game.GraphicsDevice.Textures[0], Is.SameAs(texture));
+
+                Game.GraphicsDevice.Textures[0] = null;
+
+                effectPass = effect.CurrentTechnique.Passes[0];
+                effectPass.Apply();
+
+                Assert.That(Game.GraphicsDevice.Textures[0], Is.SameAs(texture));
+            };
+            Game.Run();
+        }
+
+        [Test]
         public void EffectPassShouldSetTextureEvenIfNull()
         {
             Game.DrawWith += (sender, e) =>

--- a/Test/Framework/Visual/EffectTest.cs
+++ b/Test/Framework/Visual/EffectTest.cs
@@ -81,5 +81,26 @@ namespace MonoGame.Tests.Visual
             };
             Game.Run();
         }
+
+        [Test]
+        public void EffectPassShouldOverrideTextureIfNotExplicitlySet()
+        {
+            Game.DrawWith += (sender, e) =>
+            {
+                var texture = new Texture2D(Game.GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
+                Game.GraphicsDevice.Textures[0] = texture;
+
+                var effect = new BasicEffect(Game.GraphicsDevice);
+                effect.TextureEnabled = true;
+
+                Assert.That(Game.GraphicsDevice.Textures[0], Is.SameAs(texture));
+
+                var effectPass = effect.CurrentTechnique.Passes[0];
+                effectPass.Apply();
+
+                Assert.That(Game.GraphicsDevice.Textures[0], Is.Null);
+            };
+            Game.Run();
+        }
     }
 }

--- a/Test/Framework/Visual/SpriteBatchTest.cs
+++ b/Test/Framework/Visual/SpriteBatchTest.cs
@@ -5,7 +5,9 @@ using System.Text;
 
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+#if DIRECTX || XNA
 using MonoGame.Tests.ContentPipeline;
+#endif
 using NUnit.Framework;
 
 namespace MonoGame.Tests.Visual {
@@ -290,6 +292,7 @@ namespace MonoGame.Tests.Visual {
             Game.Run();
         }
 
+#if DIRECTX || XNA
         [Test]
         public void DrawWithCustomEffectAndTwoTextures()
         {
@@ -310,5 +313,6 @@ namespace MonoGame.Tests.Visual {
             };
             Game.Run();
         }
+#endif
 	}
 }

--- a/Test/Framework/Visual/SpriteBatchTest.cs
+++ b/Test/Framework/Visual/SpriteBatchTest.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-
+using MonoGame.Tests.ContentPipeline;
 using NUnit.Framework;
 
 namespace MonoGame.Tests.Visual {
@@ -291,21 +291,22 @@ namespace MonoGame.Tests.Visual {
         }
 
         [Test]
-        public void DrawWithTextureAlreadySet()
+        public void DrawWithCustomEffectAndTwoTextures()
         {
             Game.DrawWith += (sender, e) =>
             {
+                var customSpriteEffect = AssetTestUtility.CompileEffect(Game.GraphicsDevice, "CustomSpriteBatchEffect.fx");
                 var texture2 = new Texture2D(Game.GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
 
-                Game.GraphicsDevice.Textures[0] = texture2;
-                Game.GraphicsDevice.Textures[1] = _texture;
+                customSpriteEffect.Parameters["SourceTexture"].SetValue(texture2);
+                customSpriteEffect.Parameters["OtherTexture"].SetValue(texture2);
 
-                _spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.Opaque);
+                _spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.Opaque, null, null, null, customSpriteEffect);
                 _spriteBatch.Draw(_texture, new Vector2(20, 20), Color.White);
                 _spriteBatch.End();
 
                 Assert.That(Game.GraphicsDevice.Textures[0], Is.SameAs(_texture));
-                Assert.That(Game.GraphicsDevice.Textures[1], Is.SameAs(_texture));
+                Assert.That(Game.GraphicsDevice.Textures[1], Is.SameAs(texture2));
             };
             Game.Run();
         }

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -200,6 +200,9 @@
       <Link>Assets\Effects\Stock\Structures.fxh</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Assets\Effects\CustomSpriteBatchEffect.fx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Assets\Effects\ParserTest.fx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
This essentially undoes #3385, and applies a much simpler fix.

The first 2 commits just add tests; the last of the 3 commits implements the fixes.

A couple of things to note:

* The `stateKey`-based system I added in #3385 to decide whether to apply textures from effect parameters wasn't correct. If you switched between multiple effects, but didn't explicitly call `textureParameter.SetValue` each time, textures wouldn't be re-applied. I think this probably caused #3549.
* If you are using a custom effect with `SpriteBatch`, and that custom effect uses a couple of textures, then XNA always sets the texture you specify in `spriteBatch.Draw` into the first texture slot, even if you have explicitly set that texture to something else in your effect parameters. This was the part I didn't understand before - but I've added a test for it now. Because of this, I can remove the `stateKey` stuff from `EffectPass`.

So this PR changes the logic to: **always use the textures specified in effect parameters (`null` or otherwise), but if you're using `SpriteBatch` then ensure `Textures[0]` is set to the texture you passed to `spriteBatch.Draw`, regardless of what the effect parameter values are.**

Once again, I'd appreciate feedback on this one. Especially after I got it wrong last time :) But if it looks good, then we should merge it as soon as possible, given that it (hopefully) fixes quite a big bug.