### PR TITLE
Triangle strip GetElementCountArray fix

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -942,7 +942,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private static int GetElementCountArray(PrimitiveType primitiveType, int primitiveCount)
         {
-            //TODO: Overview the calculation
             switch (primitiveType)
             {
                 case PrimitiveType.LineList:

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -952,7 +952,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 case PrimitiveType.TriangleList:
                     return primitiveCount * 3;
                 case PrimitiveType.TriangleStrip:
-                    return 3 + (primitiveCount - 1); // ???
+                    return primitiveCount + 2;
             }
 
             throw new NotSupportedException();


### PR DESCRIPTION
The element count calculation for a triangle strip should be primitiveCount + 2.  A triangle is only drawn once three vertices are specified; thereafter an additional triangle is drawn for every additional vertex.

1 triangle    =>  3 vertices
2 triangles  =>  4 vertices
3 triangles  =>  5 vertices
...

thus vertex count = triangle count + 2