### PR TITLE
Implement comparison samplers for Direct3D and OpenGL

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsExtensions.cs
+++ b/MonoGame.Framework/Graphics/GraphicsExtensions.cs
@@ -438,6 +438,30 @@ namespace Microsoft.Xna.Framework.Graphics
 
 		}
 
+        public static DepthFunction GetDepthFunction(this CompareFunction compare)
+        {
+            switch (compare)
+            {
+                default:
+                case CompareFunction.Always:
+                    return DepthFunction.Always;
+                case CompareFunction.Equal:
+                    return DepthFunction.Equal;
+                case CompareFunction.Greater:
+                    return DepthFunction.Greater;
+                case CompareFunction.GreaterEqual:
+                    return DepthFunction.Gequal;
+                case CompareFunction.Less:
+                    return DepthFunction.Less;
+                case CompareFunction.LessEqual:
+                    return DepthFunction.Lequal;
+                case CompareFunction.Never:
+                    return DepthFunction.Never;
+                case CompareFunction.NotEqual:
+                    return DepthFunction.Notequal;
+            }
+        }
+
 #if WINDOWS || LINUX || ANGLE
         /// <summary>
         /// Convert a <see cref="SurfaceFormat"/> to an OpenTK.Graphics.ColorFormat.

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.DirectX.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.DirectX.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 var desc = new SharpDX.Direct3D11.DepthStencilStateDescription();
 
                 desc.IsDepthEnabled = DepthBufferEnable;
-                desc.DepthComparison = GetComparison(DepthBufferFunction);
+                desc.DepthComparison = DepthBufferFunction.ToComparison();
 
                 if (DepthBufferWriteEnable)
                     desc.DepthWriteMask = SharpDX.Direct3D11.DepthWriteMask.All;
@@ -38,20 +38,20 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 if (TwoSidedStencilMode)
                 {
-                    desc.BackFace.Comparison = GetComparison(CounterClockwiseStencilFunction);
+                    desc.BackFace.Comparison = CounterClockwiseStencilFunction.ToComparison();
                     desc.BackFace.DepthFailOperation = GetStencilOp(CounterClockwiseStencilDepthBufferFail);
                     desc.BackFace.FailOperation = GetStencilOp(CounterClockwiseStencilFail);
                     desc.BackFace.PassOperation = GetStencilOp(CounterClockwiseStencilPass);
                 }
                 else
                 {   //use same settings as frontFace 
-                    desc.BackFace.Comparison = GetComparison(StencilFunction);
+                    desc.BackFace.Comparison = StencilFunction.ToComparison();
                     desc.BackFace.DepthFailOperation = GetStencilOp(StencilDepthBufferFail);
                     desc.BackFace.FailOperation = GetStencilOp(StencilFail);
                     desc.BackFace.PassOperation = GetStencilOp(StencilPass);
                 }
 
-                desc.FrontFace.Comparison = GetComparison(StencilFunction);
+                desc.FrontFace.Comparison = StencilFunction.ToComparison();
                 desc.FrontFace.DepthFailOperation = GetStencilOp(StencilDepthBufferFail);
                 desc.FrontFace.FailOperation = GetStencilOp(StencilFail);
                 desc.FrontFace.PassOperation = GetStencilOp(StencilPass);
@@ -67,39 +67,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Apply the state!
             device._d3dContext.OutputMerger.SetDepthStencilState(_state, ReferenceStencil);
-        }
-
-        static private SharpDX.Direct3D11.Comparison GetComparison( CompareFunction compare)
-        {
-            switch (compare)
-            {
-                case CompareFunction.Always:
-                    return SharpDX.Direct3D11.Comparison.Always;
-
-                case CompareFunction.Equal:
-                    return SharpDX.Direct3D11.Comparison.Equal;
-
-                case CompareFunction.Greater:
-                    return SharpDX.Direct3D11.Comparison.Greater;
-
-                case CompareFunction.GreaterEqual:
-                    return SharpDX.Direct3D11.Comparison.GreaterEqual;
-
-                case CompareFunction.Less:
-                    return SharpDX.Direct3D11.Comparison.Less;
-
-                case CompareFunction.LessEqual:
-                    return SharpDX.Direct3D11.Comparison.LessEqual;
-
-                case CompareFunction.Never:
-                    return SharpDX.Direct3D11.Comparison.Never;
-
-                case CompareFunction.NotEqual:
-                    return SharpDX.Direct3D11.Comparison.NotEqual;
-
-                default:
-                    throw new ArgumentException("Invalid comparison!");
-            }
         }
 
         static private SharpDX.Direct3D11.StencilOperation GetStencilOp(StencilOperation op)

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.OpenGL.cs
@@ -37,36 +37,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             if (force || this.DepthBufferFunction != device._lastDepthStencilState.DepthBufferFunction)
             {
-                DepthFunction func;
-                switch (DepthBufferFunction)
-                {
-                    default:
-                    case CompareFunction.Always:
-                        func = DepthFunction.Always;
-                        break;
-                    case CompareFunction.Equal:
-                        func = DepthFunction.Equal;
-                        break;
-                    case CompareFunction.Greater:
-                        func = DepthFunction.Greater;
-                        break;
-                    case CompareFunction.GreaterEqual:
-                        func = DepthFunction.Gequal;
-                        break;
-                    case CompareFunction.Less:
-                        func = DepthFunction.Less;
-                        break;
-                    case CompareFunction.LessEqual:
-                        func = DepthFunction.Lequal;
-                        break;
-                    case CompareFunction.Never:
-                        func = DepthFunction.Never;
-                        break;
-                    case CompareFunction.NotEqual:
-                        func = DepthFunction.Notequal;
-                        break;
-                }
-                GL.DepthFunc(func);
+                GL.DepthFunc(DepthBufferFunction.GetDepthFunction());
                 GraphicsExtensions.CheckGLError();
                 device._lastDepthStencilState.DepthBufferFunction = this.DepthBufferFunction;
             }

--- a/MonoGame.Framework/Graphics/States/SamplerState.DirectX.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.DirectX.cs
@@ -28,9 +28,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 desc.AddressV = GetAddressMode(AddressV);
                 desc.AddressW = GetAddressMode(AddressW);
 
-                desc.Filter = GetFilter(Filter);
+                desc.Filter = GetFilter(Filter, ComparisonFunction != CompareFunction.Never);
                 desc.MaximumAnisotropy = MaxAnisotropy;
                 desc.MipLodBias = MipMapLevelOfDetailBias;
+                desc.ComparisonFunction = ComparisonFunction.ToComparison();
 
                 // TODO: How do i do these?
                 desc.MinimumLod = 0.0f;
@@ -39,7 +40,6 @@ namespace Microsoft.Xna.Framework.Graphics
                 // To support feature level 9.1 these must 
                 // be set to these exact values.
                 desc.MaximumLod = float.MaxValue;
-                desc.ComparisonFunction = SharpDX.Direct3D11.Comparison.Never;
 
                 // Create the state.
                 _state = new SharpDX.Direct3D11.SamplerState(GraphicsDevice._d3dDevice, desc);
@@ -50,39 +50,77 @@ namespace Microsoft.Xna.Framework.Graphics
             return _state;
         }
 
-        private static SharpDX.Direct3D11.Filter GetFilter(TextureFilter filter)
+        private static SharpDX.Direct3D11.Filter GetFilter(TextureFilter filter, bool comparison)
         {
-            switch (filter)
+            if (comparison)
             {
-                case TextureFilter.Anisotropic:
-                    return SharpDX.Direct3D11.Filter.Anisotropic;
+                switch (filter)
+                {
+                    case TextureFilter.Anisotropic:
+                        return SharpDX.Direct3D11.Filter.ComparisonAnisotropic;
 
-                case TextureFilter.Linear:
-                    return SharpDX.Direct3D11.Filter.MinMagMipLinear;
+                    case TextureFilter.Linear:
+                        return SharpDX.Direct3D11.Filter.ComparisonMinMagMipLinear;
 
-                case TextureFilter.LinearMipPoint:
-                    return SharpDX.Direct3D11.Filter.MinMagLinearMipPoint;
+                    case TextureFilter.LinearMipPoint:
+                        return SharpDX.Direct3D11.Filter.ComparisonMinMagLinearMipPoint;
 
-                case TextureFilter.MinLinearMagPointMipLinear:
-                    return SharpDX.Direct3D11.Filter.MinLinearMagPointMipLinear;
+                    case TextureFilter.MinLinearMagPointMipLinear:
+                        return SharpDX.Direct3D11.Filter.ComparisonMinLinearMagPointMipLinear;
 
-                case TextureFilter.MinLinearMagPointMipPoint:
-                    return SharpDX.Direct3D11.Filter.MinLinearMagMipPoint;
+                    case TextureFilter.MinLinearMagPointMipPoint:
+                        return SharpDX.Direct3D11.Filter.ComparisonMinLinearMagMipPoint;
 
-                case TextureFilter.MinPointMagLinearMipLinear:
-                    return SharpDX.Direct3D11.Filter.MinPointMagMipLinear;
+                    case TextureFilter.MinPointMagLinearMipLinear:
+                        return SharpDX.Direct3D11.Filter.ComparisonMinPointMagMipLinear;
 
-                case TextureFilter.MinPointMagLinearMipPoint:
-                    return SharpDX.Direct3D11.Filter.MinPointMagLinearMipPoint;
+                    case TextureFilter.MinPointMagLinearMipPoint:
+                        return SharpDX.Direct3D11.Filter.ComparisonMinPointMagLinearMipPoint;
 
-                case TextureFilter.Point:
-                    return SharpDX.Direct3D11.Filter.MinMagMipPoint;
+                    case TextureFilter.Point:
+                        return SharpDX.Direct3D11.Filter.ComparisonMinMagMipPoint;
 
-                case TextureFilter.PointMipLinear:
-                    return SharpDX.Direct3D11.Filter.MinMagPointMipLinear;
+                    case TextureFilter.PointMipLinear:
+                        return SharpDX.Direct3D11.Filter.ComparisonMinMagPointMipLinear;
 
-                default:
-                    throw new ArgumentException("Invalid texture filter!");
+                    default:
+                        throw new ArgumentException("Invalid texture filter!");
+                }
+            }
+            else
+            {
+                switch (filter)
+                {
+                    case TextureFilter.Anisotropic:
+                        return SharpDX.Direct3D11.Filter.Anisotropic;
+
+                    case TextureFilter.Linear:
+                        return SharpDX.Direct3D11.Filter.MinMagMipLinear;
+
+                    case TextureFilter.LinearMipPoint:
+                        return SharpDX.Direct3D11.Filter.MinMagLinearMipPoint;
+
+                    case TextureFilter.MinLinearMagPointMipLinear:
+                        return SharpDX.Direct3D11.Filter.MinLinearMagPointMipLinear;
+
+                    case TextureFilter.MinLinearMagPointMipPoint:
+                        return SharpDX.Direct3D11.Filter.MinLinearMagMipPoint;
+
+                    case TextureFilter.MinPointMagLinearMipLinear:
+                        return SharpDX.Direct3D11.Filter.MinPointMagMipLinear;
+
+                    case TextureFilter.MinPointMagLinearMipPoint:
+                        return SharpDX.Direct3D11.Filter.MinPointMagLinearMipPoint;
+
+                    case TextureFilter.Point:
+                        return SharpDX.Direct3D11.Filter.MinMagMipPoint;
+
+                    case TextureFilter.PointMipLinear:
+                        return SharpDX.Direct3D11.Filter.MinMagPointMipLinear;
+
+                    default:
+                        throw new ArgumentException("Invalid texture filter!");
+                }
             }
         }
 

--- a/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.OpenGL.cs
@@ -149,6 +149,19 @@ namespace Microsoft.Xna.Framework.Graphics
             // LOD bias is not supported by glTexParameter in OpenGL ES 2.0
             GL.TexParameter(target, TextureParameterName.TextureLodBias, MipMapLevelOfDetailBias);
             GraphicsExtensions.CheckGLError();
+            // Comparison samplers are not supported in OpenGL ES 2.0 (without an extension, anyway)
+            if (ComparisonFunction != CompareFunction.Never)
+            {
+                GL.TexParameter(target, TextureParameterName.TextureCompareMode, (int) TextureCompareMode.CompareRefToTexture);
+                GraphicsExtensions.CheckGLError();
+                GL.TexParameter(target, TextureParameterName.TextureCompareFunc, (int) ComparisonFunction.GetDepthFunction());
+                GraphicsExtensions.CheckGLError();
+            }
+            else
+            {
+                GL.TexParameter(target, TextureParameterName.TextureCompareMode, (int) TextureCompareMode.None);
+                GraphicsExtensions.CheckGLError();
+            }
 #endif
             if (GraphicsDevice.GraphicsCapabilities.SupportsTextureMaxLevel)
             {

--- a/MonoGame.Framework/Graphics/States/SamplerState.cs
+++ b/MonoGame.Framework/Graphics/States/SamplerState.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private int _maxAnisotropy;
         private int _maxMipLevel;
         private float _mipMapLevelOfDetailBias;
+        private CompareFunction _comparisonFunction;
 
         public TextureAddressMode AddressU
         {
@@ -105,6 +106,16 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        public CompareFunction ComparisonFunction
+        {
+            get { return _comparisonFunction; }
+            set
+            {
+                ThrowIfBound();
+                _comparisonFunction = value;
+            }
+        }
+
         internal void BindToGraphicsDevice(GraphicsDevice device)
         {
             if (_defaultStateObject)
@@ -131,6 +142,7 @@ namespace Microsoft.Xna.Framework.Graphics
             MaxAnisotropy = 4;
             MaxMipLevel = 0;
             MipMapLevelOfDetailBias = 0.0f;
+            ComparisonFunction = CompareFunction.Never;
         }
 
         private SamplerState(string name, TextureFilter filter, TextureAddressMode addressMode)
@@ -154,6 +166,7 @@ namespace Microsoft.Xna.Framework.Graphics
             _maxAnisotropy = cloneSource._maxAnisotropy;
             _maxMipLevel = cloneSource._maxMipLevel;
             _mipMapLevelOfDetailBias = cloneSource._mipMapLevelOfDetailBias;
+            _comparisonFunction = cloneSource._comparisonFunction;
         }
 
         internal SamplerState Clone()

--- a/MonoGame.Framework/Windows8/SharpDXHelper.cs
+++ b/MonoGame.Framework/Windows8/SharpDXHelper.cs
@@ -1,6 +1,10 @@
-﻿
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
 namespace Microsoft.Xna.Framework
 {
+    using System;
     using Microsoft.Xna.Framework.Graphics;
 
     static internal class SharpDXHelper
@@ -195,6 +199,39 @@ namespace Microsoft.Xna.Framework
                 OrientFront = new SharpDX.Vector3(forward.X, forward.Y, forward.Z),
                 OrientTop = new SharpDX.Vector3(up.X, up.Y, up.Z),                
             };
+        }
+
+        static public SharpDX.Direct3D11.Comparison ToComparison(this CompareFunction compare)
+        {
+            switch (compare)
+            {
+                case CompareFunction.Always:
+                    return SharpDX.Direct3D11.Comparison.Always;
+
+                case CompareFunction.Equal:
+                    return SharpDX.Direct3D11.Comparison.Equal;
+
+                case CompareFunction.Greater:
+                    return SharpDX.Direct3D11.Comparison.Greater;
+
+                case CompareFunction.GreaterEqual:
+                    return SharpDX.Direct3D11.Comparison.GreaterEqual;
+
+                case CompareFunction.Less:
+                    return SharpDX.Direct3D11.Comparison.Less;
+
+                case CompareFunction.LessEqual:
+                    return SharpDX.Direct3D11.Comparison.LessEqual;
+
+                case CompareFunction.Never:
+                    return SharpDX.Direct3D11.Comparison.Never;
+
+                case CompareFunction.NotEqual:
+                    return SharpDX.Direct3D11.Comparison.NotEqual;
+
+                default:
+                    throw new ArgumentException("Invalid comparison!");
+            }
         }
     }
 }

--- a/Test/Framework/Visual/SamplerStateTest.cs
+++ b/Test/Framework/Visual/SamplerStateTest.cs
@@ -66,6 +66,7 @@ namespace MonoGame.Tests.Visual
             assertMethod(() => samplerState.MaxAnisotropy = 0);
             assertMethod(() => samplerState.MaxMipLevel = 0);
             assertMethod(() => samplerState.MipMapLevelOfDetailBias = 0);
+            assertMethod(() => samplerState.ComparisonFunction = CompareFunction.Always);
         }
     }
 }


### PR DESCRIPTION
Adds `SamplerState.ComparisonFunction`, and hooks it up for Direct3D and OpenGL.

I wasn't sure whether to call the new property `ComparisonFunction` or `CompareFunction` - I decided to go with the former, because that's how both Direct3D and OpenGL refer to it, even if it doesn't match the XNA / MG enum name.

Replaces #2088 (I'd have liked to cherry-pick those commits, but it was easier just to start from scratch).

This seems like a good use-case for `GraphicsProfile` - comparison samplers aren't supported by OpenGL ES 2.0 (without an extension), nor, I believe, Direct3D 11 feature level 9.x. We could throw an runtime exception if you try to use a comparison sampler. But I guess that is for the future - MG doesn't really use graphics profiles much yet, and whether it should or not is a whole separate discussion.

(This will conflict with my other PR, #3626 - I'll just do a rebase on whichever one isn't merged first.)