### PR TITLE
Implement TextureCube.GetData for DirectX

### DIFF
--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -132,6 +132,7 @@
     <Compile Include="Framework\Visual\ScissorRectangleTest.cs" />
     <Compile Include="Framework\Visual\Texture2DTest.cs" />
     <Compile Include="Framework\Visual\Texture3DTest.cs" />
+    <Compile Include="Framework\Visual\TextureCubeTest.cs" />
     <Compile Include="Framework\Visual\IndexBufferTest.cs" />
     <Compile Include="Framework\Visual\VertexBufferTest.cs" />
     <Compile Include="Framework\Visual\MiscellaneousTests.cs" />

--- a/MonoGame.Framework/Graphics/TextureCube.DirectX.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.DirectX.cs
@@ -3,9 +3,12 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-
+using System.IO;
+using System.Runtime.InteropServices;
 using SharpDX;
 using SharpDX.Direct3D11;
+using SharpDX.DXGI;
+using MapFlags = SharpDX.Direct3D11.MapFlags;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -51,14 +54,75 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformGetData<T>(CubeMapFace cubeMapFace, T[] data) where T : struct
         {
-            throw new NotImplementedException();
+            // Create a temp staging resource for copying the data.
+            // 
+            // TODO: Like in Texture2D, we should probably be pooling these staging resources
+            // and not creating a new one each time.
+            //
+            var desc = new Texture2DDescription
+            {
+                Width = size,
+                Height = size,
+                MipLevels = 1,
+                ArraySize = 1,
+                Format = SharpDXHelper.ToFormat(_format),
+                SampleDescription = new SampleDescription(1, 0),
+                BindFlags = BindFlags.None,
+                CpuAccessFlags = CpuAccessFlags.Read,
+                Usage = ResourceUsage.Staging,
+                OptionFlags = ResourceOptionFlags.None,
+            };
+
+            var d3dContext = GraphicsDevice._d3dContext;
+            using (var stagingTex = new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice, desc))
+            {
+                lock (d3dContext)
+                {
+                    // Copy the data from the GPU to the staging texture.
+                    int subresourceIndex = CalculateSubresourceIndex(cubeMapFace, 0);
+                    d3dContext.CopySubresourceRegion(GetTexture(), subresourceIndex, null, stagingTex, 0);
+
+                    // Copy the data to the array.
+                    DataStream stream;
+                    var databox = d3dContext.MapSubresource(stagingTex, 0, MapMode.Read, MapFlags.None, out stream);
+
+                    const int startIndex = 0;
+                    var elementCount = data.Length;
+                    var elementSize = _format.GetSize();
+                    var elementsInRow = size;
+                    var rows = size;
+                    var rowSize = elementSize * elementsInRow;
+                    if (rowSize == databox.RowPitch)
+                        stream.ReadRange(data, startIndex, elementCount);
+                    else
+                    {
+                        // Some drivers may add pitch to rows.
+                        // We need to copy each row separatly and skip trailing zeros.
+                        stream.Seek(startIndex, SeekOrigin.Begin);
+
+                        int elementSizeInByte = Marshal.SizeOf(typeof(T));
+                        for (var row = 0; row < rows; row++)
+                        {
+                            int i;
+                            for (i = row * rowSize / elementSizeInByte; i < (row + 1) * rowSize / elementSizeInByte; i++)
+                                data[i] = stream.Read<T>();
+
+                            if (i >= elementCount)
+                                break;
+
+                            stream.Seek(databox.RowPitch - rowSize, SeekOrigin.Current);
+                        }
+                    }
+                    stream.Dispose();
+                }
+            }
         }
 
         private void PlatformSetData<T>(CubeMapFace face, int level, IntPtr dataPtr, int xOffset, int yOffset, int width, int height)
         {
                 var box = new DataBox(dataPtr, GetPitch(width), 0);
 
-            int subresourceIndex = (int)face * _levelCount + level;
+                int subresourceIndex = CalculateSubresourceIndex(face, level);
 
                 var region = new ResourceRegion
                 {
@@ -74,6 +138,11 @@ namespace Microsoft.Xna.Framework.Graphics
             lock (d3dContext)
                 d3dContext.UpdateSubresource(box, GetTexture(), subresourceIndex, region);
         }
+
+	    private int CalculateSubresourceIndex(CubeMapFace face, int level)
+	    {
+	        return (int) face * _levelCount + level;
+	    }
 	}
 }
 

--- a/Test/Framework/Visual/TextureCubeTest.cs
+++ b/Test/Framework/Visual/TextureCubeTest.cs
@@ -1,0 +1,40 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using NUnit.Framework;
+
+namespace MonoGame.Tests.Visual
+{
+    [TestFixture]
+    class TextureCubeTest : VisualTestFixtureBase
+    {
+        [TestCase(1)]
+        [TestCase(8)]
+        [TestCase(31)]
+        public void ShouldSetAndGetData(int size)
+        {
+            Game.DrawWith += (sender, e) =>
+            {
+                var dataSize = size * size;
+                var textureCube = new TextureCube(Game.GraphicsDevice, size, false, SurfaceFormat.Color);
+
+                for (var i = 0; i < 6; i++)
+                {
+                    var savedData = new Color[dataSize];
+                    for (var index = 0; index < dataSize; index++)
+                        savedData[index] = new Color(index + i, index + i, index + i);
+                    textureCube.SetData((CubeMapFace) i, savedData);
+
+                    var readData = new Color[dataSize];
+                    textureCube.GetData((CubeMapFace) i, readData);
+
+                    Assert.AreEqual(savedData, readData);
+                }
+            };
+            Game.Run();
+        }
+    }
+}

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Framework\Visual\IndexBufferTest.cs" />
     <Compile Include="Framework\Visual\RasterizerStateTest.cs" />
     <Compile Include="Framework\Visual\SamplerStateTest.cs" />
+    <Compile Include="Framework\Visual\TextureCubeTest.cs" />
     <Compile Include="Framework\Visual\VertexBufferTest.cs" />
     <Compile Include="Framework\Visual\ScissorRectangleTest.cs" />
     <Compile Include="Framework\Visual\Texture2DTest.cs" />


### PR DESCRIPTION
Most of the time you probably don't need this method, but when you do, you do...

(In my engine / editor, I'm rendering a skybox (either from a `TextureCube` or a procedural shader) into a `RenderTargetCube`, then using `TextureCube.GetData` to extract the rendered data and convert it to spherical harmonics, and finally using the spherical harmonics to render a directional ambient term that matches up nicely with the skybox.)