### PR TITLE
Vector docs

### DIFF
--- a/MonoGame.Framework/Vector2.cs
+++ b/MonoGame.Framework/Vector2.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Xna.Framework
     [DebuggerDisplay("{DebugDisplayString,nq}")]
     public struct Vector2 : IEquatable<Vector2>
     {
-        #region Private Fields
+        #region Private Static Fields
 
         private static Vector2 zeroVector = new Vector2(0f, 0f);
         private static Vector2 unitVector = new Vector2(1f, 1f);
@@ -30,13 +30,13 @@ namespace Microsoft.Xna.Framework
         #region Public Fields
 
         /// <summary>
-        /// The x coordinate of this <see cref="Vector2"/>.
+        /// The x coordinate of this vector.
         /// </summary>
         [DataMember]
         public float X;
 
         /// <summary>
-        /// The y coordinate of this <see cref="Vector2"/>.
+        /// The y coordinate of this vector.
         /// </summary>
         [DataMember]
         public float Y;
@@ -97,7 +97,7 @@ namespace Microsoft.Xna.Framework
         #region Constructors
 
         /// <summary>
-        /// Creates a new instance of <see cref="Vector2"/> struct, with the specified position.
+        /// Creates a new instance of <see cref="Vector2"/> struct.
         /// </summary>
         /// <param name="x">The x coordinate in 2d-space.</param>
         /// <param name="y">The y coordinate in 2d-space.</param>
@@ -108,7 +108,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new instance of <see cref="Vector2"/> struct, with the specified position.
+        /// Creates a new instance of <see cref="Vector2"/> struct.
         /// </summary>
         /// <param name="value">The x and y coordinates in 2d-space.</param>
         public Vector2(float value)
@@ -252,7 +252,7 @@ namespace Microsoft.Xna.Framework
         #region Public Methods
 
         /// <summary>
-        /// Performs vector addition on <paramref name="value1"/> and <paramref name="value2"/>.
+        /// Creates a new vector which contains sum of two vectors.
         /// </summary>
         /// <param name="value1">The first vector to add.</param>
         /// <param name="value2">The second vector to add.</param>
@@ -265,13 +265,11 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Performs vector addition on <paramref name="value1"/> and
-        /// <paramref name="value2"/>, storing the result of the
-        /// addition in <paramref name="result"/>.
+        /// Creates a new vector which contains sum of two vectors.
         /// </summary>
         /// <param name="value1">The first vector to add.</param>
         /// <param name="value2">The second vector to add.</param>
-        /// <param name="result">The result of the vector addition.</param>
+        /// <param name="result">The result of the vector addition as an output parameter.</param>
         public static void Add(ref Vector2 value1, ref Vector2 value2, out Vector2 result)
         {
             result.X = value1.X + value2.X;
@@ -279,7 +277,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains the cartesian coordinates of a vector specified in barycentric coordinates and relative to 2d-triangle.
+        /// Creates a new vector that contains the cartesian coordinates of a vector specified in barycentric coordinates and relative to 2d-triangle.
         /// </summary>
         /// <param name="value1">The first vector of 2d-triangle.</param>
         /// <param name="value2">The second vector of 2d-triangle.</param>
@@ -295,7 +293,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains the cartesian coordinates of a vector specified in barycentric coordinates and relative to 2d-triangle.
+        /// Creates a new vector that contains the cartesian coordinates of a vector specified in barycentric coordinates and relative to 2d-triangle.
         /// </summary>
         /// <param name="value1">The first vector of 2d-triangle.</param>
         /// <param name="value2">The second vector of 2d-triangle.</param>
@@ -310,7 +308,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains CatmullRom interpolation of the specified vectors.
+        /// Creates a new vector that contains CatmullRom interpolation of the specified vectors.
         /// </summary>
         /// <param name="value1">The first vector in interpolation.</param>
         /// <param name="value2">The second vector in interpolation.</param>
@@ -326,7 +324,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains CatmullRom interpolation of the specified vectors.
+        /// Creates a new vector that contains CatmullRom interpolation of the specified vectors.
         /// </summary>
         /// <param name="value1">The first vector in interpolation.</param>
         /// <param name="value2">The second vector in interpolation.</param>
@@ -341,11 +339,11 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Clamps the specified value within a range.
+        /// Clamps the specified vector values within a range of another vectors.
         /// </summary>
-        /// <param name="value1">The value to clamp.</param>
-        /// <param name="min">The min value.</param>
-        /// <param name="max">The max value.</param>
+        /// <param name="value1">The vector to clamp.</param>
+        /// <param name="min">The min vector.</param>
+        /// <param name="max">The max vector.</param>
         /// <returns>The clamped value.</returns>
         public static Vector2 Clamp(Vector2 value1, Vector2 min, Vector2 max)
         {
@@ -355,11 +353,11 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Clamps the specified value within a range.
+        /// Clamps the specified vector values within a range of another vectors.
         /// </summary>
-        /// <param name="value1">The value to clamp.</param>
-        /// <param name="min">The min value.</param>
-        /// <param name="max">The max value.</param>
+        /// <param name="value1">The vector to clamp.</param>
+        /// <param name="min">The min vector.</param>
+        /// <param name="max">The max vector.</param>
         /// <param name="result">The clamped value as an output parameter.</param>
         public static void Clamp(ref Vector2 value1, ref Vector2 min, ref Vector2 max, out Vector2 result)
         {
@@ -370,8 +368,8 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// Returns the distance between two vectors.
         /// </summary>
-        /// <param name="value1">The first <see cref="Vector2"/>.</param>
-        /// <param name="value2">The second <see cref="Vector2"/>.</param>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
         /// <returns>The distance between two vectors.</returns>
         public static float Distance(Vector2 value1, Vector2 value2)
         {
@@ -382,8 +380,8 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// Returns the distance between two vectors.
         /// </summary>
-        /// <param name="value1">The first <see cref="Vector2"/>.</param>
-        /// <param name="value2">The second <see cref="Vector2"/>.</param>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
         /// <param name="result">The distance between two vectors as an output parameter.</param>
         public static void Distance(ref Vector2 value1, ref Vector2 value2, out float result)
         {
@@ -394,8 +392,8 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// Returns the squared distance between two vectors.
         /// </summary>
-        /// <param name="value1">The first <see cref="Vector2"/>.</param>
-        /// <param name="value2">The second <see cref="Vector2"/>.</param>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
         /// <returns>The squared distance between two vectors.</returns>
         public static float DistanceSquared(Vector2 value1, Vector2 value2)
         {
@@ -406,8 +404,8 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// Returns the squared distance between two vectors.
         /// </summary>
-        /// <param name="value1">The first <see cref="Vector2"/>.</param>
-        /// <param name="value2">The second <see cref="Vector2"/>.</param>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
         /// <param name="result">The squared distance between two vectors as an output parameter.</param>
         public static void DistanceSquared(ref Vector2 value1, ref Vector2 value2, out float result)
         {
@@ -416,10 +414,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Divides the components of a <see cref="Vector2"/> by the components of another <see cref="Vector2"/>.
+        /// Creates a new vector that contains the result of division of source vector by divider vector.
         /// </summary>
-        /// <param name="value1">Source <see cref="Vector2"/>.</param>
-        /// <param name="value2">Divisor <see cref="Vector2"/>.</param>
+        /// <param name="value1">Source vector.</param>
+        /// <param name="value2">Divider vector.</param>
         /// <returns>The result of dividing the vectors.</returns>
         public static Vector2 Divide(Vector2 value1, Vector2 value2)
         {
@@ -429,10 +427,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Divides the components of a <see cref="Vector2"/> by the components of another <see cref="Vector2"/>.
+        /// Creates a new vector that contains the result of division of source vector by divider vector.
         /// </summary>
-        /// <param name="value1">Source <see cref="Vector2"/>.</param>
-        /// <param name="value2">Divisor <see cref="Vector2"/>.</param>
+        /// <param name="value1">Source vector.</param>
+        /// <param name="value2">Divider vector.</param>
         /// <param name="result">The result of dividing the vectors as an output parameter.</param>
         public static void Divide(ref Vector2 value1, ref Vector2 value2, out Vector2 result)
         {
@@ -441,10 +439,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Divides the components of a <see cref="Vector2"/> by a scalar.
+        /// Creates a new vector that contains the result of division of source vector by divider scalar.
         /// </summary>
-        /// <param name="value1">Source <see cref="Vector2"/>.</param>
-        /// <param name="divider">Divisor scalar.</param>
+        /// <param name="value1">Source vector.</param>
+        /// <param name="divider">Divider scalar.</param>
         /// <returns>The result of dividing a vector by a scalar.</returns>
         public static Vector2 Divide(Vector2 value1, float divider)
         {
@@ -455,10 +453,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Divides the components of a <see cref="Vector2"/> by a scalar.
+        /// Creates a new vector that contains the result of division of source vector by divider scalar.
         /// </summary>
-        /// <param name="value1">Source <see cref="Vector2"/>.</param>
-        /// <param name="divider">Divisor scalar.</param>
+        /// <param name="value1">Source vector.</param>
+        /// <param name="divider">Divider scalar.</param>
         /// <param name="result">The result of dividing a vector by a scalar as an output parameter.</param>
         public static void Divide(ref Vector2 value1, float divider, out Vector2 result)
         {
@@ -470,8 +468,8 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// Returns a dot product of two vectors.
         /// </summary>
-        /// <param name="value1">The first <see cref="Vector2"/>.</param>
-        /// <param name="value2">The second <see cref="Vector2"/>.</param>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
         /// <returns>The dot product of two vectors.</returns>
         public static float Dot(Vector2 value1, Vector2 value2)
         {
@@ -481,8 +479,8 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// Returns a dot product of two vectors.
         /// </summary>
-        /// <param name="value1">The first <see cref="Vector2"/>.</param>
-        /// <param name="value2">The second <see cref="Vector2"/>.</param>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
         /// <param name="result">The dot product of two vectors as an output parameter.</param>
         public static void Dot(ref Vector2 value1, ref Vector2 value2, out float result)
         {
@@ -524,7 +522,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains hermite spline interpolation.
+        /// Creates a new vector that contains the result of hermite spline interpolation.
         /// </summary>
         /// <param name="value1">The first position vector.</param>
         /// <param name="tangent1">The first tangent vector.</param>
@@ -538,7 +536,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains hermite spline interpolation.
+        /// Creates a new vector that contains the result of hermite spline interpolation.
         /// </summary>
         /// <param name="value1">The first position vector.</param>
         /// <param name="tangent1">The first tangent vector.</param>
@@ -553,28 +551,28 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Returns the length of this <see cref="Vector2"/>.
+        /// Returns the length of this vector.
         /// </summary>
-        /// <returns>The length of this <see cref="Vector2"/>.</returns>
+        /// <returns>The length of this vector.</returns>
         public float Length()
         {
             return (float)Math.Sqrt((X * X) + (Y * Y));
         }
 
         /// <summary>
-        /// Returns the squared length of this <see cref="Vector2"/>.
+        /// Returns the squared length of this vector.
         /// </summary>
-        /// <returns>The squared length of this <see cref="Vector2"/>.</returns>
+        /// <returns>The squared length of this vector.</returns>
         public float LengthSquared()
         {
             return (X * X) + (Y * Y);
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains linear interpolation of the specified vectors.
+        /// Creates a new vector that contains linear interpolation of the specified vectors.
         /// </summary>
-        /// <param name="value1">The first <see cref="Vector2"/>.</param>
-        /// <param name="value2">The second <see cref="Vector2"/>.</param>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
         /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
         /// <returns>The result of linear interpolation of the specified vectors.</returns>
         public static Vector2 Lerp(Vector2 value1, Vector2 value2, float amount)
@@ -585,10 +583,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains linear interpolation of the specified vectors.
+        /// Creates a new vector that contains linear interpolation of the specified vectors.
         /// </summary>
-        /// <param name="value1">The first <see cref="Vector2"/>.</param>
-        /// <param name="value2">The second <see cref="Vector2"/>.</param>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
         /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
         /// <param name="result">The result of linear interpolation of the specified vectors as an output parameter.</param>
         public static void Lerp(ref Vector2 value1, ref Vector2 value2, float amount, out Vector2 result)
@@ -598,11 +596,11 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains a maximal values from the two vectors.
+        /// Creates a new vector that contains the maximal values from the two vectors.
         /// </summary>
-        /// <param name="value1">The first <see cref="Vector2"/>.</param>
-        /// <param name="value2">The second <see cref="Vector2"/>.</param>
-        /// <returns>The <see cref="Vector2"/> with maximal values from the two vectors.</returns>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>A new vector with maximal values from the two vectors.</returns>
         public static Vector2 Max(Vector2 value1, Vector2 value2)
         {
             return new Vector2(value1.X > value2.X ? value1.X : value2.X,
@@ -610,11 +608,11 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains a maximal values from the two vectors.
+        /// Creates a new vector that contains the maximal values from the two vectors.
         /// </summary>
-        /// <param name="value1">The first <see cref="Vector2"/>.</param>
-        /// <param name="value2">The second <see cref="Vector2"/>.</param>
-        /// <param name="result">The <see cref="Vector2"/> with maximal values from the two vectors as an output parameter.</param>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="result">A new vector with maximal values from the two vectors as an output parameter.</param>
         public static void Max(ref Vector2 value1, ref Vector2 value2, out Vector2 result)
         {
             result.X = value1.X > value2.X ? value1.X : value2.X;
@@ -622,11 +620,11 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains a minimal values from the two vectors.
+        /// Creates a new vector that contains the minimal values from the two vectors.
         /// </summary>
-        /// <param name="value1">The first <see cref="Vector2"/>.</param>
-        /// <param name="value2">The second <see cref="Vector2"/>.</param>
-        /// <returns>The <see cref="Vector2"/> with minimal values from the two vectors.</returns>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>A new vector with minimal values from the two vectors.</returns>
         public static Vector2 Min(Vector2 value1, Vector2 value2)
         {
             return new Vector2(value1.X < value2.X ? value1.X : value2.X,
@@ -634,11 +632,11 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains a minimal values from the two vectors.
+        /// Creates a new vector that contains the minimal values from the two vectors.
         /// </summary>
-        /// <param name="value1">The first <see cref="Vector2"/>.</param>
-        /// <param name="value2">The second <see cref="Vector2"/>.</param>
-        /// <param name="result">The <see cref="Vector2"/> with minimal values from the two vectors as an output parameter.</param>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="result">A new vector with minimal values from the two vectors as an output parameter.</param>
         public static void Min(ref Vector2 value1, ref Vector2 value2, out Vector2 result)
         {
             result.X = value1.X < value2.X ? value1.X : value2.X;
@@ -646,7 +644,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains a multiplication of two vectors.
+        /// Creates a new vector that contains a multiplication of two vectors.
         /// </summary>
         /// <param name="value1">Source <see cref="Vector2"/>.</param>
         /// <param name="value2">Source <see cref="Vector2"/>.</param>
@@ -659,7 +657,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains a multiplication of two vectors.
+        /// Creates a new vector that contains a multiplication of two vectors.
         /// </summary>
         /// <param name="value1">Source <see cref="Vector2"/>.</param>
         /// <param name="value2">Source <see cref="Vector2"/>.</param>
@@ -671,9 +669,9 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains a multiplication of <see cref="Vector2"/> and a scalar.
+        /// Creates a new vector that contains a multiplication of vector and a scalar.
         /// </summary>
-        /// <param name="value1">Source <see cref="Vector2"/>.</param>
+        /// <param name="value1">Source vector.</param>
         /// <param name="scaleFactor">Scalar value.</param>
         /// <returns>Result of the vector multiplication with a scalar.</returns>
         public static Vector2 Multiply(Vector2 value1, float scaleFactor)
@@ -684,11 +682,11 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains a multiplication of <see cref="Vector2"/> and a scalar.
+        /// Creates a new vector that contains a multiplication of vector and a scalar.
         /// </summary>
-        /// <param name="value1">Source <see cref="Vector2"/>.</param>
+        /// <param name="value1">Source vector.</param>
         /// <param name="scaleFactor">Scalar value.</param>
-        /// <param name="result">Result of the multiplication with a scalar as an output parameter.</param>
+        /// <param name="result">Result of the vector multiplication with a scalar as an output parameter.</param>
         public static void Multiply(ref Vector2 value1, float scaleFactor, out Vector2 result)
         {
             result.X = value1.X * scaleFactor;
@@ -696,9 +694,9 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains the specified vector inversion.
+        /// Creates a new vector that contains the specified vector inversion.
         /// </summary>
-        /// <param name="value">Source <see cref="Vector2"/>.</param>
+        /// <param name="value">Source vector.</param>
         /// <returns>Result of the vector inversion.</returns>
         public static Vector2 Negate(Vector2 value)
         {
@@ -708,9 +706,9 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains the specified vector inversion.
+        /// Creates a new vector that contains the specified vector inversion.
         /// </summary>
-        /// <param name="value">Source <see cref="Vector2"/>.</param>
+        /// <param name="value">Source vector.</param>
         /// <param name="result">Result of the vector inversion as an output parameter.</param>
         public static void Negate(ref Vector2 value, out Vector2 result)
         {
@@ -729,9 +727,9 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains a normalized values from another vector.
+        /// Creates a new vector that contains the normalized values from another vector.
         /// </summary>
-        /// <param name="value">Source <see cref="Vector2"/>.</param>
+        /// <param name="value">Source vector.</param>
         /// <returns>Unit vector.</returns>
         public static Vector2 Normalize(Vector2 value)
         {
@@ -742,9 +740,9 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains a normalized values from another vector.
+        /// Creates a new vector that contains the normalized values from another vector.
         /// </summary>
-        /// <param name="value">Source <see cref="Vector2"/>.</param>
+        /// <param name="value">Source vector.</param>
         /// <param name="result">Unit vector as an output parameter.</param>
         public static void Normalize(ref Vector2 value, out Vector2 result)
         {
@@ -754,9 +752,9 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains reflect vector of the given vector and normal.
+        /// Creates a new vector that contains reflect vector of the given vector and normal.
         /// </summary>
-        /// <param name="vector">Source <see cref="Vector2"/>.</param>
+        /// <param name="vector">Source vector.</param>
         /// <param name="normal">Reflection normal.</param>
         /// <returns>Reflected vector.</returns>
         public static Vector2 Reflect(Vector2 vector, Vector2 normal)
@@ -769,9 +767,9 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains reflect vector of the given vector and normal.
+        /// Creates a new vector that contains reflect vector of the given vector and normal.
         /// </summary>
-        /// <param name="vector">Source <see cref="Vector2"/>.</param>
+        /// <param name="vector">Source vector.</param>
         /// <param name="normal">Reflection normal.</param>
         /// <param name="result">Reflected vector as an output parameter.</param>
         public static void Reflect(ref Vector2 vector, ref Vector2 normal, out Vector2 result)
@@ -782,10 +780,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains cubic interpolation of the specified vectors.
+        /// Creates a new vector that contains cubic interpolation of the specified vectors.
         /// </summary>
-        /// <param name="value1">Source <see cref="Vector2"/>.</param>
-        /// <param name="value2">Source <see cref="Vector2"/>.</param>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
         /// <param name="amount">Weighting value.</param>
         /// <returns>Cubic interpolation of the specified vectors.</returns>
         public static Vector2 SmoothStep(Vector2 value1, Vector2 value2, float amount)
@@ -796,10 +794,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains cubic interpolation of the specified vectors.
+        /// Creates a new vector that contains cubic interpolation of the specified vectors.
         /// </summary>
-        /// <param name="value1">Source <see cref="Vector2"/>.</param>
-        /// <param name="value2">Source <see cref="Vector2"/>.</param>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
         /// <param name="amount">Weighting value.</param>
         /// <param name="result">Cubic interpolation of the specified vectors as an output parameter.</param>
         public static void SmoothStep(ref Vector2 value1, ref Vector2 value2, float amount, out Vector2 result)
@@ -809,10 +807,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains subtraction of on <see cref="Vector2"/> from a another.
+        /// Creates a new vector that contains subtraction of one vector from another.
         /// </summary>
-        /// <param name="value1">The first <see cref="Vector2"/>.</param>
-        /// <param name="value2">The second <see cref="Vector2"/>.</param>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
         /// <returns>The result of the vector subtraction.</returns>
         public static Vector2 Subtract(Vector2 value1, Vector2 value2)
         {
@@ -822,10 +820,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains subtraction of on <see cref="Vector2"/> from a another.
+        /// Creates a new vector that contains subtraction of one vector from another.
         /// </summary>
-        /// <param name="value1">The first <see cref="Vector2"/>.</param>
-        /// <param name="value2">The second <see cref="Vector2"/>.</param>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
         /// <param name="result">The result of the vector subtraction as an output parameter.</param>
         public static void Subtract(ref Vector2 value1, ref Vector2 value2, out Vector2 result)
         {
@@ -853,22 +851,22 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains a transformation of vector(position.X,position.Y,0,1) by the specified <see cref="Matrix"/>.
+        /// Creates a new vector that contains a transformation of vector by the specified <see cref="Matrix"/>.
         /// </summary>
-        /// <param name="position">Source <see cref="Vector2"/>.</param>
+        /// <param name="position">Source vector.</param>
         /// <param name="matrix">The transformation <see cref="Matrix"/>.</param>
-        /// <returns>Transformed <see cref="Vector2"/>.</returns>
+        /// <returns>Transformed vector.</returns>
         public static Vector2 Transform(Vector2 position, Matrix matrix)
         {
             return new Vector2((position.X * matrix.M11) + (position.Y * matrix.M21) + matrix.M41, (position.X * matrix.M12) + (position.Y * matrix.M22) + matrix.M42);
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains a transformation of vector(position.X,position.Y,0,1) by the specified <see cref="Matrix"/>.
+        /// Creates a new vector that contains a transformation of vector by the specified <see cref="Matrix"/>.
         /// </summary>
-        /// <param name="position">Source <see cref="Vector2"/>.</param>
+        /// <param name="position">Source vector.</param>
         /// <param name="matrix">The transformation <see cref="Matrix"/>.</param>
-        /// <param name="result">Transformed <see cref="Vector2"/> as an output parameter.</param>
+        /// <param name="result">Transformed vector as an output parameter.</param>
         public static void Transform(ref Vector2 position, ref Matrix matrix, out Vector2 result)
         {
             var x = (position.X * matrix.M11) + (position.Y * matrix.M21) + matrix.M41;
@@ -878,11 +876,11 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains a transformation of vector(position.X,position.Y,0,0) by the specified <see cref="Quaternion"/>, representing the rotation.
+        /// Creates a new vector that contains a transformation of vector by the specified <see cref="Quaternion"/>, representing the rotation.
         /// </summary>
-        /// <param name="value">Source <see cref="Vector2"/>.</param>
+        /// <param name="value">Source vector.</param>
         /// <param name="rotation">The <see cref="Quaternion"/> which contains rotation transformation.</param>
-        /// <returns>Transformed <see cref="Vector2"/>.</returns>
+        /// <returns>Transformed vector.</returns>
         public static Vector2 Transform(Vector2 value, Quaternion rotation)
         {
             Transform(ref value, ref rotation, out value);
@@ -890,11 +888,11 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new <see cref="Vector2"/> that contains a transformation of vector(position.X,position.Y,0,0) by the specified <see cref="Quaternion"/>, representing the rotation.
+        /// Creates a new vector that contains a transformation of vector by the specified <see cref="Quaternion"/>, representing the rotation.
         /// </summary>
-        /// <param name="value">Source <see cref="Vector2"/>.</param>
+        /// <param name="value">Source vector.</param>
         /// <param name="rotation">The <see cref="Quaternion"/> which contains rotation transformation.</param>
-        /// <param name="result">Transformed <see cref="Vector2"/> as an output parameter.</param>
+        /// <param name="result">Transformed vector as an output parameter.</param>
         public static void Transform(ref Vector2 value, ref Quaternion rotation, out Vector2 result)
         {
             var rot1 = new Vector3(rotation.X + rotation.X, rotation.Y + rotation.Y, rotation.Z + rotation.Z);

--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -9,6 +9,9 @@ using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
 {
+    /// <summary>
+    /// Describes a 3D-vector.
+    /// </summary>
 #if WINDOWS
     [System.ComponentModel.TypeConverter(typeof(Microsoft.Xna.Framework.Design.Vector3TypeConverter))]
 #endif
@@ -16,7 +19,7 @@ namespace Microsoft.Xna.Framework
     [DebuggerDisplay("{DebugDisplayString,nq}")]
     public struct Vector3 : IEquatable<Vector3>
     {
-        #region Private Fields
+        #region Private Static Fields
 
         private static  Vector3 zero = new Vector3(0f, 0f, 0f);
         private static  Vector3 one = new Vector3(1f, 1f, 1f);
@@ -32,25 +35,32 @@ namespace Microsoft.Xna.Framework
 
         #endregion Private Fields
 
-
         #region Public Fields
-        
+
+        /// <summary>
+        /// The x coordinate of this vector.
+        /// </summary>
         [DataMember]
         public float X;
-      
+
+        /// <summary>
+        /// The y coordinate of this vector.
+        /// </summary>
         [DataMember]
         public float Y;
-      
+
+        /// <summary>
+        /// The z coordinate of this vector.
+        /// </summary>
         [DataMember]
         public float Z;
 
         #endregion Public Fields
 
-
         #region Properties
 
         /// <summary>
-        /// Returns a <see>Vector3</see> with components 0, 0, 0.
+        /// Returns a <see cref="Vector3"/> with components 0, 0, 0.
         /// </summary>
         public static Vector3 Zero
         {
@@ -58,7 +68,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Returns a <see>Vector3</see> with components 1, 1, 1.
+        /// Returns a <see cref="Vector3"/> with components 1, 1, 1.
         /// </summary>
         public static Vector3 One
         {
@@ -66,7 +76,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Returns a <see>Vector3</see> with components 1, 0, 0.
+        /// Returns a <see cref="Vector3"/> with components 1, 0, 0.
         /// </summary>
         public static Vector3 UnitX
         {
@@ -74,7 +84,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Returns a <see>Vector3</see> with components 0, 1, 0.
+        /// Returns a <see cref="Vector3"/> with components 0, 1, 0.
         /// </summary>
         public static Vector3 UnitY
         {
@@ -82,38 +92,56 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Returns a <see>Vector3</see> with components 0, 0, 1.
+        /// Returns a <see cref="Vector3"/> with components 0, 0, 1.
         /// </summary>
         public static Vector3 UnitZ
         {
             get { return unitZ; }
         }
 
+        /// <summary>
+        /// Returns a <see cref="Vector3"/> with components 0, 1, 0.
+        /// </summary>
         public static Vector3 Up
         {
             get { return up; }
         }
 
+        /// <summary>
+        /// Returns a <see cref="Vector3"/> with components 0, -1, 0.
+        /// </summary>
         public static Vector3 Down
         {
             get { return down; }
         }
 
+        /// <summary>
+        /// Returns a <see cref="Vector3"/> with components 1, 0, 0.
+        /// </summary>
         public static Vector3 Right
         {
             get { return right; }
         }
 
+        /// <summary>
+        /// Returns a <see cref="Vector3"/> with components -1, 0, 0.
+        /// </summary>
         public static Vector3 Left
         {
             get { return left; }
         }
 
+        /// <summary>
+        /// Returns a <see cref="Vector3"/> with components 0, 0, -1.
+        /// </summary>
         public static Vector3 Forward
         {
             get { return forward; }
         }
 
+        /// <summary>
+        /// Returns a <see cref="Vector3"/> with components 0, 0, 1.
+        /// </summary>
         public static Vector3 Backward
         {
             get { return backward; }
@@ -121,9 +149,30 @@ namespace Microsoft.Xna.Framework
 
         #endregion Properties
 
+        #region Internal Properties
+
+        internal string DebugDisplayString
+        {
+            get
+            {
+                return string.Concat(
+                    this.X.ToString(), "  ",
+                    this.Y.ToString(), "  ",
+                    this.Z.ToString()
+                );
+            }
+        }
+
+        #endregion
 
         #region Constructors
 
+        /// <summary>
+        /// Creates a new instance of <see cref="Vector3"/> struct.
+        /// </summary>
+        /// <param name="x">The x coordinate in 3d-space.</param>
+        /// <param name="y">The y coordinate in 3d-space.</param>
+        /// <param name="z">The z coordinate in 3d-space.</param>
         public Vector3(float x, float y, float z)
         {
             this.X = x;
@@ -131,7 +180,10 @@ namespace Microsoft.Xna.Framework
             this.Z = z;
         }
 
-
+        /// <summary>
+        /// Creates a new instance of <see cref="Vector3"/> struct.
+        /// </summary>
+        /// <param name="value">The x, y and z coordinates in 3d-space.</param>
         public Vector3(float value)
         {
             this.X = value;
@@ -139,7 +191,11 @@ namespace Microsoft.Xna.Framework
             this.Z = value;
         }
 
-
+        /// <summary>
+        /// Creates a new instance of <see cref="Vector3"/> struct.
+        /// </summary>
+        /// <param name="value">The x and y coordinates in 3d-space.</param>
+        /// <param name="z">The z coordinate in 3d-space.</param>
         public Vector3(Vector2 value, float z)
         {
             this.X = value.X;
@@ -147,14 +203,150 @@ namespace Microsoft.Xna.Framework
             this.Z = z;
         }
 
-
         #endregion Constructors
 
+        #region Operators
+
+        /// <summary>
+        /// Inverts values in the specified <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector3"/> on the right of the sub sign.</param>
+        /// <returns>Result of the inversion.</returns>
+        public static Vector3 operator -(Vector3 value)
+        {
+            value = new Vector3(-value.X, -value.Y, -value.Z);
+            return value;
+        }
+
+        /// <summary>
+        /// Adds two vectors.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/> on the left of the add sign.</param>
+        /// <param name="value2">Source <see cref="Vector3"/> on the right of the add sign.</param>
+        /// <returns>Sum of the vectors.</returns>
+        public static Vector3 operator +(Vector3 value1, Vector3 value2)
+        {
+            value1.X += value2.X;
+            value1.Y += value2.Y;
+            value1.Z += value2.Z;
+            return value1;
+        }
+
+        /// <summary>
+        /// Subtracts a <see cref="Vector3"/> from a <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/> on the left of the sub sign.</param>
+        /// <param name="value2">Source <see cref="Vector3"/> on the right of the sub sign.</param>
+        /// <returns>Result of the vector subtraction.</returns>
+        public static Vector3 operator -(Vector3 value1, Vector3 value2)
+        {
+            value1.X -= value2.X;
+            value1.Y -= value2.Y;
+            value1.Z -= value2.Z;
+            return value1;
+        }
+
+        /// <summary>
+        /// Multiplies the components of two vectors by each other.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/> on the left of the mul sign.</param>
+        /// <param name="value2">Source <see cref="Vector3"/> on the right of the mul sign.</param>
+        /// <returns>Result of the vector multiplication.</returns>
+        public static Vector3 operator *(Vector3 value1, Vector3 value2)
+        {
+            value1.X *= value2.X;
+            value1.Y *= value2.Y;
+            value1.Z *= value2.Z;
+            return value1;
+        }
+
+        /// <summary>
+        /// Multiplies the components of vector by a scalar.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector3"/> on the left of the mul sign.</param>
+        /// <param name="scaleFactor">Scalar value on the right of the mul sign.</param>
+        /// <returns>Result of the vector multiplication with a scalar.</returns>
+        public static Vector3 operator *(Vector3 value, float scaleFactor)
+        {
+            value.X *= scaleFactor;
+            value.Y *= scaleFactor;
+            value.Z *= scaleFactor;
+            return value;
+        }
+
+        /// <summary>
+        /// Multiplies the components of vector by a scalar.
+        /// </summary>
+        /// <param name="scaleFactor">Scalar value on the left of the mul sign.</param>
+        /// <param name="value">Source <see cref="Vector3"/> on the right of the mul sign.</param>
+        /// <returns>Result of the vector multiplication with a scalar.</returns>
+        public static Vector3 operator *(float scaleFactor, Vector3 value)
+        {
+            value.X *= scaleFactor;
+            value.Y *= scaleFactor;
+            value.Z *= scaleFactor;
+            return value;
+        }
+
+        /// <summary>
+        /// Divides the components of a <see cref="Vector3"/> by the components of another <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/> on the left of the div sign.</param>
+        /// <param name="value2">Divisor <see cref="Vector3"/> on the right of the div sign.</param>
+        /// <returns>The result of dividing the vectors.</returns>
+        public static Vector3 operator /(Vector3 value1, Vector3 value2)
+        {
+            value1.X /= value2.X;
+            value1.Y /= value2.Y;
+            value1.Z /= value2.Z;
+            return value1;
+        }
+
+        /// <summary>
+        /// Divides the components of a <see cref="Vector3"/> by a scalar.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/> on the left of the div sign.</param>
+        /// <param name="divider">Divisor scalar on the right of the div sign.</param>
+        /// <returns>The result of dividing a vector by a scalar.</returns>
+        public static Vector3 operator /(Vector3 value1, float divider)
+        {
+            float factor = 1 / divider;
+            value1.X *= factor;
+            value1.Y *= factor;
+            value1.Z *= factor;
+            return value1;
+        }
+
+        /// <summary>
+        /// Compares whether two <see cref="Vector3"/> instances are equal.
+        /// </summary>
+        /// <param name="value1"><see cref="Vector3"/> instance on the left of the equal sign.</param>
+        /// <param name="value2"><see cref="Vector3"/> instance on the right of the equal sign.</param>
+        /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        public static bool operator ==(Vector3 value1, Vector3 value2)
+        {
+            return value1.X == value2.X
+                && value1.Y == value2.Y
+                && value1.Z == value2.Z;
+        }
+
+        /// <summary>
+        /// Compares whether two <see cref="Vector3"/> instances are not equal.
+        /// </summary>
+        /// <param name="value1"><see cref="Vector3"/> instance on the left of the not equal sign.</param>
+        /// <param name="value2"><see cref="Vector3"/> instance on the right of the not equal sign.</param>
+        /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>	
+        public static bool operator !=(Vector3 value1, Vector3 value2)
+        {
+            return !(value1 == value2);
+        }
+
+        #endregion
 
         #region Public Methods
 
         /// <summary>
-        /// Performs vector addition on <paramref name="value1"/> and <paramref name="value2"/>.
+        /// Creates a new vector which contains the sum of two vectors.
         /// </summary>
         /// <param name="value1">The first vector to add.</param>
         /// <param name="value2">The second vector to add.</param>
@@ -168,13 +360,11 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Performs vector addition on <paramref name="value1"/> and
-        /// <paramref name="value2"/>, storing the result of the
-        /// addition in <paramref name="result"/>.
+        /// Creates a new vector which contains the sum of two vectors.
         /// </summary>
         /// <param name="value1">The first vector to add.</param>
         /// <param name="value2">The second vector to add.</param>
-        /// <param name="result">The result of the vector addition.</param>
+        /// <param name="result">The result of the vector addition as an output parameter.</param>
         public static void Add(ref Vector3 value1, ref Vector3 value2, out Vector3 result)
         {
             result.X = value1.X + value2.X;
@@ -182,6 +372,15 @@ namespace Microsoft.Xna.Framework
             result.Z = value1.Z + value2.Z;
         }
 
+        /// <summary>
+        /// Creates a new vector that contains the cartesian coordinates of a vector specified in barycentric coordinates and relative to 3d-triangle.
+        /// </summary>
+        /// <param name="value1">The first vector of 3d-triangle.</param>
+        /// <param name="value2">The second vector of 3d-triangle.</param>
+        /// <param name="value3">The third vector of 3d-triangle.</param>
+        /// <param name="amount1">Barycentric scalar <c>b2</c> which represents a weighting factor towards second vector of 3d-triangle.</param>
+        /// <param name="amount2">Barycentric scalar <c>b3</c> which represents a weighting factor towards third vector of 3d-triangle.</param>
+        /// <returns>A cartesian translation of barycentric coordinates.</returns>
         public static Vector3 Barycentric(Vector3 value1, Vector3 value2, Vector3 value3, float amount1, float amount2)
         {
             return new Vector3(
@@ -190,6 +389,15 @@ namespace Microsoft.Xna.Framework
                 MathHelper.Barycentric(value1.Z, value2.Z, value3.Z, amount1, amount2));
         }
 
+        /// <summary>
+        /// Creates a new vector that contains the cartesian coordinates of a vector specified in barycentric coordinates and relative to 3d-triangle.
+        /// </summary>
+        /// <param name="value1">The first vector of 3d-triangle.</param>
+        /// <param name="value2">The second vector of 3d-triangle.</param>
+        /// <param name="value3">The third vector of 3d-triangle.</param>
+        /// <param name="amount1">Barycentric scalar <c>b2</c> which represents a weighting factor towards second vector of 3d-triangle.</param>
+        /// <param name="amount2">Barycentric scalar <c>b3</c> which represents a weighting factor towards third vector of 3d-triangle.</param>
+        /// <param name="result">A cartesian translation of barycentric coordinates as an output parameter.</param>
         public static void Barycentric(ref Vector3 value1, ref Vector3 value2, ref Vector3 value3, float amount1, float amount2, out Vector3 result)
         {
             result.X = MathHelper.Barycentric(value1.X, value2.X, value3.X, amount1, amount2);
@@ -197,6 +405,15 @@ namespace Microsoft.Xna.Framework
             result.Z = MathHelper.Barycentric(value1.Z, value2.Z, value3.Z, amount1, amount2);
         }
 
+        /// <summary>
+        /// Creates a new vector that contains CatmullRom interpolation of the specified vectors.
+        /// </summary>
+        /// <param name="value1">The first vector in interpolation.</param>
+        /// <param name="value2">The second vector in interpolation.</param>
+        /// <param name="value3">The third vector in interpolation.</param>
+        /// <param name="value4">The fourth vector in interpolation.</param>
+        /// <param name="amount">Weighting factor.</param>
+        /// <returns>The result of CatmullRom interpolation.</returns>
         public static Vector3 CatmullRom(Vector3 value1, Vector3 value2, Vector3 value3, Vector3 value4, float amount)
         {
             return new Vector3(
@@ -205,6 +422,15 @@ namespace Microsoft.Xna.Framework
                 MathHelper.CatmullRom(value1.Z, value2.Z, value3.Z, value4.Z, amount));
         }
 
+        /// <summary>
+        /// Creates a new vector that contains CatmullRom interpolation of the specified vectors.
+        /// </summary>
+        /// <param name="value1">The first vector in interpolation.</param>
+        /// <param name="value2">The second vector in interpolation.</param>
+        /// <param name="value3">The third vector in interpolation.</param>
+        /// <param name="value4">The fourth vector in interpolation.</param>
+        /// <param name="amount">Weighting factor.</param>
+        /// <param name="result">The result of CatmullRom interpolation as an output parameter.</param>
         public static void CatmullRom(ref Vector3 value1, ref Vector3 value2, ref Vector3 value3, ref Vector3 value4, float amount, out Vector3 result)
         {
             result.X = MathHelper.CatmullRom(value1.X, value2.X, value3.X, value4.X, amount);
@@ -212,6 +438,13 @@ namespace Microsoft.Xna.Framework
             result.Z = MathHelper.CatmullRom(value1.Z, value2.Z, value3.Z, value4.Z, amount);
         }
 
+        /// <summary>
+        /// Clamps the specified vector values within a range of another vectors.
+        /// </summary>
+        /// <param name="value1">The vector to clamp.</param>
+        /// <param name="min">The min vector.</param>
+        /// <param name="max">The max vector.</param>
+        /// <returns>The clamped value.</returns>
         public static Vector3 Clamp(Vector3 value1, Vector3 min, Vector3 max)
         {
             return new Vector3(
@@ -220,6 +453,13 @@ namespace Microsoft.Xna.Framework
                 MathHelper.Clamp(value1.Z, min.Z, max.Z));
         }
 
+        /// <summary>
+        /// Clamps the specified vector values within a range of another vectors.
+        /// </summary>
+        /// <param name="value1">The vector to clamp.</param>
+        /// <param name="min">The min vector.</param>
+        /// <param name="max">The max vector.</param>
+        /// <param name="result">The clamped value as an output parameter.</param>
         public static void Clamp(ref Vector3 value1, ref Vector3 min, ref Vector3 max, out Vector3 result)
         {
             result.X = MathHelper.Clamp(value1.X, min.X, max.X);
@@ -227,12 +467,25 @@ namespace Microsoft.Xna.Framework
             result.Z = MathHelper.Clamp(value1.Z, min.Z, max.Z);
         }
 
+        /// <summary>
+        /// Returns the cross product of two vectors.
+        /// </summary>
+        /// <param name="vector1">The first vector.</param>
+        /// <param name="vector2">The second vector.</param>
+        /// <returns>The cross product of two vectors.</returns>
         public static Vector3 Cross(Vector3 vector1, Vector3 vector2)
         {
-            Cross(ref vector1, ref vector2, out vector1);
-            return vector1;
+            return new Vector3(vector1.Y * vector2.Z - vector2.Y * vector1.Z,
+                             -(vector1.X * vector2.Z - vector2.X * vector1.Z),
+                               vector1.X * vector2.Y - vector2.X * vector1.Y);
         }
 
+        /// <summary>
+        /// Returns the cross product of two vectors.
+        /// </summary>
+        /// <param name="vector1">The first vector.</param>
+        /// <param name="vector2">The second vector.</param>
+        /// <param name="result">The cross product of two vectors as an output parameter.</param>
         public static void Cross(ref Vector3 vector1, ref Vector3 vector2, out Vector3 result)
         {
             var x = vector1.Y * vector2.Z - vector2.Y * vector1.Z;
@@ -243,26 +496,50 @@ namespace Microsoft.Xna.Framework
             result.Z = z;
         }
 
-        public static float Distance(Vector3 vector1, Vector3 vector2)
+        /// <summary>
+        /// Returns the distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>The distance between two vectors.</returns>
+        public static float Distance(Vector3 value1, Vector3 value2)
         {
             float result;
-            DistanceSquared(ref vector1, ref vector2, out result);
+            DistanceSquared(ref value1, ref value2, out result);
             return (float)Math.Sqrt(result);
         }
 
+        /// <summary>
+        /// Returns the distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="result">The distance between two vectors as an output parameter.</param>
         public static void Distance(ref Vector3 value1, ref Vector3 value2, out float result)
         {
             DistanceSquared(ref value1, ref value2, out result);
             result = (float)Math.Sqrt(result);
         }
 
+        /// <summary>
+        /// Returns the squared distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>The squared distance between two vectors.</returns>
         public static float DistanceSquared(Vector3 value1, Vector3 value2)
         {
-            float result;
-            DistanceSquared(ref value1, ref value2, out result);
-            return result;
+           return (value1.X - value2.X) * (value1.X - value2.X) +
+                  (value1.Y - value2.Y) * (value1.Y - value2.Y) +
+                  (value1.Z - value2.Z) * (value1.Z - value2.Z);
         }
 
+        /// <summary>
+        /// Returns the squared distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="result">The squared distance between two vectors as an output parameter.</param>
         public static void DistanceSquared(ref Vector3 value1, ref Vector3 value2, out float result)
         {
             result = (value1.X - value2.X) * (value1.X - value2.X) +
@@ -270,6 +547,12 @@ namespace Microsoft.Xna.Framework
                      (value1.Z - value2.Z) * (value1.Z - value2.Z);
         }
 
+        /// <summary>
+        /// Creates a new vector that contains the result of division of source vector by divider vector.
+        /// </summary>
+        /// <param name="value1">Source vector.</param>
+        /// <param name="value2">Divider vector.</param>
+        /// <returns>The result of dividing the vectors.</returns>
         public static Vector3 Divide(Vector3 value1, Vector3 value2)
         {
             value1.X /= value2.X;
@@ -278,23 +561,12 @@ namespace Microsoft.Xna.Framework
             return value1;
         }
 
-        public static Vector3 Divide(Vector3 value1, float value2)
-        {
-            float factor = 1 / value2;
-            value1.X *= factor;
-            value1.Y *= factor;
-            value1.Z *= factor;
-            return value1;
-        }
-
-        public static void Divide(ref Vector3 value1, float divisor, out Vector3 result)
-        {
-            float factor = 1 / divisor;
-            result.X = value1.X * factor;
-            result.Y = value1.Y * factor;
-            result.Z = value1.Z * factor;
-        }
-
+        /// <summary>
+        /// Creates a new vector that contains the result of division of source vector by divider vector.
+        /// </summary>
+        /// <param name="value1">Source vector.</param>
+        /// <param name="value2">Divider vector.</param>
+        /// <param name="result">The result of dividing the vectors as an output parameter.</param>
         public static void Divide(ref Vector3 value1, ref Vector3 value2, out Vector3 result)
         {
             result.X = value1.X / value2.X;
@@ -302,27 +574,77 @@ namespace Microsoft.Xna.Framework
             result.Z = value1.Z / value2.Z;
         }
 
-        public static float Dot(Vector3 vector1, Vector3 vector2)
+        /// <summary>
+        /// Creates a new vector that contains the result of division of source vector by divider scalar.
+        /// </summary>
+        /// <param name="value1">Source vector.</param>
+        /// <param name="divider">Divider scalar.</param>
+        /// <returns>The result of dividing a vector by a scalar.</returns>
+        public static Vector3 Divide(Vector3 value1, float divider)
         {
-            return vector1.X * vector2.X + vector1.Y * vector2.Y + vector1.Z * vector2.Z;
+            float factor = 1 / divider;
+            value1.X *= factor;
+            value1.Y *= factor;
+            value1.Z *= factor;
+            return value1;
         }
 
+        /// <summary>
+        /// Creates a new vector that contains the result of division of source vector by divider scalar.
+        /// </summary>
+        /// <param name="value1">Source vector.</param>
+        /// <param name="divider">Divider scalar.</param>
+        /// <param name="result">The result of dividing a vector by a scalar as an output parameter.</param>
+        public static void Divide(ref Vector3 value1, float divider, out Vector3 result)
+        {
+            float factor = 1 / divider;
+            result.X = value1.X * factor;
+            result.Y = value1.Y * factor;
+            result.Z = value1.Z * factor;
+        }
+
+        /// <summary>
+        /// Returns a dot product of two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>The dot product of two vectors.</returns>
+        public static float Dot(Vector3 value1, Vector3 value2)
+        {
+            return value1.X * value2.X + value1.Y * value2.Y + value1.Z * value2.Z;
+        }
+
+        /// <summary>
+        /// Returns a dot product of two vectors.
+        /// </summary>
+        /// <param name="vector1">The first vector.</param>
+        /// <param name="vector2">The second vector.</param>
+        /// <param name="result">The dot product of two vectors as an output parameter.</param>
         public static void Dot(ref Vector3 vector1, ref Vector3 vector2, out float result)
         {
             result = vector1.X * vector2.X + vector1.Y * vector2.Y + vector1.Z * vector2.Z;
         }
 
+        /// <summary>
+        /// Compares whether current instance is equal to specified <see cref="Object"/>.
+        /// </summary>
+        /// <param name="obj">The <see cref="Object"/> to compare.</param>
+        /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
         public override bool Equals(object obj)
         {
-            if (!(obj is Vector3))
-                return false;
+            if (obj is Vector3)
+            {
+                return Equals((Vector3)obj);
+            }
 
-            var other = (Vector3)obj;
-            return  X == other.X &&
-                    Y == other.Y &&
-                    Z == other.Z;
+            return false;
         }
 
+        /// <summary>
+        /// Compares whether current instance is equal to specified <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="other">The <see cref="Vector3"/> to compare.</param>
+        /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
         public bool Equals(Vector3 other)
         {
             return  X == other.X && 
@@ -330,18 +652,40 @@ namespace Microsoft.Xna.Framework
                     Z == other.Z;
         }
 
+        /// <summary>
+        /// Gets the hash code of this <see cref="Vector3"/>.
+        /// </summary>
+        /// <returns>Hash code of this <see cref="Vector3"/>.</returns>
         public override int GetHashCode()
         {
-            return (int)(this.X + this.Y + this.Z);
+            return (int)(this.X.GetHashCode() + this.Y.GetHashCode() + this.Z.GetHashCode());
         }
 
+        /// <summary>
+        /// Creates a new vector that contains the result of hermite spline interpolation.
+        /// </summary>
+        /// <param name="value1">The first position vector.</param>
+        /// <param name="tangent1">The first tangent vector.</param>
+        /// <param name="value2">The second position vector.</param>
+        /// <param name="tangent2">The second tangent vector.</param>
+        /// <param name="amount">Weighting factor.</param>
+        /// <returns>The hermite spline interpolation vector.</returns>
         public static Vector3 Hermite(Vector3 value1, Vector3 tangent1, Vector3 value2, Vector3 tangent2, float amount)
         {
-            Vector3 result = new Vector3();
-            Hermite(ref value1, ref tangent1, ref value2, ref tangent2, amount, out result);
-            return result;
+            return new Vector3(MathHelper.Hermite(value1.X, tangent1.X, value2.X, tangent2.X, amount),
+                               MathHelper.Hermite(value1.Y, tangent1.Y, value2.Y, tangent2.Y, amount),
+                               MathHelper.Hermite(value1.Z, tangent1.Z, value2.Z, tangent2.Z, amount));
         }
 
+        /// <summary>
+        /// Creates a new vector that contains the result of hermite spline interpolation.
+        /// </summary>
+        /// <param name="value1">The first position vector.</param>
+        /// <param name="tangent1">The first tangent vector.</param>
+        /// <param name="value2">The second position vector.</param>
+        /// <param name="tangent2">The second tangent vector.</param>
+        /// <param name="amount">Weighting factor.</param>
+        /// <param name="result">The hermite spline interpolation vector as an output parameter.</param>
         public static void Hermite(ref Vector3 value1, ref Vector3 tangent1, ref Vector3 value2, ref Vector3 tangent2, float amount, out Vector3 result)
         {
             result.X = MathHelper.Hermite(value1.X, tangent1.X, value2.X, tangent2.X, amount);
@@ -349,20 +693,31 @@ namespace Microsoft.Xna.Framework
             result.Z = MathHelper.Hermite(value1.Z, tangent1.Z, value2.Z, tangent2.Z, amount);
         }
 
+        /// <summary>
+        /// Returns the length of this vector.
+        /// </summary>
+        /// <returns>The length of this vector.</returns>
         public float Length()
         {
-            float result;
-            DistanceSquared(ref this, ref zero, out result);
-            return (float)Math.Sqrt(result);
+            return (float)Math.Sqrt((X * X) + (Y * Y) + (Z * Z));
         }
 
+        /// <summary>
+        /// Returns the squared length of this vector.
+        /// </summary>
+        /// <returns>The squared length of this vector.</returns>
         public float LengthSquared()
         {
-            float result;
-            DistanceSquared(ref this, ref zero, out result);
-            return result;
+            return (X * X) + (Y * Y) + (Z * Z);
         }
 
+        /// <summary>
+        /// Creates a new vector that contains linear interpolation of the specified vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
+        /// <returns>The result of linear interpolation of the specified vectors.</returns>
         public static Vector3 Lerp(Vector3 value1, Vector3 value2, float amount)
         {
             return new Vector3(
@@ -371,6 +726,13 @@ namespace Microsoft.Xna.Framework
                 MathHelper.Lerp(value1.Z, value2.Z, amount));
         }
 
+        /// <summary>
+        /// Creates a new vector that contains linear interpolation of the specified vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
+        /// <param name="result">The result of linear interpolation of the specified vectors as an output parameter.</param>
         public static void Lerp(ref Vector3 value1, ref Vector3 value2, float amount, out Vector3 result)
         {
             result.X = MathHelper.Lerp(value1.X, value2.X, amount);
@@ -378,6 +740,12 @@ namespace Microsoft.Xna.Framework
             result.Z = MathHelper.Lerp(value1.Z, value2.Z, amount);
         }
 
+        /// <summary>
+        /// Creates a new vector that contains the maximal values from the two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>A new vector with maximal values from the two vectors.</returns>
         public static Vector3 Max(Vector3 value1, Vector3 value2)
         {
             return new Vector3(
@@ -386,6 +754,12 @@ namespace Microsoft.Xna.Framework
                 MathHelper.Max(value1.Z, value2.Z));
         }
 
+        /// <summary>
+        /// Creates a new vector that contains the maximal values from the two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="result">A new vector with maximal values from the two vectors as an output parameter.</param>
         public static void Max(ref Vector3 value1, ref Vector3 value2, out Vector3 result)
         {
             result.X = MathHelper.Max(value1.X, value2.X);
@@ -393,6 +767,12 @@ namespace Microsoft.Xna.Framework
             result.Z = MathHelper.Max(value1.Z, value2.Z);
         }
 
+        /// <summary>
+        /// Creates a new vector that contains the minimal values from the two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>A new vector with minimal values from the two vectors.</returns>
         public static Vector3 Min(Vector3 value1, Vector3 value2)
         {
             return new Vector3(
@@ -401,6 +781,12 @@ namespace Microsoft.Xna.Framework
                 MathHelper.Min(value1.Z, value2.Z));
         }
 
+        /// <summary>
+        /// Creates a new vector that contains the minimal values from the two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="result">A new vector with minimal values from the two vectors as an output parameter.</param>
         public static void Min(ref Vector3 value1, ref Vector3 value2, out Vector3 result)
         {
             result.X = MathHelper.Min(value1.X, value2.X);
@@ -408,6 +794,12 @@ namespace Microsoft.Xna.Framework
             result.Z = MathHelper.Min(value1.Z, value2.Z);
         }
 
+        /// <summary>
+        /// Creates a new vector that contains a multiplication of two vectors.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector2"/>.</param>
+        /// <param name="value2">Source <see cref="Vector2"/>.</param>
+        /// <returns>Result of the vector multiplication.</returns>
         public static Vector3 Multiply(Vector3 value1, Vector3 value2)
         {
             value1.X *= value2.X;
@@ -416,21 +808,12 @@ namespace Microsoft.Xna.Framework
             return value1;
         }
 
-        public static Vector3 Multiply(Vector3 value1, float scaleFactor)
-        {
-            value1.X *= scaleFactor;
-            value1.Y *= scaleFactor;
-            value1.Z *= scaleFactor;
-            return value1;
-        }
-
-        public static void Multiply(ref Vector3 value1, float scaleFactor, out Vector3 result)
-        {
-            result.X = value1.X * scaleFactor;
-            result.Y = value1.Y * scaleFactor;
-            result.Z = value1.Z * scaleFactor;
-        }
-
+        /// <summary>
+        /// Creates a new vector that contains a multiplication of two vectors.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector2"/>.</param>
+        /// <param name="value2">Source <see cref="Vector2"/>.</param>
+        /// <param name="result">Result of the vector multiplication as an output parameter.</param>
         public static void Multiply(ref Vector3 value1, ref Vector3 value2, out Vector3 result)
         {
             result.X = value1.X * value2.X;
@@ -439,11 +822,37 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Returns a <see>Vector3</see> pointing in the opposite
-        /// direction of <paramref name="value"/>.
+        /// Creates a new vector that contains a multiplication of vector and a scalar.
         /// </summary>
-        /// <param name="value">The vector to negate.</param>
-        /// <returns>The vector negation of <paramref name="value"/>.</returns>
+        /// <param name="value1">Source vector.</param>
+        /// <param name="scaleFactor">Scalar value.</param>
+        /// <returns>Result of the vector multiplication with a scalar.</returns>
+        public static Vector3 Multiply(Vector3 value1, float scaleFactor)
+        {
+            value1.X *= scaleFactor;
+            value1.Y *= scaleFactor;
+            value1.Z *= scaleFactor;
+            return value1;
+        }
+
+        /// <summary>
+        /// Creates a new vector that contains a multiplication of vector and a scalar.
+        /// </summary>
+        /// <param name="value1">Source vector.</param>
+        /// <param name="scaleFactor">Scalar value.</param>
+        /// <param name="result">Result of the vector multiplication with a scalar as an output parameter.</param>
+        public static void Multiply(ref Vector3 value1, float scaleFactor, out Vector3 result)
+        {
+            result.X = value1.X * scaleFactor;
+            result.Y = value1.Y * scaleFactor;
+            result.Z = value1.Z * scaleFactor;
+        }
+
+        /// <summary>
+        /// Creates a new vector that contains the specified vector inversion.
+        /// </summary>
+        /// <param name="value">Source vector.</param>
+        /// <returns>Result of the vector inversion.</returns>
         public static Vector3 Negate(Vector3 value)
         {
             value = new Vector3(-value.X, -value.Y, -value.Z);
@@ -451,11 +860,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Stores a <see>Vector3</see> pointing in the opposite
-        /// direction of <paramref name="value"/> in <paramref name="result"/>.
+        /// Creates a new vector that contains the specified vector inversion.
         /// </summary>
-        /// <param name="value">The vector to negate.</param>
-        /// <param name="result">The vector that the negation of <paramref name="value"/> will be stored in.</param>
+        /// <param name="value">Source vector.</param>
+        /// <param name="result">Result of the vector inversion as an output parameter.</param>
         public static void Negate(ref Vector3 value, out Vector3 result)
         {
             result.X = -value.X;
@@ -463,17 +871,30 @@ namespace Microsoft.Xna.Framework
             result.Z = -value.Z;
         }
 
+        /// <summary>
+        /// Turns this <see cref="Vector3"/> to a unit vector with the same direction.
+        /// </summary>
         public void Normalize()
         {
             Normalize(ref this, out this);
         }
 
-        public static Vector3 Normalize(Vector3 vector)
+        /// <summary>
+        /// Creates a new vector that contains the normalized values from another vector.
+        /// </summary>
+        /// <param name="value">Source vector.</param>
+        /// <returns>Unit vector.</returns>
+        public static Vector3 Normalize(Vector3 value)
         {
-            Normalize(ref vector, out vector);
-            return vector;
+            Normalize(ref value, out value);
+            return value;
         }
 
+        /// <summary>
+        /// Creates a new vector that contains the normalized values from another vector.
+        /// </summary>
+        /// <param name="value">Source vector.</param>
+        /// <param name="result">Unit vector as an output parameter.</param>
         public static void Normalize(ref Vector3 value, out Vector3 result)
         {
             float factor;
@@ -484,6 +905,12 @@ namespace Microsoft.Xna.Framework
             result.Z = value.Z * factor;
         }
 
+        /// <summary>
+        /// Creates a new vector that contains reflect vector of the given vector and normal.
+        /// </summary>
+        /// <param name="vector">Source vector.</param>
+        /// <param name="normal">Reflection normal.</param>
+        /// <returns>Reflected vector.</returns>
         public static Vector3 Reflect(Vector3 vector, Vector3 normal)
         {
             // I is the original array
@@ -499,6 +926,12 @@ namespace Microsoft.Xna.Framework
             return reflectedVector;
         }
 
+        /// <summary>
+        /// Creates a new vector that contains reflect vector of the given vector and normal.
+        /// </summary>
+        /// <param name="vector">Source vector.</param>
+        /// <param name="normal">Reflection normal.</param>
+        /// <param name="result">Reflected vector as an output parameter.</param>
         public static void Reflect(ref Vector3 vector, ref Vector3 normal, out Vector3 result)
         {
             // I is the original array
@@ -512,6 +945,13 @@ namespace Microsoft.Xna.Framework
             result.Z = vector.Z - (2.0f * normal.Z) * dotProduct;
         }
 
+        /// <summary>
+        /// Creates a new vector that contains cubic interpolation of the specified vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="amount">Weighting value.</param>
+        /// <returns>Cubic interpolation of the specified vectors.</returns>
         public static Vector3 SmoothStep(Vector3 value1, Vector3 value2, float amount)
         {
             return new Vector3(
@@ -520,6 +960,13 @@ namespace Microsoft.Xna.Framework
                 MathHelper.SmoothStep(value1.Z, value2.Z, amount));
         }
 
+        /// <summary>
+        /// Creates a new vector that contains cubic interpolation of the specified vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="amount">Weighting value.</param>
+        /// <param name="result">Cubic interpolation of the specified vectors as an output parameter.</param>
         public static void SmoothStep(ref Vector3 value1, ref Vector3 value2, float amount, out Vector3 result)
         {
             result.X = MathHelper.SmoothStep(value1.X, value2.X, amount);
@@ -528,10 +975,10 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Performs vector subtraction on <paramref name="value1"/> and <paramref name="value2"/>.
+        /// Creates a new vector that contains subtraction of one vector from another.
         /// </summary>
-        /// <param name="value1">The vector to be subtracted from.</param>
-        /// <param name="value2">The vector to be subtracted from <paramref name="value1"/>.</param>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
         /// <returns>The result of the vector subtraction.</returns>
         public static Vector3 Subtract(Vector3 value1, Vector3 value2)
         {
@@ -542,11 +989,11 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Performs vector subtraction on <paramref name="value1"/> and <paramref name="value2"/>.
+        /// Creates a new vector that contains subtraction of one vector from another.
         /// </summary>
-        /// <param name="value1">The vector to be subtracted from.</param>
-        /// <param name="value2">The vector to be subtracted from <paramref name="value1"/>.</param>
-        /// <param name="result">The result of the vector subtraction.</param>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="result">The result of the vector subtraction as an output parameter.</param>
         public static void Subtract(ref Vector3 value1, ref Vector3 value2, out Vector3 result)
         {
             result.X = value1.X - value2.X;
@@ -554,37 +1001,34 @@ namespace Microsoft.Xna.Framework
             result.Z = value1.Z - value2.Z;
         }
 
-        internal string DebugDisplayString
-        {
-            get
-            {
-                return string.Concat(
-                    this.X.ToString(), "  ",
-                    this.Y.ToString(), "  ",
-                    this.Z.ToString()
-                );
-            }
-        }
-
+        /// <summary>
+        /// Returns a <see cref="String"/> representation of this <see cref="Vector3"/> in the format:
+        /// {X:[<see cref="X"/>] Y:[<see cref="Y"/>]} Z:[<see cref="Z"/>]}
+        /// </summary>
+        /// <returns>A <see cref="String"/> representation of this <see cref="Vector3"/>.</returns>
         public override string ToString()
         {
-            StringBuilder sb = new StringBuilder(32);
-            sb.Append("{X:");
-            sb.Append(this.X);
-            sb.Append(" Y:");
-            sb.Append(this.Y);
-            sb.Append(" Z:");
-            sb.Append(this.Z);
-            sb.Append("}");
-            return sb.ToString();
+            return "{X:" + X + " Y:" + Y + " Z:" + Z + "}";
         }
 
+        /// <summary>
+        /// Creates a new vector that contains a transformation of vector by the specified <see cref="Matrix"/>.
+        /// </summary>
+        /// <param name="position">Source vector.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix"/>.</param>
+        /// <returns>Transformed vector.</returns>
         public static Vector3 Transform(Vector3 position, Matrix matrix)
         {
             Transform(ref position, ref matrix, out position);
             return position;
         }
 
+        /// <summary>
+        /// Creates a new vector that contains a transformation of vector by the specified <see cref="Matrix"/>.
+        /// </summary>
+        /// <param name="position">Source vector.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix"/>.</param>
+        /// <param name="result">Transformed vector as an output parameter.</param>
         public static void Transform(ref Vector3 position, ref Matrix matrix, out Vector3 result)
         {
             var x = (position.X * matrix.M11) + (position.Y * matrix.M21) + (position.Z * matrix.M31) + matrix.M41;
@@ -595,26 +1039,54 @@ namespace Microsoft.Xna.Framework
             result.Z = z;
         }
 
-        public static void Transform(Vector3[] sourceArray, ref Matrix matrix, Vector3[] destinationArray)
+        /// <summary>
+        /// Creates a new vector that contains a transformation of vector by the specified <see cref="Quaternion"/>, representing the rotation.
+        /// </summary>
+        /// <param name="value">Source vector.</param>
+        /// <param name="rotation">The <see cref="Quaternion"/> which contains rotation transformation.</param>
+        /// <returns>Transformed vector.</returns>
+        public static Vector3 Transform(Vector3 value, Quaternion rotation)
         {
-            Debug.Assert(destinationArray.Length >= sourceArray.Length, "The destination array is smaller than the source array.");
-
-            // TODO: Are there options on some platforms to implement a vectorized version of this?
-
-            for (var i = 0; i < sourceArray.Length; i++)
-            {
-                var position = sourceArray[i];                
-                destinationArray[i] =
-                    new Vector3(
-                        (position.X*matrix.M11) + (position.Y*matrix.M21) + (position.Z*matrix.M31) + matrix.M41,
-                        (position.X*matrix.M12) + (position.Y*matrix.M22) + (position.Z*matrix.M32) + matrix.M42,
-                        (position.X*matrix.M13) + (position.Y*matrix.M23) + (position.Z*matrix.M33) + matrix.M43);
-            }
+            Vector3 result;
+            Transform(ref value, ref rotation, out result);
+            return result;
         }
 
-        public static void Transform(Vector3[] sourceArray, int sourceIndex, ref Matrix matrix, Vector3[] destinationArray, int destinationIndex, int length)
+        /// <summary>
+        /// Creates a new vector that contains a transformation of vector by the specified <see cref="Quaternion"/>, representing the rotation.
+        /// </summary>
+        /// <param name="value">Source vector.</param>
+        /// <param name="rotation">The <see cref="Quaternion"/> which contains rotation transformation.</param>
+        /// <param name="result">Transformed vector as an output parameter.</param>
+        public static void Transform(ref Vector3 value, ref Quaternion rotation, out Vector3 result)
         {
-            Debug.Assert(sourceArray.Length - sourceIndex >= length, 
+            float x = 2 * (rotation.Y * value.Z - rotation.Z * value.Y);
+            float y = 2 * (rotation.Z * value.X - rotation.X * value.Z);
+            float z = 2 * (rotation.X * value.Y - rotation.Y * value.X);
+
+            result.X = value.X + x * rotation.W + (rotation.Y * z - rotation.Z * y);
+            result.Y = value.Y + y * rotation.W + (rotation.Z * x - rotation.X * z);
+            result.Z = value.Z + z * rotation.W + (rotation.X * y - rotation.Y * x);
+        }
+
+        /// <summary>
+        /// Apply transformation on vectors within array of <see cref="Vector3"/> by the specified <see cref="Matrix"/> and places the results in an another array.
+        /// </summary>
+        /// <param name="sourceArray">Source array.</param>
+        /// <param name="sourceIndex">The starting index of transformation in the source array.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix"/>.</param>
+        /// <param name="destinationArray">Destination array.</param>
+        /// <param name="destinationIndex">The starting index in the destination array, where the first <see cref="Vector3"/> should be written.</param>
+        /// <param name="length">The number of vectors to be transformed.</param>
+        public static void Transform(
+            Vector3[] sourceArray,
+            int sourceIndex,
+            ref Matrix matrix,
+            Vector3[] destinationArray,
+            int destinationIndex,
+            int length)
+        {
+            Debug.Assert(sourceArray.Length - sourceIndex >= length,
                 "The source array is too small for the given sourceIndex and length.");
             Debug.Assert(destinationArray.Length - destinationIndex >= length,
                 "The destination array is too small for the given destinationIndex and length.");
@@ -632,62 +1104,75 @@ namespace Microsoft.Xna.Framework
             }
         }
 
-	/// <summary>
-        /// Transforms a vector by a quaternion rotation.
-        /// </summary>
-        /// <param name="vec">The vector to transform.</param>
-        /// <param name="quat">The quaternion to rotate the vector by.</param>
-        /// <returns>The result of the operation.</returns>
-        public static Vector3 Transform(Vector3 vec, Quaternion quat)
-        {
-            Vector3 result;
-            Transform(ref vec, ref quat, out result);
-            return result;
-        }
-
-        ///// <summary>
-        ///// Transforms a vector by a quaternion rotation.
-        ///// </summary>
-        ///// <param name="vec">The vector to transform.</param>
-        ///// <param name="quat">The quaternion to rotate the vector by.</param>
-        ///// <param name="result">The result of the operation.</param>
-//        public static void Transform(ref Vector3 vec, ref Quaternion quat, out Vector3 result)
-//        {
-//		// Taken from the OpentTK implementation of Vector3
-//            // Since vec.W == 0, we can optimize quat * vec * quat^-1 as follows:
-//            // vec + 2.0 * cross(quat.xyz, cross(quat.xyz, vec) + quat.w * vec)
-//            Vector3 xyz = quat.Xyz, temp, temp2;
-//            Vector3.Cross(ref xyz, ref vec, out temp);
-//            Vector3.Multiply(ref vec, quat.W, out temp2);
-//            Vector3.Add(ref temp, ref temp2, out temp);
-//            Vector3.Cross(ref xyz, ref temp, out temp);
-//            Vector3.Multiply(ref temp, 2, out temp);
-//            Vector3.Add(ref vec, ref temp, out result);
-//        }
-
         /// <summary>
-        /// Transforms a vector by a quaternion rotation.
+        /// Apply transformation on vectors within array of <see cref="Vector3"/> by the specified <see cref="Quaternion"/> and places the results in an another array.
         /// </summary>
-        /// <param name="value">The vector to transform.</param>
-        /// <param name="rotation">The quaternion to rotate the vector by.</param>
-        /// <param name="result">The result of the operation.</param>
-        public static void Transform(ref Vector3 value, ref Quaternion rotation, out Vector3 result)
+        /// <param name="sourceArray">Source array.</param>
+        /// <param name="sourceIndex">The starting index of transformation in the source array.</param>
+        /// <param name="rotation">The <see cref="Quaternion"/> which contains rotation transformation.</param>
+        /// <param name="destinationArray">Destination array.</param>
+        /// <param name="destinationIndex">The starting index in the destination array, where the first <see cref="Vector3"/> should be written.</param>
+        /// <param name="length">The number of vectors to be transformed.</param>
+        public static void Transform(
+            Vector3[] sourceArray,
+            int sourceIndex,
+            ref Quaternion rotation,
+            Vector3[] destinationArray,
+            int destinationIndex,
+            int length)
         {
-            float x = 2 * (rotation.Y * value.Z - rotation.Z * value.Y);
-            float y = 2 * (rotation.Z * value.X - rotation.X * value.Z);
-            float z = 2 * (rotation.X * value.Y - rotation.Y * value.X);
+            Debug.Assert(sourceArray.Length - sourceIndex >= length,
+                "The source array is too small for the given sourceIndex and length.");
+            Debug.Assert(destinationArray.Length - destinationIndex >= length,
+                "The destination array is too small for the given destinationIndex and length.");
 
-            result.X = value.X + x * rotation.W + (rotation.Y * z - rotation.Z * y);
-            result.Y = value.Y + y * rotation.W + (rotation.Z * x - rotation.X * z);
-            result.Z = value.Z + z * rotation.W + (rotation.X * y - rotation.Y * x);
+            // TODO: Are there options on some platforms to implement a vectorized version of this?
+
+            for (var i = 0; i < length; i++)
+            {
+                var position = sourceArray[sourceIndex + i];
+
+                float x = 2 * (rotation.Y * position.Z - rotation.Z * position.Y);
+                float y = 2 * (rotation.Z * position.X - rotation.X * position.Z);
+                float z = 2 * (rotation.X * position.Y - rotation.Y * position.X);
+
+                destinationArray[destinationIndex + i] =
+                    new Vector3(
+                        position.X + x * rotation.W + (rotation.Y * z - rotation.Z * y),
+                        position.Y + y * rotation.W + (rotation.Z * x - rotation.X * z),
+                        position.Z + z * rotation.W + (rotation.X * y - rotation.Y * x));
+            }
         }
 
         /// <summary>
-        /// Transforms an array of vectors by a quaternion rotation.
+        /// Apply transformation on all vectors within array of <see cref="Vector3"/> by the specified <see cref="Matrix"/> and places the results in an another array.
         /// </summary>
-        /// <param name="sourceArray">The vectors to transform</param>
-        /// <param name="rotation">The quaternion to rotate the vector by.</param>
-        /// <param name="destinationArray">The result of the operation.</param>
+        /// <param name="sourceArray">Source array.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix"/>.</param>
+        /// <param name="destinationArray">Destination array.</param>
+        public static void Transform(Vector3[] sourceArray, ref Matrix matrix, Vector3[] destinationArray)
+        {
+            Debug.Assert(destinationArray.Length >= sourceArray.Length, "The destination array is smaller than the source array.");
+
+            // TODO: Are there options on some platforms to implement a vectorized version of this?
+
+            for (var i = 0; i < sourceArray.Length; i++)
+            {
+                var position = sourceArray[i];                
+                destinationArray[i] =
+                    new Vector3(
+                        (position.X*matrix.M11) + (position.Y*matrix.M21) + (position.Z*matrix.M31) + matrix.M41,
+                        (position.X*matrix.M12) + (position.Y*matrix.M22) + (position.Z*matrix.M32) + matrix.M42,
+                        (position.X*matrix.M13) + (position.Y*matrix.M23) + (position.Z*matrix.M33) + matrix.M43);
+            }
+        }
+
+        /// <summary>
+        /// Apply transformation on all vectors within array of <see cref="Vector3"/> by the specified <see cref="Quaternion"/> and places the results in an another array.
+        /// </summary>
+        /// <param name="sourceArray">Source array.</param>
+        /// <param name="rotation">The <see cref="Quaternion"/> which contains rotation transformation.</param>
+        /// <param name="destinationArray">Destination array.</param>
         public static void Transform(Vector3[] sourceArray, ref Quaternion rotation, Vector3[] destinationArray)
         {
             Debug.Assert(destinationArray.Length >= sourceArray.Length, "The destination array is smaller than the source array.");
@@ -711,56 +1196,37 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Transforms an array of vectors within a given range by a quaternion rotation.
+        /// Creates a new <see cref="Vector3"/> that contains a transformation of the specified normal by the specified <see cref="Matrix"/>.
         /// </summary>
-        /// <param name="sourceArray">The vectors to transform.</param>
-        /// <param name="sourceIndex">The starting index in the source array.</param>
-        /// <param name="rotation">The quaternion to rotate the vector by.</param>
-        /// <param name="destinationArray">The array to store the result of the operation.</param>
-        /// <param name="destinationIndex">The starting index in the destination array.</param>
-        /// <param name="length">The number of vectors to transform.</param>
-        public static void Transform(Vector3[] sourceArray, int sourceIndex, ref Quaternion rotation, Vector3[] destinationArray, int destinationIndex, int length)
-        {
-            Debug.Assert(sourceArray.Length - sourceIndex >= length,
-                "The source array is too small for the given sourceIndex and length.");
-            Debug.Assert(destinationArray.Length - destinationIndex >= length,
-                "The destination array is too small for the given destinationIndex and length.");
-
-            // TODO: Are there options on some platforms to implement a vectorized version of this?
-
-            for (var i = 0; i < length; i++) 
-            {
-                var position = sourceArray[sourceIndex + i];
-
-                float x = 2 * (rotation.Y * position.Z - rotation.Z * position.Y);
-                float y = 2 * (rotation.Z * position.X - rotation.X * position.Z);
-                float z = 2 * (rotation.X * position.Y - rotation.Y * position.X);
-
-                destinationArray[destinationIndex + i] =
-                    new Vector3(
-                        position.X + x * rotation.W + (rotation.Y * z - rotation.Z * y),
-                        position.Y + y * rotation.W + (rotation.Z * x - rotation.X * z),
-                        position.Z + z * rotation.W + (rotation.X * y - rotation.Y * x));
-            }
-        }
-
-
+        /// <param name="normal">Source <see cref="Vector3"/> which represents a normal vector.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix"/>.</param>
+        /// <returns>Transformed normal.</returns>
         public static Vector3 TransformNormal(Vector3 normal, Matrix matrix)
         {
-            TransformNormal(ref normal, ref matrix, out normal);
-            return normal;
+            return new Vector3((normal.X * matrix.M11) + (normal.Y * matrix.M21) + (normal.Z * matrix.M31),
+                               (normal.X * matrix.M12) + (normal.Y * matrix.M22) + (normal.Z * matrix.M32),
+                               (normal.X * matrix.M13) + (normal.Y * matrix.M23) + (normal.Z * matrix.M33));
         }
 
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains a transformation of the specified normal by the specified <see cref="Matrix"/>.
+        /// </summary>
+        /// <param name="normal">Source <see cref="Vector3"/> which represents a normal vector.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix"/>.</param>
+        /// <param name="result">Transformed normal as an output parameter.</param>
         public static void TransformNormal(ref Vector3 normal, ref Matrix matrix, out Vector3 result)
         {
-            var x = (normal.X * matrix.M11) + (normal.Y * matrix.M21) + (normal.Z * matrix.M31);
-            var y = (normal.X * matrix.M12) + (normal.Y * matrix.M22) + (normal.Z * matrix.M32);
-            var z = (normal.X * matrix.M13) + (normal.Y * matrix.M23) + (normal.Z * matrix.M33);
-            result.X = x;
-            result.Y = y;
-            result.Z = z;
+            result.X = (normal.X * matrix.M11) + (normal.Y * matrix.M21) + (normal.Z * matrix.M31);
+            result.Y = (normal.X * matrix.M12) + (normal.Y * matrix.M22) + (normal.Z * matrix.M32);
+            result.Z = (normal.X * matrix.M13) + (normal.Y * matrix.M23) + (normal.Z * matrix.M33);
         }
 
+        /// <summary>
+        /// Apply transformation on all normals within array of <see cref="Vector3"/> by the specified <see cref="Matrix"/> and places the results in an another array.
+        /// </summary>
+        /// <param name="sourceArray">Source array.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix"/>.</param>
+        /// <param name="destinationArray">Destination array.</param>
         public static void TransformNormal(Vector3[] sourceArray, ref Matrix matrix, Vector3[] destinationArray)
         {
             Debug.Assert(destinationArray.Length >= sourceArray.Length, "The destination array is smaller than the source array.");
@@ -777,85 +1243,5 @@ namespace Microsoft.Xna.Framework
         }
 
         #endregion Public methods
-
-
-        #region Operators
-
-        public static bool operator ==(Vector3 value1, Vector3 value2)
-        {
-            return value1.X == value2.X
-                && value1.Y == value2.Y
-                && value1.Z == value2.Z;
-        }
-
-        public static bool operator !=(Vector3 value1, Vector3 value2)
-        {
-            return !(value1 == value2);
-        }
-
-        public static Vector3 operator +(Vector3 value1, Vector3 value2)
-        {
-            value1.X += value2.X;
-            value1.Y += value2.Y;
-            value1.Z += value2.Z;
-            return value1;
-        }
-
-        public static Vector3 operator -(Vector3 value)
-        {
-            value = new Vector3(-value.X, -value.Y, -value.Z);
-            return value;
-        }
-
-        public static Vector3 operator -(Vector3 value1, Vector3 value2)
-        {
-            value1.X -= value2.X;
-            value1.Y -= value2.Y;
-            value1.Z -= value2.Z;
-            return value1;
-        }
-
-        public static Vector3 operator *(Vector3 value1, Vector3 value2)
-        {
-            value1.X *= value2.X;
-            value1.Y *= value2.Y;
-            value1.Z *= value2.Z;
-            return value1;
-        }
-
-        public static Vector3 operator *(Vector3 value, float scaleFactor)
-        {
-            value.X *= scaleFactor;
-            value.Y *= scaleFactor;
-            value.Z *= scaleFactor;
-            return value;
-        }
-
-        public static Vector3 operator *(float scaleFactor, Vector3 value)
-        {
-            value.X *= scaleFactor;
-            value.Y *= scaleFactor;
-            value.Z *= scaleFactor;
-            return value;
-        }
-
-        public static Vector3 operator /(Vector3 value1, Vector3 value2)
-        {
-            value1.X /= value2.X;
-            value1.Y /= value2.Y;
-            value1.Z /= value2.Z;
-            return value1;
-        }
-
-        public static Vector3 operator /(Vector3 value, float divider)
-        {
-            float factor = 1 / divider;
-            value.X *= factor;
-            value.Y *= factor;
-            value.Z *= factor;
-            return value;
-        }
-
-        #endregion
     }
 }

--- a/MonoGame.Framework/Vector4.cs
+++ b/MonoGame.Framework/Vector4.cs
@@ -9,6 +9,9 @@ using System.Diagnostics;
 
 namespace Microsoft.Xna.Framework
 {
+    /// <summary>
+    /// Describes a 4D-vector.
+    /// </summary>
 #if WINDOWS
     [System.ComponentModel.TypeConverter(typeof(Microsoft.Xna.Framework.Design.Vector4TypeConverter))]
 #endif
@@ -29,16 +32,28 @@ namespace Microsoft.Xna.Framework
 
 
         #region Public Fields
-        
+
+        /// <summary>
+        /// The x coordinate of this vector.
+        /// </summary>
         [DataMember]
         public float X;
 
+        /// <summary>
+        /// The y coordinate of this vector.
+        /// </summary>
         [DataMember]
         public float Y;
-      
+
+        /// <summary>
+        /// The z coordinate of this vector.
+        /// </summary>
         [DataMember]
         public float Z;
-      
+
+        /// <summary>
+        /// The w coordinate of this vector.
+        /// </summary>
         [DataMember]
         public float W;
 

--- a/Test/Framework/Vector3Test.cs
+++ b/Test/Framework/Vector3Test.cs
@@ -8,6 +8,121 @@ namespace MonoGame.Tests.Framework
     class Vector3Test
     {
         [Test]
+        public void Properties()
+        {
+            Assert.AreEqual(new Vector3(0, 0, 0), Vector3.Zero);
+            Assert.AreEqual(new Vector3(1, 1, 1), Vector3.One);
+            Assert.AreEqual(new Vector3(1, 0, 0), Vector3.UnitX);
+            Assert.AreEqual(new Vector3(0, 1, 0), Vector3.UnitY);
+            Assert.AreEqual(new Vector3(0, 0, 1), Vector3.UnitZ);
+            Assert.AreEqual(new Vector3(0, 1, 0), Vector3.Up);
+            Assert.AreEqual(new Vector3(0, -1, 0), Vector3.Down);
+            Assert.AreEqual(new Vector3(-1, 0, 0), Vector3.Left);
+            Assert.AreEqual(new Vector3(1, 0, 0), Vector3.Right);
+            Assert.AreEqual(new Vector3(0, 0, -1), Vector3.Forward);
+            Assert.AreEqual(new Vector3(0, 0, 1), Vector3.Backward);
+        }
+
+        [Test]
+        public void Cross()
+        {
+            Vector3 vOut;
+            var v1 = new Vector3(1, 2, 3);
+            var v2 = new Vector3(2, 3.5f, -1.1f);
+            var result = new Vector3(-12.7f, 7.1f, -0.5f);
+            Vector3.Cross(ref v1, ref v2, out vOut);
+
+            Assert.AreEqual(result, vOut);
+            Assert.AreEqual(vOut, Vector3.Cross(v1, v2));
+        }
+
+        [Test]
+        public void Distance()
+        {
+            var v1 = new Vector3(1, 2, 3);
+            var v2 = new Vector3(2, 3.5f, -1.1f);
+            float fOut;
+            const float result = 4.478839f;
+            Vector3.Distance(ref v1, ref v2, out fOut);
+
+            Assert.AreEqual(result, fOut);
+            Assert.AreEqual(fOut, Vector3.Distance(v1, v2));
+        }
+
+        [Test]
+        public void DistanceSquared()
+        {
+            var v1 = new Vector3(1, 2, 3);
+            var v2 = new Vector3(2, 3.5f, -1.1f);
+            float fOut;
+            const float result = 20.06f;
+            Vector3.DistanceSquared(ref v1, ref v2, out fOut);
+
+            Assert.AreEqual(result, fOut);
+            Assert.AreEqual(fOut, Vector3.DistanceSquared(v1, v2));
+        }
+
+        [Test]
+        public void Dot()
+        {
+            var v1 = new Vector3(1, 2, 3);
+            var v2 = new Vector3(2, 3.5f, -1.1f);
+            float fOut;
+            const float result = 5.7f;
+            Vector3.Dot(ref v1, ref v2, out fOut);
+
+            Assert.AreEqual(result, fOut);
+            Assert.AreEqual(fOut, Vector3.Dot(v1, v2));
+        }
+
+        [Test]
+        public void Hermite()
+        {
+            var v1 = new Vector3(1, 2, 3);
+            var t1 = new Vector3(0.4f, 0.2f, 0.1f);
+            var v2 = new Vector3(4, 2, 1);
+            var t2 = new Vector3(10, 3, 1.4f);
+            Vector3 vOut;
+            const float amount = 0.5f;
+            var result = new Vector3(1.3f,1.65f,1.8375f);
+            Vector3.Hermite(ref v1,ref t1,ref v2,ref t2, amount,out vOut);
+
+            Assert.AreEqual(result, vOut);
+            Assert.AreEqual(vOut,Vector3.Hermite(v1,t1,v2,t2,amount));
+        }
+
+        [Test]
+        public void Length()
+        {
+            var result = 3.7416575f;
+            Assert.AreEqual(result, new Vector3(1, 2, 3).Length());
+        }
+
+        [Test]
+        public void LengthSquared()
+        {
+            var result = 14.0f;
+            Assert.AreEqual(result, new Vector3(1, 2, 3).LengthSquared());
+        }
+
+        [Test]
+        public void Multiply()
+        {
+            var v1 = new Vector3(1, 2, 3);
+            var v2 = new Vector3(1, 2, 3);
+            Vector3 vOut;
+            Vector3.Multiply(ref v1, ref v2, out vOut);
+            Assert.AreEqual(new Vector3(1, 4, 9), vOut);
+            Assert.AreEqual(vOut,Vector3.Multiply(v1,v2));
+        }
+
+        [Test]
+        public void ToStringTest()
+        {
+            Assert.AreEqual("{X:0 Y:1 Z:2}", new Vector3(0, 1, 2).ToString());
+        }
+
+        [Test]
         public void TypeConverter()
         {
             var converter = TypeDescriptor.GetConverter(typeof(Vector3));


### PR DESCRIPTION
-Rewrited Vector2 docs - removed "see = cref>Vector2" routines and place simple "vector" instead.
-Fully documented Vector3 based on Vector2 translation.
-Optimization in few places in Vector3 -> New tests for Vector3.
-Few Vector4 docs.