### PR TITLE
Loop length in XNB now matches XNA

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
@@ -281,6 +281,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
                     channelCount,
                     format,
                     sampleRate);
+
+                // Loop start and length in number of samples. Defaults to entire sound
+                loopStart = 0;
+                loopLength = data.Count / ((bitsPerSample / 8) * channelCount);
             }
             finally
             {

--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -154,11 +154,6 @@ namespace Microsoft.Xna.Framework.Audio
             _format = format;
             _dataStream = dataStream;
 
-            // Convert the loop points from bytes to samples.
-            var bytesPerSample = 2 * _format.Channels;
-            loopStart /= bytesPerSample;
-            loopLength /= bytesPerSample;
-
             _buffer = new AudioBuffer
             {
                 Stream = _dataStream,


### PR DESCRIPTION
The XNB File Format document specifies the loop start and loop length are in bytes, but they are in samples.
Loop start and length are now populated in AudioContent when loading the sample data.
The loop start and loop length are no longer treated as bytes in XAudio playback.
XNA and MonoGame generated XNB files are now only different by one bit (1ms in duration).

Fixes #3507