### PR TITLE
Pipeline now accepts uppercase extensions

### DIFF
--- a/Tools/Pipeline/Common/PipelineTypes.cs
+++ b/Tools/Pipeline/Common/PipelineTypes.cs
@@ -355,9 +355,10 @@ namespace MonoGame.Tools.Pipeline
                 return null;
             }
 
+            var lowerFileExt = fileExtension.ToLowerInvariant();
             foreach (var i in Importers)
             {
-                if (i.FileExtensions.Contains(fileExtension.ToLowerInvariant()))
+                if (i.FileExtensions.Any(e => e.ToLowerInvariant() == lowerFileExt))
                     return i;
             }
 

--- a/Tools/Pipeline/Common/PipelineTypes.cs
+++ b/Tools/Pipeline/Common/PipelineTypes.cs
@@ -357,7 +357,7 @@ namespace MonoGame.Tools.Pipeline
 
             foreach (var i in Importers)
             {
-                if (i.FileExtensions.Contains(fileExtension))
+                if (i.FileExtensions.Contains(fileExtension.ToLowerInvariant()))
                     return i;
             }
 


### PR DESCRIPTION
Uppercase extensions foiled the importer auto-detect. File extension is now lower-cased for the detection process.