### PR TITLE
SpriteBatch.DrawCount property

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		Rectangle _tempRect = new Rectangle (0,0,0,0);
 		Vector2 _texCoordTL = new Vector2 (0,0);
 		Vector2 _texCoordBR = new Vector2 (0,0);
-        ulong _drawCount;
+        uint _drawCount;
 
         /// <summary>
         /// Gets the internal amount of draw calls which happened between <see cref="SpriteBatch.Begin"/> and <see cref="SpriteBatch.End"/>.
@@ -38,7 +38,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <remarks>
         /// String drawing will increase this value by the amount of characters in text.
         /// </remarks>
-        public ulong DrawCount { get { return _drawCount; } }
+        public uint DrawCount { get { return _drawCount; } }
 
         /// <summary>
         /// Creates a new instance of <see cref="SpriteBatch"/> class.

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -410,7 +410,7 @@ namespace Microsoft.Xna.Framework.Graphics
 			
 		    unchecked
 		    {
-                ++_drawCount;
+                _drawCount++;
 		    }
 			if (autoFlush)
 			{

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -1,3 +1,7 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
 using System;
 using System.Text;
 
@@ -26,6 +30,15 @@ namespace Microsoft.Xna.Framework.Graphics
 		Rectangle _tempRect = new Rectangle (0,0,0,0);
 		Vector2 _texCoordTL = new Vector2 (0,0);
 		Vector2 _texCoordBR = new Vector2 (0,0);
+        ulong _drawCount;
+
+        /// <summary>
+        /// Gets the internal amount of draw calls which happened between <see cref="SpriteBatch.Begin"/> and <see cref="SpriteBatch.End"/>.
+        /// </summary>
+        /// <remarks>
+        /// String drawing will increase this value by the amount of characters in text.
+        /// </remarks>
+        public ulong DrawCount { get { return _drawCount; } }
 
         /// <summary>
         /// Creates a new instance of <see cref="SpriteBatch"/> class.
@@ -85,6 +98,7 @@ namespace Microsoft.Xna.Framework.Graphics
             _rasterizerState = rasterizerState ?? RasterizerState.CullCounterClockwise;
             _effect = effect;
             _matrix = transformMatrix ?? Matrix.Identity;
+            _drawCount = 0;
 
             // Setup things now so a user can change them.
             if (sortMode == SpriteSortMode.Immediate)
@@ -394,6 +408,10 @@ namespace Microsoft.Xna.Framework.Graphics
 					_texCoordTL, 
 					_texCoordBR);			
 			
+		    unchecked
+		    {
+                ++_drawCount;
+		    }
 			if (autoFlush)
 			{
 				FlushIfNeeded();


### PR DESCRIPTION
This is addition to SpriteBatch which is ulong value which will increase every DrawInternal call. Useful for debugging purposes and performance increasing. The value is unchecked so it is defended from overflow exception.