### PR TITLE
Updated Assembly version number for dev release (post 3.3 release)

### DIFF
--- a/MonoGame.Framework/Properties/AssemblyInfo.cs
+++ b/MonoGame.Framework/Properties/AssemblyInfo.cs
@@ -67,6 +67,6 @@ using System.Resources;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.1.2.0")]
-[assembly: AssemblyFileVersion("3.1.2.0")]
+[assembly: AssemblyVersion("3.3.1.0")]
+[assembly: AssemblyFileVersion("3.3.1.0")]
 [assembly: NeutralResourcesLanguageAttribute("en-US")]

--- a/MonoGame.Framework/Properties/AssemblyInfo.cs
+++ b/MonoGame.Framework/Properties/AssemblyInfo.cs
@@ -67,6 +67,6 @@ using System.Resources;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.3.1.0")]
-[assembly: AssemblyFileVersion("3.3.1.0")]
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]
 [assembly: NeutralResourcesLanguageAttribute("en-US")]


### PR DESCRIPTION
Noticed (a little too late) that the assembly version on the branch wasn't updated on release.

Verified that Official release did version the dll's correctly, so this is just a tidy up

Updated to 3.3.1.0