### PR TITLE
Installer fix for templates on Windows

### DIFF
--- a/Installers/Windows/MonoGame.nsi
+++ b/Installers/Windows/MonoGame.nsi
@@ -338,14 +338,13 @@ IfFileExists `$DOCUMENTS\Visual Studio 2013\Templates\ProjectTemplates\Visual C#
   end:
 FunctionEnd
 
-Function .onInit
-
+Function .onInit 
   IntOp $0 $0 | ${SF_RO}
-  SectionSetFlags ${core_id} $0
-  
   Call checkVS2010
   Call checkVS2012
   Call checkVS2013
+  IntOp $0 ${SF_SELECTED} | ${SF_RO}
+  SectionSetFlags ${core_id} $0
 FunctionEnd
 
 ;--------------------------------

--- a/Installers/Windows/MonoGame.nsi
+++ b/Installers/Windows/MonoGame.nsi
@@ -317,12 +317,35 @@ LangString MenuDesc ${LANG_ENGLISH} "Add a link to the MonoGame website to your 
   !insertmacro MUI_DESCRIPTION_TEXT ${Menu} $(MenuDesc)
 !insertmacro MUI_FUNCTION_DESCRIPTION_END
 
+Function checkVS2010
+IfFileExists `$DOCUMENTS\Visual Studio 2010\Templates\ProjectTemplates\Visual C#\*.*` end disable
+  disable:
+	 SectionSetFlags ${VS2010} $0
+  end:
+FunctionEnd
+ 
+Function checkVS2012
+IfFileExists `$DOCUMENTS\Visual Studio 2012\Templates\ProjectTemplates\Visual C#\*.*` end disable
+  disable:
+	 SectionSetFlags ${VS2012} $0
+  end:
+FunctionEnd
 
+Function checkVS2013
+IfFileExists `$DOCUMENTS\Visual Studio 2013\Templates\ProjectTemplates\Visual C#\*.*` end disable
+  disable:
+	 SectionSetFlags ${VS2013} $0
+  end:
+FunctionEnd
 
 Function .onInit
 
-  IntOp $0 ${SF_SELECTED} | ${SF_RO}
+  IntOp $0 $0 | ${SF_RO}
   SectionSetFlags ${core_id} $0
+  
+  Call checkVS2010
+  Call checkVS2012
+  Call checkVS2013
 FunctionEnd
 
 ;--------------------------------


### PR DESCRIPTION
This is correction fix for installer. Before this, installer always mark templates even if appropriate visual studio's(or its folder in Documents) is not existed in the system.

![image](https://cloud.githubusercontent.com/assets/3036176/6871805/1ed93250-d4b6-11e4-8c21-9dc99d0d0c75.png)

after this change it should be(on my computer where only VS2013 existed) like this

![image](https://cloud.githubusercontent.com/assets/3036176/6872013/96f38eec-d4b7-11e4-9e24-98f52a4aadcd.png)

