### PR TITLE
Gtk Pipeline Tool, Fixed context menu and retitled the tool to MonoGame Pipeline

### DIFF
--- a/Tools/Pipeline/Gtk/Widgets/ProjectView.cs
+++ b/Tools/Pipeline/Gtk/Widgets/ProjectView.cs
@@ -24,7 +24,6 @@ namespace MonoGame.Tools.Pipeline
         PropertiesView propertiesView;
 
         MenuItem treeadd, treeaddseperator, treenewitem, treeadditem, treenewfolder, treeaddfolder, treeopenfile, treedelete, treeopenfilelocation;
-        SeparatorMenuItem seperator, seperator2;
 
         public ProjectView ()
         {
@@ -72,16 +71,16 @@ namespace MonoGame.Tools.Pipeline
             treeaddseperator = new SeparatorMenuItem ();
 
             treenewitem = new MenuItem ("New Item...");
-            treenewitem.Activated += window.OnNewItemActionActivated;
+            treenewitem.ButtonPressEvent += window.OnNewItemActionActivated;
 
             treenewfolder = new MenuItem ("New Folder...");
-            treenewfolder.Activated += window.OnNewFolderActionActivated;
+            treenewfolder.ButtonPressEvent += window.OnNewFolderActionActivated;
 
             treeadditem = new MenuItem ("Existing Item...");
-            treeadditem.Activated += window.OnAddItemActionActivated;
+            treeadditem.ButtonPressEvent += window.OnAddItemActionActivated;
 
             treeaddfolder = new MenuItem ("Existing Folder...");
-            treeaddfolder.Activated += window.OnAddFolderActionActivated;
+            treeaddfolder.ButtonPressEvent += window.OnAddFolderActionActivated;
 
             treedelete = new MenuItem ("Delete");
             treedelete.Activated += window.OnDeleteActionActivated;
@@ -120,7 +119,6 @@ namespace MonoGame.Tools.Pipeline
             addmenu.Add (treeaddfolder);
 
             menu.Add (treeopenfile);
-            menu.Add (new SeparatorMenuItem ());
             menu.Add (treeadd);
             menu.Add (treeaddseperator);
             menu.Add (treeopenfilelocation);
@@ -482,7 +480,7 @@ namespace MonoGame.Tools.Pipeline
                         treeadd.Visible = false;
                         treeopenfile.Visible = true;
                     }
-                    treeaddseperator.Visible = treeadd.Visible;
+                    treeaddseperator.Visible = treeadd.Visible || treeopenfile.Visible;
 
                     menu.Popup ();
                 }
@@ -492,7 +490,7 @@ namespace MonoGame.Tools.Pipeline
                 treenewitem.Visible = false;
                 treeadditem.Visible = false;
                 treeopenfile.Visible = false;
-                seperator.Visible = false;
+                treeaddseperator.Visible = false;
                 treeopenfile.Visible = false;
                 treeopenfilelocation.Visible = false;
 

--- a/Tools/Pipeline/gtk-gui/MonoGame.Tools.Pipeline.MainWindow.cs
+++ b/Tools/Pipeline/gtk-gui/MonoGame.Tools.Pipeline.MainWindow.cs
@@ -167,7 +167,7 @@ namespace MonoGame.Tools.Pipeline
 			this.UIManager.InsertActionGroup (w1, 0);
 			this.AddAccelGroup (this.UIManager.AccelGroup);
 			this.Name = "MonoGame.Tools.Pipeline.MainWindow";
-			this.Title = global::Mono.Unix.Catalog.GetString ("Monogame Pipeline");
+			this.Title = global::Mono.Unix.Catalog.GetString ("MonoGame Pipeline");
 			this.Icon = global::Gdk.Pixbuf.LoadFromResource ("MonoGame.Tools.Pipeline.App.ico");
 			this.WindowPosition = ((global::Gtk.WindowPosition)(4));
 			// Container child MonoGame.Tools.Pipeline.MainWindow.Gtk.Container+ContainerChild


### PR DESCRIPTION
Notes:
<ul>
<li>In #3645 I changed the title of the tool using monodevelop's gui editor which actually only changed it in gui.stetic instead of MonoGame.Tools.Pipeline.MainWindow.cs</li>
<li>Context menu submenus were broken because of the Gtk bug (<a href="http://stackoverflow.com/questions/5221326/submenu-item-does-not-call-function-with-working-solution">stackoverflow link</a>) so I fixed that up</li>
<li>Fixed context menu separator positions</li>
</ul>