### PR TITLE
AAC streams should have m4a extension

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Audio/AudioHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/AudioHelper.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
     class AudioHelper
     {
         // This array must remain in sync with the ConversionFormat enum.
-        static string[] conversionFormatExtensions = new[] { "wav", "wav", "wma", "xma", "wav", "mp4", "ogg" };
+        static string[] conversionFormatExtensions = new[] { "wav", "wav", "wma", "xma", "wav", "m4a", "ogg" };
 
         /// <summary>
         /// Gets the file extension for an audio format.


### PR DESCRIPTION
mp4 is the container format and is usually used for files containing video. m4a is used for files containing audio only.