### PR TITLE
Bunch of small improvements and fixes for Gtk Pipeline

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
@@ -284,7 +284,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
 
                 // Loop start and length in number of samples. Defaults to entire sound
                 loopStart = 0;
-                loopLength = data.Count / ((bitsPerSample / 8) * channelCount);
+
+                //this line of code breaks audio compilation and therefor it has been commented
+                //2 things that this line of code does wrong are:
+                //1) data can be null, set by line 222
+                //2) bitsPerSample can be 0 ???
+                //loopLength = data.Count / ((bitsPerSample / 8) * channelCount);
             }
             finally
             {

--- a/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
@@ -284,12 +284,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
 
                 // Loop start and length in number of samples. Defaults to entire sound
                 loopStart = 0;
-
-                //this line of code breaks audio compilation and therefor it has been commented
-                //2 things that this line of code does wrong are:
-                //1) data can be null, set by line 222
-                //2) bitsPerSample can be 0 ???
-                //loopLength = data.Count / ((bitsPerSample / 8) * channelCount);
+                loopLength = data.Count / ((bitsPerSample / 8) * channelCount);
             }
             finally
             {

--- a/Tools/Pipeline/Gtk/Dialogs/TextEditorDialog.cs
+++ b/Tools/Pipeline/Gtk/Dialogs/TextEditorDialog.cs
@@ -5,11 +5,16 @@ namespace MonoGame.Tools.Pipeline
 {
     public partial class TextEditorDialog : Dialog
     {
+        bool strictmode;
+
         public string text;
 
-        public TextEditorDialog(string title, string label, string text)
+        public TextEditorDialog(string title, string label, string text, bool strictmode)
         {
             Build();
+
+            this.strictmode = strictmode;
+            buttonOk.Sensitive = !strictmode;
 
             Title = title;
             label2.Text = label;
@@ -19,6 +24,30 @@ namespace MonoGame.Tools.Pipeline
         protected void OnResponse(object sender, EventArgs e)
         {
             Destroy ();
+        }
+
+        public void ButtonOkEnabled()
+        {
+            if (!strictmode)
+                return;
+
+            if (entry1.Text != "") {
+                if (MainWindow.CheckString (entry1.Text, MainWindow.AllowedCharacters)) {
+                    buttonOk.Sensitive = true;
+                    label3.Visible = false;
+                } else {
+                    buttonOk.Sensitive = false;
+                    label3.Visible = true;
+                }
+            } else {
+                buttonOk.Sensitive = false;
+                label3.Visible = false;
+            }
+        }
+
+        protected void OnEntry1Changed(object sender, EventArgs e)
+        {
+            ButtonOkEnabled();
         }
 
         protected void OnButtonOkClicked(object sender, EventArgs e)

--- a/Tools/Pipeline/gtk-gui/MonoGame.Tools.Pipeline.MainWindow.cs
+++ b/Tools/Pipeline/gtk-gui/MonoGame.Tools.Pipeline.MainWindow.cs
@@ -30,10 +30,6 @@ namespace MonoGame.Tools.Pipeline
 		
 		private global::Gtk.Action RedoAction;
 		
-		private global::Gtk.Action NewItemAction;
-		
-		private global::Gtk.Action AddItemAction;
-		
 		private global::Gtk.Action DeleteAction;
 		
 		private global::Gtk.Action BuildAction;
@@ -54,9 +50,15 @@ namespace MonoGame.Tools.Pipeline
 		
 		private global::Gtk.Action CancelBuildAction;
 		
-		private global::Gtk.Action AddFolderAction;
+		private global::Gtk.Action AddAction;
+		
+		private global::Gtk.Action NewItemAction;
 		
 		private global::Gtk.Action NewFolderAction;
+		
+		private global::Gtk.Action ExistingItemAction;
+		
+		private global::Gtk.Action ExistingFolderAction;
 		
 		private global::Gtk.VBox vbox2;
 		
@@ -117,12 +119,6 @@ namespace MonoGame.Tools.Pipeline
 			this.RedoAction = new global::Gtk.Action ("RedoAction", global::Mono.Unix.Catalog.GetString ("Redo"), null, null);
 			this.RedoAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Redo");
 			w1.Add (this.RedoAction, "<Control>y");
-			this.NewItemAction = new global::Gtk.Action ("NewItemAction", global::Mono.Unix.Catalog.GetString ("New Item..."), null, null);
-			this.NewItemAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("New Item...");
-			w1.Add (this.NewItemAction, null);
-			this.AddItemAction = new global::Gtk.Action ("AddItemAction", global::Mono.Unix.Catalog.GetString ("Add Item..."), null, null);
-			this.AddItemAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Add Item...");
-			w1.Add (this.AddItemAction, null);
 			this.DeleteAction = new global::Gtk.Action ("DeleteAction", global::Mono.Unix.Catalog.GetString ("Delete"), null, null);
 			this.DeleteAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Delete");
 			w1.Add (this.DeleteAction, null);
@@ -153,12 +149,21 @@ namespace MonoGame.Tools.Pipeline
 			this.CancelBuildAction = new global::Gtk.Action ("CancelBuildAction", global::Mono.Unix.Catalog.GetString ("Cancel Build"), null, null);
 			this.CancelBuildAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Cancel Build");
 			w1.Add (this.CancelBuildAction, null);
-			this.AddFolderAction = new global::Gtk.Action ("AddFolderAction", global::Mono.Unix.Catalog.GetString ("Add Folder..."), null, null);
-			this.AddFolderAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Add Folder...");
-			w1.Add (this.AddFolderAction, null);
+			this.AddAction = new global::Gtk.Action ("AddAction", global::Mono.Unix.Catalog.GetString ("Add"), null, null);
+			this.AddAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Add");
+			w1.Add (this.AddAction, null);
+			this.NewItemAction = new global::Gtk.Action ("NewItemAction", global::Mono.Unix.Catalog.GetString ("New Item..."), null, null);
+			this.NewItemAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("New Item...");
+			w1.Add (this.NewItemAction, null);
 			this.NewFolderAction = new global::Gtk.Action ("NewFolderAction", global::Mono.Unix.Catalog.GetString ("New Folder..."), null, null);
 			this.NewFolderAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("New Folder...");
 			w1.Add (this.NewFolderAction, null);
+			this.ExistingItemAction = new global::Gtk.Action ("ExistingItemAction", global::Mono.Unix.Catalog.GetString ("Existing Item..."), null, null);
+			this.ExistingItemAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Add Existing Item...");
+			w1.Add (this.ExistingItemAction, null);
+			this.ExistingFolderAction = new global::Gtk.Action ("ExistingFolderAction", global::Mono.Unix.Catalog.GetString ("Existing Folder..."), null, null);
+			this.ExistingFolderAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Add Existing Folder...");
+			w1.Add (this.ExistingFolderAction, null);
 			this.UIManager.InsertActionGroup (w1, 0);
 			this.AddAccelGroup (this.UIManager.AccelGroup);
 			this.Name = "MonoGame.Tools.Pipeline.MainWindow";
@@ -169,7 +174,7 @@ namespace MonoGame.Tools.Pipeline
 			this.vbox2 = new global::Gtk.VBox ();
 			this.vbox2.Name = "vbox2";
 			// Container child vbox2.Gtk.Box+BoxChild
-			this.UIManager.AddUiFromString ("<ui><menubar name='menubar1'><menu name='FileAction' action='FileAction'><menuitem name='NewAction' action='NewAction'/><menuitem name='OpenAction' action='OpenAction'/><menuitem name='OpenRecentAction' action='OpenRecentAction'/><menuitem name='CloseAction' action='CloseAction'/><separator/><menuitem name='ImportAction' action='ImportAction'/><separator/><menuitem name='SaveAction' action='SaveAction'/><menuitem name='SaveAsAction' action='SaveAsAction'/><separator/><menuitem name='ExitAction' action='ExitAction'/></menu><menu name='EditAction' action='EditAction'><menuitem name='UndoAction' action='UndoAction'/><menuitem name='RedoAction' action='RedoAction'/><separator/><menuitem name='NewItemAction' action='NewItemAction'/><menuitem name='AddItemAction' action='AddItemAction'/><menuitem name='NewFolderAction' action='NewFolderAction'/><menuitem name='AddFolderAction' action='AddFolderAction'/><separator/><menuitem name='DeleteAction' action='DeleteAction'/></menu><menu name='BuildAction' action='BuildAction'><menuitem name='BuildAction1' action='BuildAction1'/><menuitem name='RebuildAction' action='RebuildAction'/><menuitem name='CleanAction' action='CleanAction'/><menuitem name='CancelBuildAction' action='CancelBuildAction'/></menu><menu name='HelpAction' action='HelpAction'><menuitem name='ViewHelpAction' action='ViewHelpAction'/><separator/><menuitem name='AboutAction' action='AboutAction'/></menu></menubar></ui>");
+			this.UIManager.AddUiFromString ("<ui><menubar name='menubar1'><menu name='FileAction' action='FileAction'><menuitem name='NewAction' action='NewAction'/><menuitem name='OpenAction' action='OpenAction'/><menuitem name='OpenRecentAction' action='OpenRecentAction'/><menuitem name='CloseAction' action='CloseAction'/><separator/><menuitem name='ImportAction' action='ImportAction'/><separator/><menuitem name='SaveAction' action='SaveAction'/><menuitem name='SaveAsAction' action='SaveAsAction'/><separator/><menuitem name='ExitAction' action='ExitAction'/></menu><menu name='EditAction' action='EditAction'><menuitem name='UndoAction' action='UndoAction'/><menuitem name='RedoAction' action='RedoAction'/><separator/><menu name='AddAction' action='AddAction'><menuitem name='NewItemAction' action='NewItemAction'/><menuitem name='NewFolderAction' action='NewFolderAction'/><separator/><menuitem name='ExistingItemAction' action='ExistingItemAction'/><menuitem name='ExistingFolderAction' action='ExistingFolderAction'/></menu><separator/><menuitem name='DeleteAction' action='DeleteAction'/></menu><menu name='BuildAction' action='BuildAction'><menuitem name='BuildAction1' action='BuildAction1'/><menuitem name='RebuildAction' action='RebuildAction'/><menuitem name='CleanAction' action='CleanAction'/><menuitem name='CancelBuildAction' action='CancelBuildAction'/></menu><menu name='HelpAction' action='HelpAction'><menuitem name='ViewHelpAction' action='ViewHelpAction'/><separator/><menuitem name='AboutAction' action='AboutAction'/></menu></menubar></ui>");
 			this.menubar1 = ((global::Gtk.MenuBar)(this.UIManager.GetWidget ("/menubar1")));
 			this.menubar1.Name = "menubar1";
 			this.vbox2.Add (this.menubar1);
@@ -226,7 +231,6 @@ namespace MonoGame.Tools.Pipeline
 			this.DefaultHeight = 557;
 			this.Show ();
 			this.DeleteEvent += new global::Gtk.DeleteEventHandler (this.OnDeleteEvent);
-			this.FileAction.Activated += new global::System.EventHandler (this.OnFileActionActivated);
 			this.NewAction.Activated += new global::System.EventHandler (this.OnNewActionActivated);
 			this.OpenAction.Activated += new global::System.EventHandler (this.OnOpenActionActivated);
 			this.CloseAction.Activated += new global::System.EventHandler (this.OnCloseActionActivated);
@@ -236,17 +240,16 @@ namespace MonoGame.Tools.Pipeline
 			this.ExitAction.Activated += new global::System.EventHandler (this.OnExitActionActivated);
 			this.UndoAction.Activated += new global::System.EventHandler (this.OnUndoActionActivated);
 			this.RedoAction.Activated += new global::System.EventHandler (this.OnRedoActionActivated);
-			this.NewItemAction.Activated += new global::System.EventHandler (this.OnNewItemActionActivated);
-			this.AddItemAction.Activated += new global::System.EventHandler (this.OnAddItemActionActivated);
 			this.DeleteAction.Activated += new global::System.EventHandler (this.OnDeleteActionActivated);
-			this.BuildAction.Activated += new global::System.EventHandler (this.OnBuildActionActivated);
 			this.BuildAction1.Activated += new global::System.EventHandler (this.OnBuildAction1Activated);
 			this.RebuildAction.Activated += new global::System.EventHandler (this.OnRebuildActionActivated);
 			this.CleanAction.Activated += new global::System.EventHandler (this.OnCleanActionActivated);
 			this.ViewHelpAction.Activated += new global::System.EventHandler (this.OnViewHelpActionActivated);
 			this.AboutAction.Activated += new global::System.EventHandler (this.OnAboutActionActivated);
-			this.AddFolderAction.Activated += new global::System.EventHandler (this.OnAddFolderActionActivated);
+			this.NewItemAction.Activated += new global::System.EventHandler (this.OnNewItemActionActivated);
 			this.NewFolderAction.Activated += new global::System.EventHandler (this.OnNewFolderActionActivated);
+			this.ExistingItemAction.Activated += new global::System.EventHandler (this.OnAddItemActionActivated);
+			this.ExistingFolderAction.Activated += new global::System.EventHandler (this.OnAddFolderActionActivated);
 		}
 	}
 }

--- a/Tools/Pipeline/gtk-gui/MonoGame.Tools.Pipeline.TextEditorDialog.cs
+++ b/Tools/Pipeline/gtk-gui/MonoGame.Tools.Pipeline.TextEditorDialog.cs
@@ -8,6 +8,8 @@ namespace MonoGame.Tools.Pipeline
 		
 		private global::Gtk.Entry entry1;
 		
+		private global::Gtk.Label label3;
+		
 		private global::Gtk.Button buttonCancel;
 		
 		private global::Gtk.Button buttonOk;
@@ -32,8 +34,6 @@ namespace MonoGame.Tools.Pipeline
 			w1.Add (this.label2);
 			global::Gtk.Box.BoxChild w2 = ((global::Gtk.Box.BoxChild)(w1 [this.label2]));
 			w2.Position = 0;
-			w2.Expand = false;
-			w2.Fill = false;
 			// Container child dialog1_VBox.Gtk.Box+BoxChild
 			this.entry1 = new global::Gtk.Entry ();
 			this.entry1.CanFocus = true;
@@ -43,14 +43,22 @@ namespace MonoGame.Tools.Pipeline
 			w1.Add (this.entry1);
 			global::Gtk.Box.BoxChild w3 = ((global::Gtk.Box.BoxChild)(w1 [this.entry1]));
 			w3.Position = 1;
-			w3.Expand = false;
-			w3.Fill = false;
+			// Container child dialog1_VBox.Gtk.Box+BoxChild
+			this.label3 = new global::Gtk.Label ();
+			this.label3.HeightRequest = 0;
+			this.label3.Name = "label3";
+			this.label3.LabelProp = global::Mono.Unix.Catalog.GetString ("Only Letters, numbers, space and \"_\" are allowed.");
+			w1.Add (this.label3);
+			global::Gtk.Box.BoxChild w4 = ((global::Gtk.Box.BoxChild)(w1 [this.label3]));
+			w4.Position = 2;
+			w4.Expand = false;
+			w4.Fill = false;
 			// Internal child MonoGame.Tools.Pipeline.TextEditorDialog.ActionArea
-			global::Gtk.HButtonBox w4 = this.ActionArea;
-			w4.Name = "dialog1_ActionArea";
-			w4.Spacing = 10;
-			w4.BorderWidth = ((uint)(5));
-			w4.LayoutStyle = ((global::Gtk.ButtonBoxStyle)(4));
+			global::Gtk.HButtonBox w5 = this.ActionArea;
+			w5.Name = "dialog1_ActionArea";
+			w5.Spacing = 10;
+			w5.BorderWidth = ((uint)(5));
+			w5.LayoutStyle = ((global::Gtk.ButtonBoxStyle)(4));
 			// Container child dialog1_ActionArea.Gtk.ButtonBox+ButtonBoxChild
 			this.buttonCancel = new global::Gtk.Button ();
 			this.buttonCancel.CanDefault = true;
@@ -60,29 +68,32 @@ namespace MonoGame.Tools.Pipeline
 			this.buttonCancel.UseUnderline = true;
 			this.buttonCancel.Label = "gtk-cancel";
 			this.AddActionWidget (this.buttonCancel, -6);
-			global::Gtk.ButtonBox.ButtonBoxChild w5 = ((global::Gtk.ButtonBox.ButtonBoxChild)(w4 [this.buttonCancel]));
-			w5.Expand = false;
-			w5.Fill = false;
+			global::Gtk.ButtonBox.ButtonBoxChild w6 = ((global::Gtk.ButtonBox.ButtonBoxChild)(w5 [this.buttonCancel]));
+			w6.Expand = false;
+			w6.Fill = false;
 			// Container child dialog1_ActionArea.Gtk.ButtonBox+ButtonBoxChild
 			this.buttonOk = new global::Gtk.Button ();
+			this.buttonOk.Sensitive = false;
 			this.buttonOk.CanDefault = true;
 			this.buttonOk.CanFocus = true;
 			this.buttonOk.Name = "buttonOk";
 			this.buttonOk.UseStock = true;
 			this.buttonOk.UseUnderline = true;
 			this.buttonOk.Label = "gtk-ok";
-			w4.Add (this.buttonOk);
-			global::Gtk.ButtonBox.ButtonBoxChild w6 = ((global::Gtk.ButtonBox.ButtonBoxChild)(w4 [this.buttonOk]));
-			w6.Position = 1;
-			w6.Expand = false;
-			w6.Fill = false;
+			w5.Add (this.buttonOk);
+			global::Gtk.ButtonBox.ButtonBoxChild w7 = ((global::Gtk.ButtonBox.ButtonBoxChild)(w5 [this.buttonOk]));
+			w7.Position = 1;
+			w7.Expand = false;
+			w7.Fill = false;
 			if ((this.Child != null)) {
 				this.Child.ShowAll ();
 			}
 			this.DefaultWidth = 367;
-			this.DefaultHeight = 118;
+			this.DefaultHeight = 143;
+			this.label3.Hide ();
 			this.Show ();
 			this.Response += new global::Gtk.ResponseHandler (this.OnResponse);
+			this.entry1.Changed += new global::System.EventHandler (this.OnEntry1Changed);
 			this.buttonOk.Clicked += new global::System.EventHandler (this.OnButtonOkClicked);
 		}
 	}

--- a/Tools/Pipeline/gtk-gui/gui.stetic
+++ b/Tools/Pipeline/gtk-gui/gui.stetic
@@ -175,7 +175,7 @@
     </action-group>
     <property name="MemberName" />
     <property name="GeneratePublic">False</property>
-    <property name="Title" translatable="yes">Monogame Pipeline</property>
+    <property name="Title" translatable="yes">MonoGame Pipeline</property>
     <property name="Icon">resource:MonoGame.Tools.Pipeline.App.ico</property>
     <property name="WindowPosition">CenterOnParent</property>
     <signal name="DeleteEvent" handler="OnDeleteEvent" />

--- a/Tools/Pipeline/gtk-gui/gui.stetic
+++ b/Tools/Pipeline/gtk-gui/gui.stetic
@@ -14,7 +14,6 @@
         <property name="Type">Action</property>
         <property name="Label" translatable="yes">File</property>
         <property name="ShortLabel" translatable="yes">File</property>
-        <signal name="Activated" handler="OnFileActionActivated" />
       </action>
       <action id="NewAction">
         <property name="Type">Action</property>
@@ -86,18 +85,6 @@
         <property name="ShortLabel" translatable="yes">Redo</property>
         <signal name="Activated" handler="OnRedoActionActivated" />
       </action>
-      <action id="NewItemAction">
-        <property name="Type">Action</property>
-        <property name="Label" translatable="yes">New Item...</property>
-        <property name="ShortLabel" translatable="yes">New Item...</property>
-        <signal name="Activated" handler="OnNewItemActionActivated" />
-      </action>
-      <action id="AddItemAction">
-        <property name="Type">Action</property>
-        <property name="Label" translatable="yes">Add Item...</property>
-        <property name="ShortLabel" translatable="yes">Add Item...</property>
-        <signal name="Activated" handler="OnAddItemActionActivated" />
-      </action>
       <action id="DeleteAction">
         <property name="Type">Action</property>
         <property name="Label" translatable="yes">Delete</property>
@@ -108,7 +95,6 @@
         <property name="Type">Action</property>
         <property name="Label" translatable="yes">Build</property>
         <property name="ShortLabel" translatable="yes">Build</property>
-        <signal name="Activated" handler="OnBuildActionActivated" />
       </action>
       <action id="BuildAction1">
         <property name="Type">Action</property>
@@ -157,17 +143,34 @@
         <property name="Label" translatable="yes">Cancel Build</property>
         <property name="ShortLabel" translatable="yes">Cancel Build</property>
       </action>
-      <action id="AddFolderAction">
+      <action id="AddAction">
         <property name="Type">Action</property>
-        <property name="Label" translatable="yes">Add Folder...</property>
-        <property name="ShortLabel" translatable="yes">Add Folder...</property>
-        <signal name="Activated" handler="OnAddFolderActionActivated" />
+        <property name="Label" translatable="yes">Add</property>
+        <property name="ShortLabel" translatable="yes">Add</property>
+      </action>
+      <action id="NewItemAction">
+        <property name="Type">Action</property>
+        <property name="Label" translatable="yes">New Item...</property>
+        <property name="ShortLabel" translatable="yes">New Item...</property>
+        <signal name="Activated" handler="OnNewItemActionActivated" />
       </action>
       <action id="NewFolderAction">
         <property name="Type">Action</property>
         <property name="Label" translatable="yes">New Folder...</property>
         <property name="ShortLabel" translatable="yes">New Folder...</property>
         <signal name="Activated" handler="OnNewFolderActionActivated" />
+      </action>
+      <action id="ExistingItemAction">
+        <property name="Type">Action</property>
+        <property name="Label" translatable="yes">Existing Item...</property>
+        <property name="ShortLabel" translatable="yes">Add Existing Item...</property>
+        <signal name="Activated" handler="OnAddItemActionActivated" />
+      </action>
+      <action id="ExistingFolderAction">
+        <property name="Type">Action</property>
+        <property name="Label" translatable="yes">Existing Folder...</property>
+        <property name="ShortLabel" translatable="yes">Add Existing Folder...</property>
+        <signal name="Activated" handler="OnAddFolderActionActivated" />
       </action>
     </action-group>
     <property name="MemberName" />
@@ -200,10 +203,13 @@
                 <node type="Menuitem" action="UndoAction" />
                 <node type="Menuitem" action="RedoAction" />
                 <node type="Separator" />
-                <node type="Menuitem" action="NewItemAction" />
-                <node type="Menuitem" action="AddItemAction" />
-                <node type="Menuitem" action="NewFolderAction" />
-                <node type="Menuitem" action="AddFolderAction" />
+                <node type="Menu" action="AddAction">
+                  <node type="Menuitem" action="NewItemAction" />
+                  <node type="Menuitem" action="NewFolderAction" />
+                  <node type="Separator" />
+                  <node type="Menuitem" action="ExistingItemAction" />
+                  <node type="Menuitem" action="ExistingFolderAction" />
+                </node>
                 <node type="Separator" />
                 <node type="Menuitem" action="DeleteAction" />
               </node>
@@ -973,6 +979,7 @@
             <property name="MemberName" />
             <property name="CanFocus">True</property>
             <property name="Label" translatable="yes">Copy the file to the directory</property>
+            <property name="Active">True</property>
             <property name="DrawIndicator">True</property>
             <property name="HasLabel">True</property>
             <property name="UseUnderline">True</property>
@@ -1213,7 +1220,7 @@
       </widget>
     </child>
   </widget>
-  <widget class="Gtk.Dialog" id="MonoGame.Tools.Pipeline.TextEditorDialog" design-size="367 118">
+  <widget class="Gtk.Dialog" id="MonoGame.Tools.Pipeline.TextEditorDialog" design-size="367 143">
     <property name="MemberName" />
     <property name="WindowPosition">CenterOnParent</property>
     <property name="BorderWidth">4</property>
@@ -1233,9 +1240,7 @@
           </widget>
           <packing>
             <property name="Position">0</property>
-            <property name="AutoSize">True</property>
-            <property name="Expand">False</property>
-            <property name="Fill">False</property>
+            <property name="AutoSize">False</property>
           </packing>
         </child>
         <child>
@@ -1244,9 +1249,22 @@
             <property name="CanFocus">True</property>
             <property name="IsEditable">True</property>
             <property name="InvisibleChar">●</property>
+            <signal name="Changed" handler="OnEntry1Changed" />
           </widget>
           <packing>
             <property name="Position">1</property>
+            <property name="AutoSize">False</property>
+          </packing>
+        </child>
+        <child>
+          <widget class="Gtk.Label" id="label3">
+            <property name="MemberName" />
+            <property name="HeightRequest">0</property>
+            <property name="Visible">False</property>
+            <property name="LabelProp" translatable="yes">Only Letters, numbers, space and "_" are allowed.</property>
+          </widget>
+          <packing>
+            <property name="Position">2</property>
             <property name="AutoSize">True</property>
             <property name="Expand">False</property>
             <property name="Fill">False</property>
@@ -1280,6 +1298,7 @@
         <child>
           <widget class="Gtk.Button" id="buttonOk">
             <property name="MemberName" />
+            <property name="Sensitive">False</property>
             <property name="CanDefault">True</property>
             <property name="CanFocus">True</property>
             <property name="UseStock">True</property>


### PR DESCRIPTION
Things done:
<ul>
<li>Changed "Monogame Pipeline" to "MonoGame Pipeline"</li>
<li>Fixed a bug where the Pipeline had a small chance of crashing upon calling buid/rebuild/clean</li>
<li>Output TextView now autoscrolls during compilation</li>
<li>Double clicking item in treeview now opens the default application for that item</li>
<li>Text dialog now checks entered characters to make sure they are characters than can be used for creating a directory</li>
<li>Some terminology improvements (#3292):</li>
</ul>
![file](https://cloud.githubusercontent.com/assets/6773302/6760539/df65891e-cf49-11e4-9656-57caaa35a00c.png)
![folder](https://cloud.githubusercontent.com/assets/6773302/6760540/df7edea0-cf49-11e4-90ca-e70851f8b437.png)
![main](https://cloud.githubusercontent.com/assets/6773302/6760541/df7f33a0-cf49-11e4-9971-1b0b390798d3.png)

PS. Next PR I will submit will bring WinForms Pipeline up to date