### PR TITLE
Don't calculate loopLength if a null or zero

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
@@ -284,7 +284,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
 
                 // Loop start and length in number of samples. Defaults to entire sound
                 loopStart = 0;
-                loopLength = data.Count / ((bitsPerSample / 8) * channelCount);
+                if (data != null && bitsPerSample > 0 && channelCount > 0)
+                    loopLength = data.Count / ((bitsPerSample / 8) * channelCount);
+                else
+                    loopLength = 0;
             }
             finally
             {


### PR DESCRIPTION
is in any member used to calculate it.  Audio compilation does need a revision based on what I found.

Fixes #3663, #3644