### PR TITLE
New docs

### DIFF
--- a/MonoGame.Framework/Graphics/ClearOptions.cs
+++ b/MonoGame.Framework/Graphics/ClearOptions.cs
@@ -7,9 +7,7 @@ using System;
 namespace Microsoft.Xna.Framework.Graphics
 {
     /// <summary>
-#pragma warning disable 1574 // disabling ambigious overload of <see cref="GraphicsDevice.Clear"/> warning
     /// Defines the buffers for clearing when calling <see cref="GraphicsDevice.Clear"/> operation.
-#pragma warning restore 1574 // restoring warning behaviour
     /// </summary>
     [Flags]
     public enum ClearOptions

--- a/MonoGame.Framework/Graphics/ClearOptions.cs
+++ b/MonoGame.Framework/Graphics/ClearOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Xna.Framework.Graphics
     public enum ClearOptions
     {
         /// <summary>
-        /// Render target buffer.
+        /// Color buffer.
         /// </summary>
 		Target = 1,
         /// <summary>

--- a/MonoGame.Framework/Graphics/ClearOptions.cs
+++ b/MonoGame.Framework/Graphics/ClearOptions.cs
@@ -1,52 +1,30 @@
-#region License
-/*
-Microsoft Public License (Ms-PL)
-MonoGame - Copyright © 2009 The MonoGame Team
-
-All rights reserved.
-
-This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
-accept the license, do not use the software.
-
-1. Definitions
-The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
-U.S. copyright law.
-
-A "contribution" is the original software, or any additions or changes to the software.
-A "contributor" is any person that distributes its contribution under this license.
-"Licensed patents" are a contributor's patent claims that read directly on its contribution.
-
-2. Grant of Rights
-(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-
-3. Conditions and Limitations
-(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
-your patent license from such contributor to the software ends automatically.
-(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
-notices that are present in the software.
-(D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
-a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
-code form, you may only do so under a license that complies with this license.
-(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
-or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
-permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
-purpose and non-infringement.
-*/
-#endregion License
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
 
 using System;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+#pragma warning disable 1574 // disabling ambigious overload of <see cref="GraphicsDevice.Clear"/> warning
+    /// Defines the buffers for clearing when calling <see cref="GraphicsDevice.Clear"/> operation.
+#pragma warning restore 1574 // restoring warning behaviour
+    /// </summary>
     [Flags]
     public enum ClearOptions
     {
+        /// <summary>
+        /// Render target buffer.
+        /// </summary>
 		Target = 1,
+        /// <summary>
+        /// Depth buffer.
+        /// </summary>
         DepthBuffer = 2,
+        /// <summary>
+        /// Stencil buffer.
+        /// </summary>
         Stencil = 4        
     }
 }

--- a/MonoGame.Framework/Graphics/ColorWriteChannels.cs
+++ b/MonoGame.Framework/Graphics/ColorWriteChannels.cs
@@ -1,55 +1,40 @@
-// #region License
-// /*
-// Microsoft Public License (Ms-PL)
-// MonoGame - Copyright © 2009 The MonoGame Team
-// 
-// All rights reserved.
-// 
-// This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
-// accept the license, do not use the software.
-// 
-// 1. Definitions
-// The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
-// U.S. copyright law.
-// 
-// A "contribution" is the original software, or any additions or changes to the software.
-// A "contributor" is any person that distributes its contribution under this license.
-// "Licensed patents" are a contributor's patent claims that read directly on its contribution.
-// 
-// 2. Grant of Rights
-// (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-// each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-// (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-// each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-// 
-// 3. Conditions and Limitations
-// (A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-// (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
-// your patent license from such contributor to the software ends automatically.
-// (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
-// notices that are present in the software.
-// (D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
-// a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
-// code form, you may only do so under a license that complies with this license.
-// (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
-// or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
-// permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
-// purpose and non-infringement.
-// */
-// #endregion License
-// 
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
 using System;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Defines the color channels for render target blending operations.
+    /// </summary>
 	[Flags]
 	public enum ColorWriteChannels
 	{
+        /// <summary>
+        /// No channels selected.
+        /// </summary>
 		None = 0,
+        /// <summary>
+        /// Red channel.
+        /// </summary>
 		Red = 1,
+        /// <summary>
+        /// Green channel.
+        /// </summary>
 		Green = 2,
+        /// <summary>
+        /// Blue channel.
+        /// </summary>
 		Blue = 4,
+        /// <summary>
+        /// Alpha channel.
+        /// </summary>
 		Alpha = 8,
+        /// <summary>
+        /// All channels selected.
+        /// </summary>
 		All = 15
 	}
 }

--- a/MonoGame.Framework/Graphics/ColorWriteChannels.cs
+++ b/MonoGame.Framework/Graphics/ColorWriteChannels.cs
@@ -17,19 +17,19 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
 		None = 0,
         /// <summary>
-        /// Red channel.
+        /// Red channel selected.
         /// </summary>
 		Red = 1,
         /// <summary>
-        /// Green channel.
+        /// Green channel selected.
         /// </summary>
 		Green = 2,
         /// <summary>
-        /// Blue channel.
+        /// Blue channel selected.
         /// </summary>
 		Blue = 4,
         /// <summary>
-        /// Alpha channel.
+        /// Alpha channel selected.
         /// </summary>
 		Alpha = 8,
         /// <summary>

--- a/MonoGame.Framework/Graphics/CubeMapFace.cs
+++ b/MonoGame.Framework/Graphics/CubeMapFace.cs
@@ -1,14 +1,37 @@
-using System;
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Defines the faces in a cube map for the <see cref="TextureCube"/> class.
+    /// </summary>
 	public enum CubeMapFace
-	{
+    {
+        /// <summary>
+        /// Positive X face in the cube map.
+        /// </summary>
 		PositiveX,
-		NegativeX,
-		PositiveY,
-		NegativeY,
-		PositiveZ,
+        /// <summary>
+        /// Negative X face in the cube map.
+        /// </summary>
+        NegativeX, 
+        /// <summary>
+        /// Positive Y face in the cube map.
+        /// </summary>
+        PositiveY,
+        /// <summary>
+        /// Negative Y face in the cube map.
+        /// </summary>
+        NegativeY,
+        /// <summary>
+        /// Positive Z face in the cube map.
+        /// </summary>
+        PositiveZ,
+        /// <summary>
+        /// Negative Z face in the cube map.
+        /// </summary>
 		NegativeZ
 	}
 }

--- a/MonoGame.Framework/Graphics/States/Blend.cs
+++ b/MonoGame.Framework/Graphics/States/Blend.cs
@@ -5,7 +5,7 @@
 namespace Microsoft.Xna.Framework.Graphics
 {
     /// <summary>
-    /// Defines color blending options.
+    /// Defines a blend mode.
     /// </summary>
 	public enum Blend
 	{

--- a/MonoGame.Framework/Graphics/States/Blend.cs
+++ b/MonoGame.Framework/Graphics/States/Blend.cs
@@ -1,61 +1,74 @@
-// #region License
-// /*
-// Microsoft Public License (Ms-PL)
-// MonoGame - Copyright © 2009 The MonoGame Team
-// 
-// All rights reserved.
-// 
-// This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
-// accept the license, do not use the software.
-// 
-// 1. Definitions
-// The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
-// U.S. copyright law.
-// 
-// A "contribution" is the original software, or any additions or changes to the software.
-// A "contributor" is any person that distributes its contribution under this license.
-// "Licensed patents" are a contributor's patent claims that read directly on its contribution.
-// 
-// 2. Grant of Rights
-// (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-// each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-// (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-// each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-// 
-// 3. Conditions and Limitations
-// (A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-// (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
-// your patent license from such contributor to the software ends automatically.
-// (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
-// notices that are present in the software.
-// (D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
-// a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
-// code form, you may only do so under a license that complies with this license.
-// (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
-// or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
-// permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
-// purpose and non-infringement.
-// */
-// #endregion License
-// 
-using System;
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Defines color blending options.
+    /// </summary>
 	public enum Blend
 	{
-		One,				// Each component of the color is multiplied by (1, 1, 1, 1).
-		Zero,	 			// Each component of the color is multiplied by (0, 0, 0, 0).
-		SourceColor,		// Each component of the color is multiplied by the source color. This can be represented as (Rs, Gs, Bs, As), where R, G, B, and A respectively stand for the red, green, blue, and alpha source values.
-		InverseSourceColor,	// Each component of the color is multiplied by the inverse of the source color. This can be represented as (1 − Rs, 1 − Gs, 1 − Bs, 1 − As) where R, G, B, and A respectively stand for the red, green, blue, and alpha destination values.
-		SourceAlpha,		// Each component of the color is multiplied by the alpha value of the source. This can be represented as (As, As, As, As), where As is the alpha source value. 
-		InverseSourceAlpha,	// Each component of the color is multiplied by the inverse of the alpha value of the source. This can be represented as (1 − As, 1 − As, 1 − As, 1 − As), where As is the alpha destination value.
-		DestinationColor,	//Each component color is multiplied by the destination color. This can be represented as (Rd, Gd, Bd, Ad), where R, G, B, and A respectively stand for red, green, blue, and alpha destination values.
-		InverseDestinationColor,	// Each component of the color is multiplied by the inverse of the destination color. This can be represented as (1 − Rd, 1 − Gd, 1 − Bd, 1 − Ad), where Rd, Gd, Bd, and Ad respectively stand for the red, green, blue, and alpha destination values.
-		DestinationAlpha,	// Each component of the color is multiplied by the alpha value of the destination. This can be represented as (Ad, Ad, Ad, Ad), where Ad is the destination alpha value.
-		InverseDestinationAlpha,	// Each component of the color is multiplied by the inverse of the alpha value of the source. This can be represented as (1 − As, 1 − As, 1 − As, 1 − As), where As is the alpha destination value.
-		BlendFactor,		// Each component of the color is multiplied by a constant set in BlendFactor.
-		InverseBlendFactor,	//Each component of the color is multiplied by the inverse of a constant set in BlendFactor.
-		SourceAlphaSaturation,	// Each component of the color is multiplied by either the alpha of the source color, or the inverse of the alpha of the source color, whichever is greater. This can be represented as (f, f, f, 1), where f = min(A, 1 − Ad).
+        /// <summary>
+        /// Each component of the color is multiplied by {1, 1, 1, 1}.
+        /// </summary>
+		One,
+        /// <summary>
+        /// Each component of the color is multiplied by {0, 0, 0, 0}.
+        /// </summary>
+		Zero,
+        /// <summary>
+        /// Each component of the color is multiplied by the source color. 
+        /// {Rs, Gs, Bs, As}, where Rs, Gs, Bs, As are color source values.
+        /// </summary>
+		SourceColor,
+        /// <summary>
+        /// Each component of the color is multiplied by the inverse of the source color.
+        ///  {1 − Rs, 1 − Gs, 1 − Bs, 1 − As}, where Rs, Gs, Bs, As are color source values.
+        /// </summary>
+		InverseSourceColor,
+        /// <summary>
+        /// Each component of the color is multiplied by the alpha value of the source. 
+        /// {As, As, As, As}, where As is the source alpha value.
+        /// </summary>
+		SourceAlpha,
+        /// <summary>
+        /// Each component of the color is multiplied by the inverse of the alpha value of the source. 
+        /// {1 − As, 1 − As, 1 − As, 1 − As}, where As is the source alpha value.
+        /// </summary>
+		InverseSourceAlpha,
+        /// <summary>
+        /// Each component color is multiplied by the destination color. 
+        /// {Rd, Gd, Bd, Ad}, where Rd, Gd, Bd, Ad are color destination values.
+        /// </summary>
+		DestinationColor,	
+        /// <summary>
+        /// Each component of the color is multiplied by the inversed destination color. 
+        /// {1 − Rd, 1 − Gd, 1 − Bd, 1 − Ad}, where Rd, Gd, Bd, Ad are color destination values.
+        /// </summary>
+		InverseDestinationColor,
+        /// <summary>
+        /// Each component of the color is multiplied by the alpha value of the destination.
+        /// {Ad, Ad, Ad, Ad}, where Ad is the destination alpha value.
+        /// </summary>
+		DestinationAlpha,	
+        /// <summary>
+        /// Each component of the color is multiplied by the inversed alpha value of the destination. 
+        /// {1 − Ad, 1 − Ad, 1 − Ad, 1 − Ad}, where Ad is the destination alpha value.
+        /// </summary>
+		InverseDestinationAlpha,
+	    /// <summary>
+        /// Each component of the color is multiplied by a constant in the <see cref="GraphicsDevice.BlendFactor"/>.
+	    /// </summary>
+		BlendFactor,
+        /// <summary>
+        /// Each component of the color is multiplied by a inversed constant in the <see cref="GraphicsDevice.BlendFactor"/>.
+        /// </summary>
+		InverseBlendFactor,
+        /// <summary>
+        /// Each component of the color is multiplied by either the alpha of the source color, or the inverse of the alpha of the source color, whichever is greater. 
+        /// {f, f, f, 1}, where f = min(As, 1 − As), where As is the source alpha value.
+        /// </summary>
+		SourceAlphaSaturation
 	}
 }
-

--- a/MonoGame.Framework/Graphics/States/BlendFunction.cs
+++ b/MonoGame.Framework/Graphics/States/BlendFunction.cs
@@ -22,12 +22,12 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         ReverseSubtract,
         /// <summary>
-        /// The function will extracts maximum of the source and destination. max((srcColor * srcBlend),(destColor * destBlend))
-        /// </summary>
-        Max,
-        /// <summary>
         /// The function will extracts minimum of the source and destination. min((srcColor * srcBlend),(destColor * destBlend))
         /// </summary>
-		Min,
+        Min, 
+        /// <summary>
+        /// The function will extracts maximum of the source and destination. max((srcColor * srcBlend),(destColor * destBlend))
+        /// </summary>
+		Max
 	}
 }

--- a/MonoGame.Framework/Graphics/States/BlendFunction.cs
+++ b/MonoGame.Framework/Graphics/States/BlendFunction.cs
@@ -1,54 +1,33 @@
-// #region License
-// /*
-// Microsoft Public License (Ms-PL)
-// MonoGame - Copyright © 2009 The MonoGame Team
-// 
-// All rights reserved.
-// 
-// This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
-// accept the license, do not use the software.
-// 
-// 1. Definitions
-// The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
-// U.S. copyright law.
-// 
-// A "contribution" is the original software, or any additions or changes to the software.
-// A "contributor" is any person that distributes its contribution under this license.
-// "Licensed patents" are a contributor's patent claims that read directly on its contribution.
-// 
-// 2. Grant of Rights
-// (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-// each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-// (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-// each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-// 
-// 3. Conditions and Limitations
-// (A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-// (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
-// your patent license from such contributor to the software ends automatically.
-// (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
-// notices that are present in the software.
-// (D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
-// a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
-// code form, you may only do so under a license that complies with this license.
-// (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
-// or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
-// permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
-// purpose and non-infringement.
-// */
-// #endregion License
-// 
-
-using System;
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
 
 namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Defines a function for color blending.
+    /// </summary>
 	public enum BlendFunction
 	{
+        /// <summary>
+        /// The function will adds destination to the source. (srcColor * srcBlend) + (destColor * destBlend)
+        /// </summary>
 		Add,
+        /// <summary>
+        /// The function will subtracts destination from source. (srcColor * srcBlend) − (destColor * destBlend)
+        /// </summary>
 		Subtract,
-		ReverseSubtract,
-		Max,
+        /// <summary>
+        /// The function will subtracts source from destination. (destColor * destBlend) - (srcColor * srcBlend) 
+        /// </summary>
+        ReverseSubtract,
+        /// <summary>
+        /// The function will extracts maximum of the source and destination. max((srcColor * srcBlend),(destColor * destBlend))
+        /// </summary>
+        Max,
+        /// <summary>
+        /// The function will extracts minimum of the source and destination. min((srcColor * srcBlend),(destColor * destBlend))
+        /// </summary>
 		Min,
 	}
 }

--- a/MonoGame.Framework/Graphics/States/CompareFunction.cs
+++ b/MonoGame.Framework/Graphics/States/CompareFunction.cs
@@ -5,7 +5,7 @@
 namespace Microsoft.Xna.Framework.Graphics
 {
     /// <summary>
-    /// Defines comparison functions for the various rendering tests.
+    /// The comparison function used for depth, stencil, and alpha tests.
     /// </summary>
     public enum CompareFunction
     {

--- a/MonoGame.Framework/Graphics/States/CompareFunction.cs
+++ b/MonoGame.Framework/Graphics/States/CompareFunction.cs
@@ -1,14 +1,45 @@
-﻿namespace Microsoft.Xna.Framework.Graphics
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Defines comparison functions for the various rendering tests.
+    /// </summary>
     public enum CompareFunction
     {
+        /// <summary>
+        /// Always passes the test.
+        /// </summary>
         Always,
+        /// <summary>
+        /// Never passes the test.
+        /// </summary>
         Never,
+        /// <summary>
+        /// Passes the test when the new pixel value is less than current pixel value.
+        /// </summary>
         Less,
+        /// <summary>
+        /// Passes the test when the new pixel value is less than or equal to current pixel value.
+        /// </summary>
         LessEqual,
+        /// <summary>
+        /// Passes the test when the new pixel value is equal to current pixel value.
+        /// </summary>
         Equal,
+        /// <summary>
+        /// Passes the test when the new pixel value is greater than or equal to current pixel value.
+        /// </summary>
         GreaterEqual,
+        /// <summary>
+        /// Passes the test when the new pixel value is greater than current pixel value.
+        /// </summary>
         Greater,
+        /// <summary>
+        /// Passes the test when the new pixel value does not equal to current pixel value.
+        /// </summary>
         NotEqual
     }
 }

--- a/MonoGame.Framework/Graphics/States/CullMode.cs
+++ b/MonoGame.Framework/Graphics/States/CullMode.cs
@@ -1,9 +1,25 @@
-﻿namespace Microsoft.Xna.Framework.Graphics
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Defines a culling mode for faces in rasterization process.
+    /// </summary>
     public enum CullMode
     {
+        /// <summary>
+        /// Do not cull faces.
+        /// </summary>
         None,
+        /// <summary>
+        /// Cull faces with clockwise order.
+        /// </summary>
         CullClockwiseFace,
+        /// <summary>
+        /// Cull faces with counter clockwise order.
+        /// </summary>
         CullCounterClockwiseFace
     }
 }

--- a/MonoGame.Framework/Graphics/Vertices/BufferUsage.cs
+++ b/MonoGame.Framework/Graphics/Vertices/BufferUsage.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         None,
         /// <summary>
-        /// Buffer will not be readable and will fails if reading occurs, but it will have better performance than <see cref="BufferUsage.None"/>.
+        /// The buffer will not be readable and will be optimized for rendering and writing.
         /// </summary>
         WriteOnly
     }

--- a/MonoGame.Framework/Graphics/Vertices/BufferUsage.cs
+++ b/MonoGame.Framework/Graphics/Vertices/BufferUsage.cs
@@ -1,8 +1,21 @@
-﻿namespace Microsoft.Xna.Framework.Graphics
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+namespace Microsoft.Xna.Framework.Graphics
 {
+    /// <summary>
+    /// Defines special usage for the graphics buffers.
+    /// </summary>
     public enum BufferUsage
     {
+        /// <summary>
+        /// No special usage.
+        /// </summary>
         None,
+        /// <summary>
+        /// Buffer will not be readable and will fails if reading occurs, but it will have better performance than <see cref="BufferUsage.None"/>.
+        /// </summary>
         WriteOnly
     }
 }

--- a/MonoGame.Framework/Graphics/Vertices/BufferUsage.cs
+++ b/MonoGame.Framework/Graphics/Vertices/BufferUsage.cs
@@ -5,7 +5,7 @@
 namespace Microsoft.Xna.Framework.Graphics
 {
     /// <summary>
-    /// Defines special usage for the graphics buffers.
+    /// A usage hint for optimizing memory placement of graphics buffers.
     /// </summary>
     public enum BufferUsage
     {

--- a/Test/Framework/EnumConformingTest.cs
+++ b/Test/Framework/EnumConformingTest.cs
@@ -9,6 +9,92 @@ namespace MonoGame.Tests.Framework
     class EnumConformingTest
     {
         [Test]
+        public void BlendEnum()
+        {
+            Assert.AreEqual(0, (int)Blend.One);
+            Assert.AreEqual(1, (int)Blend.Zero);
+            Assert.AreEqual(2, (int)Blend.SourceColor);
+            Assert.AreEqual(3, (int)Blend.InverseSourceColor);
+            Assert.AreEqual(4, (int)Blend.SourceAlpha);
+            Assert.AreEqual(5, (int)Blend.InverseSourceAlpha);
+            Assert.AreEqual(6, (int)Blend.DestinationColor);
+            Assert.AreEqual(7, (int)Blend.InverseDestinationColor);
+            Assert.AreEqual(8, (int)Blend.DestinationAlpha);
+            Assert.AreEqual(9, (int)Blend.InverseDestinationAlpha);
+            Assert.AreEqual(10, (int)Blend.BlendFactor);
+            Assert.AreEqual(11, (int)Blend.InverseBlendFactor);
+            Assert.AreEqual(12, (int)Blend.SourceAlphaSaturation);
+        }
+
+        [Test]
+        public void BlendFunctionEnum()
+        {
+            Assert.AreEqual(0, (int)BlendFunction.Add);
+            Assert.AreEqual(1, (int)BlendFunction.Subtract);
+            Assert.AreEqual(2, (int)BlendFunction.ReverseSubtract);
+            Assert.AreEqual(3, (int)BlendFunction.Min);
+            Assert.AreEqual(4, (int)BlendFunction.Max);
+        }
+
+        [Test]
+        public void BufferUsageEnum()
+        {
+            Assert.AreEqual(0, (int)BufferUsage.None);
+            Assert.AreEqual(1, (int)BufferUsage.WriteOnly);
+        }
+
+        [Test]
+        public void ClearOptionsEnum()
+        {
+            Assert.AreEqual(1, (int)ClearOptions.Target);
+            Assert.AreEqual(2, (int)ClearOptions.DepthBuffer);
+            Assert.AreEqual(4, (int)ClearOptions.Stencil);
+        }
+
+        [Test]
+        public void ColorWriteChannelsEnum()
+        {
+            Assert.AreEqual(0, (int)ColorWriteChannels.None);
+            Assert.AreEqual(1, (int)ColorWriteChannels.Red);
+            Assert.AreEqual(2, (int)ColorWriteChannels.Green);
+            Assert.AreEqual(4, (int)ColorWriteChannels.Blue);
+            Assert.AreEqual(8, (int)ColorWriteChannels.Alpha);
+            Assert.AreEqual(15, (int)ColorWriteChannels.All);
+        }
+
+        [Test]
+        public void CompareFunctionEnum()
+        {
+            Assert.AreEqual(0, (int)CompareFunction.Always);
+            Assert.AreEqual(1, (int)CompareFunction.Never);
+            Assert.AreEqual(2, (int)CompareFunction.Less);
+            Assert.AreEqual(3, (int)CompareFunction.LessEqual);
+            Assert.AreEqual(4, (int)CompareFunction.Equal);
+            Assert.AreEqual(5, (int)CompareFunction.GreaterEqual);
+            Assert.AreEqual(6, (int)CompareFunction.Greater);
+            Assert.AreEqual(7, (int)CompareFunction.NotEqual);
+        }
+
+        [Test]
+        public void CubeMapFaceEnum()
+        {
+            Assert.AreEqual(0, (int)CubeMapFace.PositiveX);
+            Assert.AreEqual(1, (int)CubeMapFace.NegativeX);
+            Assert.AreEqual(2, (int)CubeMapFace.PositiveY);
+            Assert.AreEqual(3, (int)CubeMapFace.NegativeY);
+            Assert.AreEqual(4, (int)CubeMapFace.PositiveZ);
+            Assert.AreEqual(5, (int)CubeMapFace.NegativeZ);
+        }
+
+        [Test]
+        public void CullModeEnum()
+        {
+            Assert.AreEqual(0, (int)CullMode.None);
+            Assert.AreEqual(1, (int)CullMode.CullClockwiseFace);
+            Assert.AreEqual(2, (int)CullMode.CullCounterClockwiseFace);
+        }
+
+        [Test]
         public void DepthFormatEnum()
         {
             Assert.AreEqual(0, (int)DepthFormat.None);


### PR DESCRIPTION
This PR caps the all remained enums in Microsoft.XNA.Framework.Graphics namespace. 
Docs for :

-Blend
-BlendFunction
-BufferUsage
-ClearOptions
-ColorWriteChannels
-CompareFunction
-CubeMapFace
-CullMode

All docs are unique and not be equal to same in XNA. New tests for them in EnumConformingTest are implemented.