### PR TITLE
MGFX Render State Fixes

### DIFF
--- a/Tools/2MGFX/MGFX.tpg
+++ b/Tools/2MGFX/MGFX.tpg
@@ -75,11 +75,42 @@ EndOfFile -> @"^$";
 [IgnoreCase] ColorWriteEnable -> @"ColorWriteEnable";
 [IgnoreCase] ZEnable -> @"ZEnable";
 [IgnoreCase] ZWriteEnable -> @"ZWriteEnable";
+[IgnoreCase] ZFunc-> @"ZFunc";
 [IgnoreCase] DepthBias -> @"DepthBias";
 [IgnoreCase] CullMode -> @"CullMode";
 [IgnoreCase] FillMode -> @"FillMode";
 [IgnoreCase] MultiSampleAntiAlias -> @"MultiSampleAntiAlias";
+[IgnoreCase] ScissorTestEnable -> @"ScissorTestEnable";
 [IgnoreCase] SlopeScaleDepthBias -> @"SlopeScaleDepthBias";
+[IgnoreCase] StencilEnable -> @"StencilEnable";
+[IgnoreCase] StencilFail -> @"StencilFail";
+[IgnoreCase] StencilFunc -> @"StencilFunc";
+[IgnoreCase] StencilMask -> @"StencilMask";
+[IgnoreCase] StencilPass -> @"StencilPass";
+[IgnoreCase] StencilRef -> @"StencilRef";
+[IgnoreCase] StencilWriteMask -> @"StencilWriteMask";
+[IgnoreCase] StencilZFail -> @"StencilZFail";
+ 
+
+// Compare function
+[IgnoreCase] Never -> @"Never";
+[IgnoreCase] Less -> @"Less";
+[IgnoreCase] Equal -> @"Equal";
+[IgnoreCase] LessEqual -> @"LessEqual";
+[IgnoreCase] Greater -> @"Greater";
+[IgnoreCase] NotEqual -> @"NotEqual";
+[IgnoreCase] GreaterEqual -> @"GreaterEqual";
+[IgnoreCase] Always -> @"Always";
+
+// Stencil operation
+[IgnoreCase] Keep -> @"Keep";
+[IgnoreCase] Zero -> @"Zero";
+[IgnoreCase] Replace -> @"Replace";
+[IgnoreCase] IncrSat -> @"IncrSat";
+[IgnoreCase] DecrSat -> @"DecrSat";
+[IgnoreCase] Invert -> @"Invert";
+[IgnoreCase] Incr -> @"Incr";
+[IgnoreCase] Decr -> @"Decr";
 
 // Colors
 [IgnoreCase] Red -> @"Red";
@@ -216,6 +247,32 @@ BlendOps -> (BlendOp_Add|BlendOp_Subtract|BlendOp_RevSubtract|BlendOp_Min|BlendO
 	return	$BlendOp_Add ?? $BlendOp_Subtract ?? $BlendOp_RevSubtract ?? $BlendOp_Min ?? $BlendOp_Max;
 };
 
+CmpFunc_Never -> Never { return CompareFunction.Never; };
+CmpFunc_Less -> Less { return CompareFunction.Less; };
+CmpFunc_Equal -> Equal { return CompareFunction.Equal; };
+CmpFunc_LessEqual -> LessEqual { return CompareFunction.LessEqual; };
+CmpFunc_Greater -> Greater { return CompareFunction.Greater; };
+CmpFunc_NotEqual -> NotEqual { return CompareFunction.NotEqual; };
+CmpFunc_GreaterEqual -> GreaterEqual { return CompareFunction.GreaterEqual; };
+CmpFunc_Always -> Always { return CompareFunction.Always; };
+CmpFunc -> (CmpFunc_Never|CmpFunc_Less|CmpFunc_Equal|CmpFunc_LessEqual|CmpFunc_Greater|CmpFunc_NotEqual|CmpFunc_GreaterEqual|CmpFunc_Always)
+{
+	return	$CmpFunc_Never ?? $CmpFunc_Less ?? $CmpFunc_Equal ?? $CmpFunc_LessEqual ?? $CmpFunc_Greater ?? $CmpFunc_NotEqual ?? $CmpFunc_GreaterEqual ?? $CmpFunc_Always;
+};
+
+StencilOp_Keep -> Keep { return StencilOperation.Keep; };
+StencilOp_Zero -> Zero { return StencilOperation.Zero; };
+StencilOp_Replace -> Replace { return StencilOperation.Replace; };
+StencilOp_IncrSat -> IncrSat { return StencilOperation.IncrementSaturation; };
+StencilOp_DecrSat -> DecrSat { return StencilOperation.DecrementSaturation; };
+StencilOp_Invert -> Invert { return StencilOperation.Invert; };
+StencilOp_Incr -> Incr { return StencilOperation.Increment; };
+StencilOp_Decr -> Decr { return StencilOperation.Decrement; };
+StencilOp -> (StencilOp_Keep|StencilOp_Zero|StencilOp_Replace|StencilOp_IncrSat|StencilOp_DecrSat|StencilOp_Invert|StencilOp_Incr|StencilOp_Decr)
+{
+	return	$StencilOp_Keep ?? $StencilOp_Zero ?? $StencilOp_Replace ?? $StencilOp_IncrSat ?? $StencilOp_DecrSat ?? $StencilOp_Invert ?? $StencilOp_Incr ?? $StencilOp_Decr;
+};
+
 // Render states
 Render_State_CullMode -> CullMode Equals CullModes Semicolon { (paramlist[0] as PassInfo).CullMode = (CullMode)$CullModes; return null; };
 Render_State_FillMode -> FillMode Equals FillModes Semicolon { (paramlist[0] as PassInfo).FillMode = (FillMode)$FillModes; return null; };
@@ -228,7 +285,17 @@ Render_State_DepthBias -> DepthBias Equals Number Semicolon { (paramlist[0] as P
 Render_State_SlopeScaleDepthBias -> SlopeScaleDepthBias Equals Number Semicolon { (paramlist[0] as PassInfo).SlopeScaleDepthBias = ParseTreeTools.ParseFloat((string)$Number); return null; };
 Render_State_ZEnable -> ZEnable Equals Boolean Semicolon { (paramlist[0] as PassInfo).ZEnable = ParseTreeTools.ParseBool((string)$Boolean); return null; };
 Render_State_ZWriteEnable -> ZWriteEnable Equals Boolean Semicolon { (paramlist[0] as PassInfo).ZWriteEnable = ParseTreeTools.ParseBool((string)$Boolean); return null; };
+Render_State_ZFunc -> ZFunc Equals CmpFunc Semicolon { (paramlist[0] as PassInfo).DepthBufferFunction = (CompareFunction)$CmpFunc; return null; };
 Render_State_MultiSampleAntiAlias -> MultiSampleAntiAlias Equals Boolean Semicolon { (paramlist[0] as PassInfo).MultiSampleAntiAlias = ParseTreeTools.ParseBool((string)$Boolean); return null; };
+Render_State_ScissorTestEnable -> ScissorTestEnable Equals Boolean Semicolon { (paramlist[0] as PassInfo).ScissorTestEnable = ParseTreeTools.ParseBool((string)$Boolean); return null; };
+Render_State_StencilEnable -> StencilEnable Equals Boolean Semicolon { (paramlist[0] as PassInfo).StencilEnable = ParseTreeTools.ParseBool((string)$Boolean); return null; };
+Render_State_StencilFail -> StencilFail Equals StencilOp Semicolon { (paramlist[0] as PassInfo).StencilFail = (StencilOperation)$StencilOp; return null; };
+Render_State_StencilFunc -> StencilFunc Equals CmpFunc Semicolon { (paramlist[0] as PassInfo).StencilFunc = (CompareFunction)$CmpFunc; return null; };
+Render_State_StencilMask -> StencilMask Equals Number Semicolon { (paramlist[0] as PassInfo).StencilMask = ParseTreeTools.ParseInt((string)$Number); return null; };
+Render_State_StencilPass -> StencilPass Equals StencilOp Semicolon { (paramlist[0] as PassInfo).StencilPass = (StencilOperation)$StencilOp; return null; };
+Render_State_StencilRef -> StencilRef Equals Number Semicolon { (paramlist[0] as PassInfo).StencilRef = ParseTreeTools.ParseInt((string)$Number); return null; };
+Render_State_StencilWriteMask -> StencilWriteMask Equals Number Semicolon { (paramlist[0] as PassInfo).StencilWriteMask = ParseTreeTools.ParseInt((string)$Number); return null; };
+Render_State_StencilZFail -> StencilZFail Equals StencilOp Semicolon { (paramlist[0] as PassInfo).StencilZFail = (StencilOperation)$StencilOp; return null; };
 
 
 Render_State_Expression ->	
@@ -243,8 +310,17 @@ Render_State_Expression ->
 				Render_State_SlopeScaleDepthBias |
 				Render_State_ZEnable |
 				Render_State_ZWriteEnable |
-				Render_State_MultiSampleAntiAlias;
-
+				Render_State_ZFunc |
+				Render_State_MultiSampleAntiAlias |
+				Render_State_ScissorTestEnable |
+				Render_State_StencilEnable |
+				Render_State_StencilFail |
+				Render_State_StencilFunc |
+				Render_State_StencilMask |
+				Render_State_StencilPass |
+				Render_State_StencilRef |
+				Render_State_StencilWriteMask |
+				Render_State_StencilZFail;
 
 Pass_Declaration ->	Pass Identifier? OpenBracket (VertexShader_Pass_Expression | PixelShader_Pass_Expression | Render_State_Expression)* CloseBracket 
 { 

--- a/Tools/2MGFX/ParseTree.cs
+++ b/Tools/2MGFX/ParseTree.cs
@@ -293,6 +293,60 @@ namespace TwoMGFX
                 case TokenType.BlendOps:
                     Value = EvalBlendOps(tree, paramlist);
                     break;
+                case TokenType.CmpFunc_Never:
+                    Value = EvalCmpFunc_Never(tree, paramlist);
+                    break;
+                case TokenType.CmpFunc_Less:
+                    Value = EvalCmpFunc_Less(tree, paramlist);
+                    break;
+                case TokenType.CmpFunc_Equal:
+                    Value = EvalCmpFunc_Equal(tree, paramlist);
+                    break;
+                case TokenType.CmpFunc_LessEqual:
+                    Value = EvalCmpFunc_LessEqual(tree, paramlist);
+                    break;
+                case TokenType.CmpFunc_Greater:
+                    Value = EvalCmpFunc_Greater(tree, paramlist);
+                    break;
+                case TokenType.CmpFunc_NotEqual:
+                    Value = EvalCmpFunc_NotEqual(tree, paramlist);
+                    break;
+                case TokenType.CmpFunc_GreaterEqual:
+                    Value = EvalCmpFunc_GreaterEqual(tree, paramlist);
+                    break;
+                case TokenType.CmpFunc_Always:
+                    Value = EvalCmpFunc_Always(tree, paramlist);
+                    break;
+                case TokenType.CmpFunc:
+                    Value = EvalCmpFunc(tree, paramlist);
+                    break;
+                case TokenType.StencilOp_Keep:
+                    Value = EvalStencilOp_Keep(tree, paramlist);
+                    break;
+                case TokenType.StencilOp_Zero:
+                    Value = EvalStencilOp_Zero(tree, paramlist);
+                    break;
+                case TokenType.StencilOp_Replace:
+                    Value = EvalStencilOp_Replace(tree, paramlist);
+                    break;
+                case TokenType.StencilOp_IncrSat:
+                    Value = EvalStencilOp_IncrSat(tree, paramlist);
+                    break;
+                case TokenType.StencilOp_DecrSat:
+                    Value = EvalStencilOp_DecrSat(tree, paramlist);
+                    break;
+                case TokenType.StencilOp_Invert:
+                    Value = EvalStencilOp_Invert(tree, paramlist);
+                    break;
+                case TokenType.StencilOp_Incr:
+                    Value = EvalStencilOp_Incr(tree, paramlist);
+                    break;
+                case TokenType.StencilOp_Decr:
+                    Value = EvalStencilOp_Decr(tree, paramlist);
+                    break;
+                case TokenType.StencilOp:
+                    Value = EvalStencilOp(tree, paramlist);
+                    break;
                 case TokenType.Render_State_CullMode:
                     Value = EvalRender_State_CullMode(tree, paramlist);
                     break;
@@ -326,8 +380,38 @@ namespace TwoMGFX
                 case TokenType.Render_State_ZWriteEnable:
                     Value = EvalRender_State_ZWriteEnable(tree, paramlist);
                     break;
+                case TokenType.Render_State_ZFunc:
+                    Value = EvalRender_State_ZFunc(tree, paramlist);
+                    break;
                 case TokenType.Render_State_MultiSampleAntiAlias:
                     Value = EvalRender_State_MultiSampleAntiAlias(tree, paramlist);
+                    break;
+                case TokenType.Render_State_ScissorTestEnable:
+                    Value = EvalRender_State_ScissorTestEnable(tree, paramlist);
+                    break;
+                case TokenType.Render_State_StencilEnable:
+                    Value = EvalRender_State_StencilEnable(tree, paramlist);
+                    break;
+                case TokenType.Render_State_StencilFail:
+                    Value = EvalRender_State_StencilFail(tree, paramlist);
+                    break;
+                case TokenType.Render_State_StencilFunc:
+                    Value = EvalRender_State_StencilFunc(tree, paramlist);
+                    break;
+                case TokenType.Render_State_StencilMask:
+                    Value = EvalRender_State_StencilMask(tree, paramlist);
+                    break;
+                case TokenType.Render_State_StencilPass:
+                    Value = EvalRender_State_StencilPass(tree, paramlist);
+                    break;
+                case TokenType.Render_State_StencilRef:
+                    Value = EvalRender_State_StencilRef(tree, paramlist);
+                    break;
+                case TokenType.Render_State_StencilWriteMask:
+                    Value = EvalRender_State_StencilWriteMask(tree, paramlist);
+                    break;
+                case TokenType.Render_State_StencilZFail:
+                    Value = EvalRender_State_StencilZFail(tree, paramlist);
                     break;
                 case TokenType.Render_State_Expression:
                     Value = EvalRender_State_Expression(tree, paramlist);
@@ -639,6 +723,96 @@ namespace TwoMGFX
             return	this.GetValue(tree, TokenType.BlendOp_Add, 0) ?? this.GetValue(tree, TokenType.BlendOp_Subtract, 0) ?? this.GetValue(tree, TokenType.BlendOp_RevSubtract, 0) ?? this.GetValue(tree, TokenType.BlendOp_Min, 0) ?? this.GetValue(tree, TokenType.BlendOp_Max, 0);
         }
 
+        protected virtual object EvalCmpFunc_Never(ParseTree tree, params object[] paramlist)
+        {
+            return CompareFunction.Never;
+        }
+
+        protected virtual object EvalCmpFunc_Less(ParseTree tree, params object[] paramlist)
+        {
+            return CompareFunction.Less;
+        }
+
+        protected virtual object EvalCmpFunc_Equal(ParseTree tree, params object[] paramlist)
+        {
+            return CompareFunction.Equal;
+        }
+
+        protected virtual object EvalCmpFunc_LessEqual(ParseTree tree, params object[] paramlist)
+        {
+            return CompareFunction.LessEqual;
+        }
+
+        protected virtual object EvalCmpFunc_Greater(ParseTree tree, params object[] paramlist)
+        {
+            return CompareFunction.Greater;
+        }
+
+        protected virtual object EvalCmpFunc_NotEqual(ParseTree tree, params object[] paramlist)
+        {
+            return CompareFunction.NotEqual;
+        }
+
+        protected virtual object EvalCmpFunc_GreaterEqual(ParseTree tree, params object[] paramlist)
+        {
+            return CompareFunction.GreaterEqual;
+        }
+
+        protected virtual object EvalCmpFunc_Always(ParseTree tree, params object[] paramlist)
+        {
+            return CompareFunction.Always;
+        }
+
+        protected virtual object EvalCmpFunc(ParseTree tree, params object[] paramlist)
+        {
+            return	this.GetValue(tree, TokenType.CmpFunc_Never, 0) ?? this.GetValue(tree, TokenType.CmpFunc_Less, 0) ?? this.GetValue(tree, TokenType.CmpFunc_Equal, 0) ?? this.GetValue(tree, TokenType.CmpFunc_LessEqual, 0) ?? this.GetValue(tree, TokenType.CmpFunc_Greater, 0) ?? this.GetValue(tree, TokenType.CmpFunc_NotEqual, 0) ?? this.GetValue(tree, TokenType.CmpFunc_GreaterEqual, 0) ?? this.GetValue(tree, TokenType.CmpFunc_Always, 0);
+        }
+
+        protected virtual object EvalStencilOp_Keep(ParseTree tree, params object[] paramlist)
+        {
+            return StencilOperation.Keep;
+        }
+
+        protected virtual object EvalStencilOp_Zero(ParseTree tree, params object[] paramlist)
+        {
+            return StencilOperation.Zero;
+        }
+
+        protected virtual object EvalStencilOp_Replace(ParseTree tree, params object[] paramlist)
+        {
+            return StencilOperation.Replace;
+        }
+
+        protected virtual object EvalStencilOp_IncrSat(ParseTree tree, params object[] paramlist)
+        {
+            return StencilOperation.IncrementSaturation;
+        }
+
+        protected virtual object EvalStencilOp_DecrSat(ParseTree tree, params object[] paramlist)
+        {
+            return StencilOperation.DecrementSaturation;
+        }
+
+        protected virtual object EvalStencilOp_Invert(ParseTree tree, params object[] paramlist)
+        {
+            return StencilOperation.Invert;
+        }
+
+        protected virtual object EvalStencilOp_Incr(ParseTree tree, params object[] paramlist)
+        {
+            return StencilOperation.Increment;
+        }
+
+        protected virtual object EvalStencilOp_Decr(ParseTree tree, params object[] paramlist)
+        {
+            return StencilOperation.Decrement;
+        }
+
+        protected virtual object EvalStencilOp(ParseTree tree, params object[] paramlist)
+        {
+            return	this.GetValue(tree, TokenType.StencilOp_Keep, 0) ?? this.GetValue(tree, TokenType.StencilOp_Zero, 0) ?? this.GetValue(tree, TokenType.StencilOp_Replace, 0) ?? this.GetValue(tree, TokenType.StencilOp_IncrSat, 0) ?? this.GetValue(tree, TokenType.StencilOp_DecrSat, 0) ?? this.GetValue(tree, TokenType.StencilOp_Invert, 0) ?? this.GetValue(tree, TokenType.StencilOp_Incr, 0) ?? this.GetValue(tree, TokenType.StencilOp_Decr, 0);
+        }
+
         protected virtual object EvalRender_State_CullMode(ParseTree tree, params object[] paramlist)
         {
             (paramlist[0] as PassInfo).CullMode = (CullMode)this.GetValue(tree, TokenType.CullModes, 0); return null;
@@ -694,9 +868,59 @@ namespace TwoMGFX
             (paramlist[0] as PassInfo).ZWriteEnable = ParseTreeTools.ParseBool((string)this.GetValue(tree, TokenType.Boolean, 0)); return null;
         }
 
+        protected virtual object EvalRender_State_ZFunc(ParseTree tree, params object[] paramlist)
+        {
+            (paramlist[0] as PassInfo).DepthBufferFunction = (CompareFunction)this.GetValue(tree, TokenType.CmpFunc, 0); return null;
+        }
+
         protected virtual object EvalRender_State_MultiSampleAntiAlias(ParseTree tree, params object[] paramlist)
         {
             (paramlist[0] as PassInfo).MultiSampleAntiAlias = ParseTreeTools.ParseBool((string)this.GetValue(tree, TokenType.Boolean, 0)); return null;
+        }
+
+        protected virtual object EvalRender_State_ScissorTestEnable(ParseTree tree, params object[] paramlist)
+        {
+            (paramlist[0] as PassInfo).ScissorTestEnable = ParseTreeTools.ParseBool((string)this.GetValue(tree, TokenType.Boolean, 0)); return null;
+        }
+
+        protected virtual object EvalRender_State_StencilEnable(ParseTree tree, params object[] paramlist)
+        {
+            (paramlist[0] as PassInfo).StencilEnable = ParseTreeTools.ParseBool((string)this.GetValue(tree, TokenType.Boolean, 0)); return null;
+        }
+
+        protected virtual object EvalRender_State_StencilFail(ParseTree tree, params object[] paramlist)
+        {
+            (paramlist[0] as PassInfo).StencilFail = (StencilOperation)this.GetValue(tree, TokenType.StencilOp, 0); return null;
+        }
+
+        protected virtual object EvalRender_State_StencilFunc(ParseTree tree, params object[] paramlist)
+        {
+            (paramlist[0] as PassInfo).StencilFunc = (CompareFunction)this.GetValue(tree, TokenType.CmpFunc, 0); return null;
+        }
+
+        protected virtual object EvalRender_State_StencilMask(ParseTree tree, params object[] paramlist)
+        {
+            (paramlist[0] as PassInfo).StencilMask = ParseTreeTools.ParseInt((string)this.GetValue(tree, TokenType.Number, 0)); return null;
+        }
+
+        protected virtual object EvalRender_State_StencilPass(ParseTree tree, params object[] paramlist)
+        {
+            (paramlist[0] as PassInfo).StencilPass = (StencilOperation)this.GetValue(tree, TokenType.StencilOp, 0); return null;
+        }
+
+        protected virtual object EvalRender_State_StencilRef(ParseTree tree, params object[] paramlist)
+        {
+            (paramlist[0] as PassInfo).StencilRef = ParseTreeTools.ParseInt((string)this.GetValue(tree, TokenType.Number, 0)); return null;
+        }
+
+        protected virtual object EvalRender_State_StencilWriteMask(ParseTree tree, params object[] paramlist)
+        {
+            (paramlist[0] as PassInfo).StencilWriteMask = ParseTreeTools.ParseInt((string)this.GetValue(tree, TokenType.Number, 0)); return null;
+        }
+
+        protected virtual object EvalRender_State_StencilZFail(ParseTree tree, params object[] paramlist)
+        {
+            (paramlist[0] as PassInfo).StencilZFail = (StencilOperation)this.GetValue(tree, TokenType.StencilOp, 0); return null;
         }
 
         protected virtual object EvalRender_State_Expression(ParseTree tree, params object[] paramlist)

--- a/Tools/2MGFX/Parser.cs
+++ b/Tools/2MGFX/Parser.cs
@@ -977,6 +977,394 @@ namespace TwoMGFX
             parent.Token.UpdateRange(node.Token);
         } // NonTerminalSymbol: BlendOps
 
+        private void ParseCmpFunc_Never(ParseNode parent) // NonTerminalSymbol: CmpFunc_Never
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.CmpFunc_Never), "CmpFunc_Never");
+            parent.Nodes.Add(node);
+
+            tok = scanner.Scan(TokenType.Never); // Terminal Rule: Never
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Never) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Never.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: CmpFunc_Never
+
+        private void ParseCmpFunc_Less(ParseNode parent) // NonTerminalSymbol: CmpFunc_Less
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.CmpFunc_Less), "CmpFunc_Less");
+            parent.Nodes.Add(node);
+
+            tok = scanner.Scan(TokenType.Less); // Terminal Rule: Less
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Less) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Less.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: CmpFunc_Less
+
+        private void ParseCmpFunc_Equal(ParseNode parent) // NonTerminalSymbol: CmpFunc_Equal
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.CmpFunc_Equal), "CmpFunc_Equal");
+            parent.Nodes.Add(node);
+
+            tok = scanner.Scan(TokenType.Equal); // Terminal Rule: Equal
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Equal) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Equal.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: CmpFunc_Equal
+
+        private void ParseCmpFunc_LessEqual(ParseNode parent) // NonTerminalSymbol: CmpFunc_LessEqual
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.CmpFunc_LessEqual), "CmpFunc_LessEqual");
+            parent.Nodes.Add(node);
+
+            tok = scanner.Scan(TokenType.LessEqual); // Terminal Rule: LessEqual
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.LessEqual) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.LessEqual.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: CmpFunc_LessEqual
+
+        private void ParseCmpFunc_Greater(ParseNode parent) // NonTerminalSymbol: CmpFunc_Greater
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.CmpFunc_Greater), "CmpFunc_Greater");
+            parent.Nodes.Add(node);
+
+            tok = scanner.Scan(TokenType.Greater); // Terminal Rule: Greater
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Greater) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Greater.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: CmpFunc_Greater
+
+        private void ParseCmpFunc_NotEqual(ParseNode parent) // NonTerminalSymbol: CmpFunc_NotEqual
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.CmpFunc_NotEqual), "CmpFunc_NotEqual");
+            parent.Nodes.Add(node);
+
+            tok = scanner.Scan(TokenType.NotEqual); // Terminal Rule: NotEqual
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.NotEqual) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.NotEqual.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: CmpFunc_NotEqual
+
+        private void ParseCmpFunc_GreaterEqual(ParseNode parent) // NonTerminalSymbol: CmpFunc_GreaterEqual
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.CmpFunc_GreaterEqual), "CmpFunc_GreaterEqual");
+            parent.Nodes.Add(node);
+
+            tok = scanner.Scan(TokenType.GreaterEqual); // Terminal Rule: GreaterEqual
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.GreaterEqual) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.GreaterEqual.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: CmpFunc_GreaterEqual
+
+        private void ParseCmpFunc_Always(ParseNode parent) // NonTerminalSymbol: CmpFunc_Always
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.CmpFunc_Always), "CmpFunc_Always");
+            parent.Nodes.Add(node);
+
+            tok = scanner.Scan(TokenType.Always); // Terminal Rule: Always
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Always) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Always.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: CmpFunc_Always
+
+        private void ParseCmpFunc(ParseNode parent) // NonTerminalSymbol: CmpFunc
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.CmpFunc), "CmpFunc");
+            parent.Nodes.Add(node);
+
+            tok = scanner.LookAhead(TokenType.Never, TokenType.Less, TokenType.Equal, TokenType.LessEqual, TokenType.Greater, TokenType.NotEqual, TokenType.GreaterEqual, TokenType.Always); // Choice Rule
+            switch (tok.Type)
+            { // Choice Rule
+                case TokenType.Never:
+                    ParseCmpFunc_Never(node); // NonTerminal Rule: CmpFunc_Never
+                    break;
+                case TokenType.Less:
+                    ParseCmpFunc_Less(node); // NonTerminal Rule: CmpFunc_Less
+                    break;
+                case TokenType.Equal:
+                    ParseCmpFunc_Equal(node); // NonTerminal Rule: CmpFunc_Equal
+                    break;
+                case TokenType.LessEqual:
+                    ParseCmpFunc_LessEqual(node); // NonTerminal Rule: CmpFunc_LessEqual
+                    break;
+                case TokenType.Greater:
+                    ParseCmpFunc_Greater(node); // NonTerminal Rule: CmpFunc_Greater
+                    break;
+                case TokenType.NotEqual:
+                    ParseCmpFunc_NotEqual(node); // NonTerminal Rule: CmpFunc_NotEqual
+                    break;
+                case TokenType.GreaterEqual:
+                    ParseCmpFunc_GreaterEqual(node); // NonTerminal Rule: CmpFunc_GreaterEqual
+                    break;
+                case TokenType.Always:
+                    ParseCmpFunc_Always(node); // NonTerminal Rule: CmpFunc_Always
+                    break;
+                default:
+                    tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected Never, Less, Equal, LessEqual, Greater, NotEqual, GreaterEqual, or Always.", 0x0002, tok));
+                    break;
+            } // Choice Rule
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: CmpFunc
+
+        private void ParseStencilOp_Keep(ParseNode parent) // NonTerminalSymbol: StencilOp_Keep
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.StencilOp_Keep), "StencilOp_Keep");
+            parent.Nodes.Add(node);
+
+            tok = scanner.Scan(TokenType.Keep); // Terminal Rule: Keep
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Keep) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Keep.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: StencilOp_Keep
+
+        private void ParseStencilOp_Zero(ParseNode parent) // NonTerminalSymbol: StencilOp_Zero
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.StencilOp_Zero), "StencilOp_Zero");
+            parent.Nodes.Add(node);
+
+            tok = scanner.Scan(TokenType.Zero); // Terminal Rule: Zero
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Zero) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Zero.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: StencilOp_Zero
+
+        private void ParseStencilOp_Replace(ParseNode parent) // NonTerminalSymbol: StencilOp_Replace
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.StencilOp_Replace), "StencilOp_Replace");
+            parent.Nodes.Add(node);
+
+            tok = scanner.Scan(TokenType.Replace); // Terminal Rule: Replace
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Replace) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Replace.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: StencilOp_Replace
+
+        private void ParseStencilOp_IncrSat(ParseNode parent) // NonTerminalSymbol: StencilOp_IncrSat
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.StencilOp_IncrSat), "StencilOp_IncrSat");
+            parent.Nodes.Add(node);
+
+            tok = scanner.Scan(TokenType.IncrSat); // Terminal Rule: IncrSat
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.IncrSat) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.IncrSat.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: StencilOp_IncrSat
+
+        private void ParseStencilOp_DecrSat(ParseNode parent) // NonTerminalSymbol: StencilOp_DecrSat
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.StencilOp_DecrSat), "StencilOp_DecrSat");
+            parent.Nodes.Add(node);
+
+            tok = scanner.Scan(TokenType.DecrSat); // Terminal Rule: DecrSat
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.DecrSat) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.DecrSat.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: StencilOp_DecrSat
+
+        private void ParseStencilOp_Invert(ParseNode parent) // NonTerminalSymbol: StencilOp_Invert
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.StencilOp_Invert), "StencilOp_Invert");
+            parent.Nodes.Add(node);
+
+            tok = scanner.Scan(TokenType.Invert); // Terminal Rule: Invert
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Invert) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Invert.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: StencilOp_Invert
+
+        private void ParseStencilOp_Incr(ParseNode parent) // NonTerminalSymbol: StencilOp_Incr
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.StencilOp_Incr), "StencilOp_Incr");
+            parent.Nodes.Add(node);
+
+            tok = scanner.Scan(TokenType.Incr); // Terminal Rule: Incr
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Incr) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Incr.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: StencilOp_Incr
+
+        private void ParseStencilOp_Decr(ParseNode parent) // NonTerminalSymbol: StencilOp_Decr
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.StencilOp_Decr), "StencilOp_Decr");
+            parent.Nodes.Add(node);
+
+            tok = scanner.Scan(TokenType.Decr); // Terminal Rule: Decr
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Decr) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Decr.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: StencilOp_Decr
+
+        private void ParseStencilOp(ParseNode parent) // NonTerminalSymbol: StencilOp
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.StencilOp), "StencilOp");
+            parent.Nodes.Add(node);
+
+            tok = scanner.LookAhead(TokenType.Keep, TokenType.Zero, TokenType.Replace, TokenType.IncrSat, TokenType.DecrSat, TokenType.Invert, TokenType.Incr, TokenType.Decr); // Choice Rule
+            switch (tok.Type)
+            { // Choice Rule
+                case TokenType.Keep:
+                    ParseStencilOp_Keep(node); // NonTerminal Rule: StencilOp_Keep
+                    break;
+                case TokenType.Zero:
+                    ParseStencilOp_Zero(node); // NonTerminal Rule: StencilOp_Zero
+                    break;
+                case TokenType.Replace:
+                    ParseStencilOp_Replace(node); // NonTerminal Rule: StencilOp_Replace
+                    break;
+                case TokenType.IncrSat:
+                    ParseStencilOp_IncrSat(node); // NonTerminal Rule: StencilOp_IncrSat
+                    break;
+                case TokenType.DecrSat:
+                    ParseStencilOp_DecrSat(node); // NonTerminal Rule: StencilOp_DecrSat
+                    break;
+                case TokenType.Invert:
+                    ParseStencilOp_Invert(node); // NonTerminal Rule: StencilOp_Invert
+                    break;
+                case TokenType.Incr:
+                    ParseStencilOp_Incr(node); // NonTerminal Rule: StencilOp_Incr
+                    break;
+                case TokenType.Decr:
+                    ParseStencilOp_Decr(node); // NonTerminal Rule: StencilOp_Decr
+                    break;
+                default:
+                    tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected Keep, Zero, Replace, IncrSat, DecrSat, Invert, Incr, or Decr.", 0x0002, tok));
+                    break;
+            } // Choice Rule
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: StencilOp
+
         private void ParseRender_State_CullMode(ParseNode parent) // NonTerminalSymbol: Render_State_CullMode
         {
             Token tok;
@@ -1496,6 +1884,50 @@ namespace TwoMGFX
             parent.Token.UpdateRange(node.Token);
         } // NonTerminalSymbol: Render_State_ZWriteEnable
 
+        private void ParseRender_State_ZFunc(ParseNode parent) // NonTerminalSymbol: Render_State_ZFunc
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.Render_State_ZFunc), "Render_State_ZFunc");
+            parent.Nodes.Add(node);
+
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.ZFunc); // Terminal Rule: ZFunc
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.ZFunc) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.ZFunc.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Equals); // Terminal Rule: Equals
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Equals) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Equals.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            ParseCmpFunc(node); // NonTerminal Rule: CmpFunc
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Semicolon); // Terminal Rule: Semicolon
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Semicolon) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Semicolon.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: Render_State_ZFunc
+
         private void ParseRender_State_MultiSampleAntiAlias(ParseNode parent) // NonTerminalSymbol: Render_State_MultiSampleAntiAlias
         {
             Token tok;
@@ -1547,6 +1979,437 @@ namespace TwoMGFX
             parent.Token.UpdateRange(node.Token);
         } // NonTerminalSymbol: Render_State_MultiSampleAntiAlias
 
+        private void ParseRender_State_ScissorTestEnable(ParseNode parent) // NonTerminalSymbol: Render_State_ScissorTestEnable
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.Render_State_ScissorTestEnable), "Render_State_ScissorTestEnable");
+            parent.Nodes.Add(node);
+
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.ScissorTestEnable); // Terminal Rule: ScissorTestEnable
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.ScissorTestEnable) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.ScissorTestEnable.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Equals); // Terminal Rule: Equals
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Equals) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Equals.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Boolean); // Terminal Rule: Boolean
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Boolean) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Boolean.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Semicolon); // Terminal Rule: Semicolon
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Semicolon) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Semicolon.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: Render_State_ScissorTestEnable
+
+        private void ParseRender_State_StencilEnable(ParseNode parent) // NonTerminalSymbol: Render_State_StencilEnable
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.Render_State_StencilEnable), "Render_State_StencilEnable");
+            parent.Nodes.Add(node);
+
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.StencilEnable); // Terminal Rule: StencilEnable
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.StencilEnable) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.StencilEnable.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Equals); // Terminal Rule: Equals
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Equals) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Equals.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Boolean); // Terminal Rule: Boolean
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Boolean) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Boolean.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Semicolon); // Terminal Rule: Semicolon
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Semicolon) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Semicolon.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: Render_State_StencilEnable
+
+        private void ParseRender_State_StencilFail(ParseNode parent) // NonTerminalSymbol: Render_State_StencilFail
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.Render_State_StencilFail), "Render_State_StencilFail");
+            parent.Nodes.Add(node);
+
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.StencilFail); // Terminal Rule: StencilFail
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.StencilFail) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.StencilFail.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Equals); // Terminal Rule: Equals
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Equals) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Equals.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            ParseStencilOp(node); // NonTerminal Rule: StencilOp
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Semicolon); // Terminal Rule: Semicolon
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Semicolon) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Semicolon.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: Render_State_StencilFail
+
+        private void ParseRender_State_StencilFunc(ParseNode parent) // NonTerminalSymbol: Render_State_StencilFunc
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.Render_State_StencilFunc), "Render_State_StencilFunc");
+            parent.Nodes.Add(node);
+
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.StencilFunc); // Terminal Rule: StencilFunc
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.StencilFunc) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.StencilFunc.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Equals); // Terminal Rule: Equals
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Equals) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Equals.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            ParseCmpFunc(node); // NonTerminal Rule: CmpFunc
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Semicolon); // Terminal Rule: Semicolon
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Semicolon) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Semicolon.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: Render_State_StencilFunc
+
+        private void ParseRender_State_StencilMask(ParseNode parent) // NonTerminalSymbol: Render_State_StencilMask
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.Render_State_StencilMask), "Render_State_StencilMask");
+            parent.Nodes.Add(node);
+
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.StencilMask); // Terminal Rule: StencilMask
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.StencilMask) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.StencilMask.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Equals); // Terminal Rule: Equals
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Equals) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Equals.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Number); // Terminal Rule: Number
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Number) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Number.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Semicolon); // Terminal Rule: Semicolon
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Semicolon) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Semicolon.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: Render_State_StencilMask
+
+        private void ParseRender_State_StencilPass(ParseNode parent) // NonTerminalSymbol: Render_State_StencilPass
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.Render_State_StencilPass), "Render_State_StencilPass");
+            parent.Nodes.Add(node);
+
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.StencilPass); // Terminal Rule: StencilPass
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.StencilPass) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.StencilPass.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Equals); // Terminal Rule: Equals
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Equals) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Equals.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            ParseStencilOp(node); // NonTerminal Rule: StencilOp
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Semicolon); // Terminal Rule: Semicolon
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Semicolon) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Semicolon.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: Render_State_StencilPass
+
+        private void ParseRender_State_StencilRef(ParseNode parent) // NonTerminalSymbol: Render_State_StencilRef
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.Render_State_StencilRef), "Render_State_StencilRef");
+            parent.Nodes.Add(node);
+
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.StencilRef); // Terminal Rule: StencilRef
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.StencilRef) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.StencilRef.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Equals); // Terminal Rule: Equals
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Equals) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Equals.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Number); // Terminal Rule: Number
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Number) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Number.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Semicolon); // Terminal Rule: Semicolon
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Semicolon) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Semicolon.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: Render_State_StencilRef
+
+        private void ParseRender_State_StencilWriteMask(ParseNode parent) // NonTerminalSymbol: Render_State_StencilWriteMask
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.Render_State_StencilWriteMask), "Render_State_StencilWriteMask");
+            parent.Nodes.Add(node);
+
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.StencilWriteMask); // Terminal Rule: StencilWriteMask
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.StencilWriteMask) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.StencilWriteMask.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Equals); // Terminal Rule: Equals
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Equals) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Equals.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Number); // Terminal Rule: Number
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Number) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Number.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Semicolon); // Terminal Rule: Semicolon
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Semicolon) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Semicolon.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: Render_State_StencilWriteMask
+
+        private void ParseRender_State_StencilZFail(ParseNode parent) // NonTerminalSymbol: Render_State_StencilZFail
+        {
+            Token tok;
+            ParseNode n;
+            ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.Render_State_StencilZFail), "Render_State_StencilZFail");
+            parent.Nodes.Add(node);
+
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.StencilZFail); // Terminal Rule: StencilZFail
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.StencilZFail) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.StencilZFail.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Equals); // Terminal Rule: Equals
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Equals) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Equals.ToString(), 0x1001, tok));
+                return;
+            }
+
+             // Concat Rule
+            ParseStencilOp(node); // NonTerminal Rule: StencilOp
+
+             // Concat Rule
+            tok = scanner.Scan(TokenType.Semicolon); // Terminal Rule: Semicolon
+            n = node.CreateNode(tok, tok.ToString() );
+            node.Token.UpdateRange(tok);
+            node.Nodes.Add(n);
+            if (tok.Type != TokenType.Semicolon) {
+                tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected " + TokenType.Semicolon.ToString(), 0x1001, tok));
+                return;
+            }
+
+            parent.Token.UpdateRange(node.Token);
+        } // NonTerminalSymbol: Render_State_StencilZFail
+
         private void ParseRender_State_Expression(ParseNode parent) // NonTerminalSymbol: Render_State_Expression
         {
             Token tok;
@@ -1554,7 +2417,7 @@ namespace TwoMGFX
             ParseNode node = parent.CreateNode(scanner.GetToken(TokenType.Render_State_Expression), "Render_State_Expression");
             parent.Nodes.Add(node);
 
-            tok = scanner.LookAhead(TokenType.CullMode, TokenType.FillMode, TokenType.AlphaBlendEnable, TokenType.SrcBlend, TokenType.DestBlend, TokenType.BlendOp, TokenType.ColorWriteEnable, TokenType.DepthBias, TokenType.SlopeScaleDepthBias, TokenType.ZEnable, TokenType.ZWriteEnable, TokenType.MultiSampleAntiAlias); // Choice Rule
+            tok = scanner.LookAhead(TokenType.CullMode, TokenType.FillMode, TokenType.AlphaBlendEnable, TokenType.SrcBlend, TokenType.DestBlend, TokenType.BlendOp, TokenType.ColorWriteEnable, TokenType.DepthBias, TokenType.SlopeScaleDepthBias, TokenType.ZEnable, TokenType.ZWriteEnable, TokenType.ZFunc, TokenType.MultiSampleAntiAlias, TokenType.ScissorTestEnable, TokenType.StencilEnable, TokenType.StencilFail, TokenType.StencilFunc, TokenType.StencilMask, TokenType.StencilPass, TokenType.StencilRef, TokenType.StencilWriteMask, TokenType.StencilZFail); // Choice Rule
             switch (tok.Type)
             { // Choice Rule
                 case TokenType.CullMode:
@@ -1590,11 +2453,41 @@ namespace TwoMGFX
                 case TokenType.ZWriteEnable:
                     ParseRender_State_ZWriteEnable(node); // NonTerminal Rule: Render_State_ZWriteEnable
                     break;
+                case TokenType.ZFunc:
+                    ParseRender_State_ZFunc(node); // NonTerminal Rule: Render_State_ZFunc
+                    break;
                 case TokenType.MultiSampleAntiAlias:
                     ParseRender_State_MultiSampleAntiAlias(node); // NonTerminal Rule: Render_State_MultiSampleAntiAlias
                     break;
+                case TokenType.ScissorTestEnable:
+                    ParseRender_State_ScissorTestEnable(node); // NonTerminal Rule: Render_State_ScissorTestEnable
+                    break;
+                case TokenType.StencilEnable:
+                    ParseRender_State_StencilEnable(node); // NonTerminal Rule: Render_State_StencilEnable
+                    break;
+                case TokenType.StencilFail:
+                    ParseRender_State_StencilFail(node); // NonTerminal Rule: Render_State_StencilFail
+                    break;
+                case TokenType.StencilFunc:
+                    ParseRender_State_StencilFunc(node); // NonTerminal Rule: Render_State_StencilFunc
+                    break;
+                case TokenType.StencilMask:
+                    ParseRender_State_StencilMask(node); // NonTerminal Rule: Render_State_StencilMask
+                    break;
+                case TokenType.StencilPass:
+                    ParseRender_State_StencilPass(node); // NonTerminal Rule: Render_State_StencilPass
+                    break;
+                case TokenType.StencilRef:
+                    ParseRender_State_StencilRef(node); // NonTerminal Rule: Render_State_StencilRef
+                    break;
+                case TokenType.StencilWriteMask:
+                    ParseRender_State_StencilWriteMask(node); // NonTerminal Rule: Render_State_StencilWriteMask
+                    break;
+                case TokenType.StencilZFail:
+                    ParseRender_State_StencilZFail(node); // NonTerminal Rule: Render_State_StencilZFail
+                    break;
                 default:
-                    tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected CullMode, FillMode, AlphaBlendEnable, SrcBlend, DestBlend, BlendOp, ColorWriteEnable, DepthBias, SlopeScaleDepthBias, ZEnable, ZWriteEnable, or MultiSampleAntiAlias.", 0x0002, tok));
+                    tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected CullMode, FillMode, AlphaBlendEnable, SrcBlend, DestBlend, BlendOp, ColorWriteEnable, DepthBias, SlopeScaleDepthBias, ZEnable, ZWriteEnable, ZFunc, MultiSampleAntiAlias, ScissorTestEnable, StencilEnable, StencilFail, StencilFunc, StencilMask, StencilPass, StencilRef, StencilWriteMask, or StencilZFail.", 0x0002, tok));
                     break;
             } // Choice Rule
 
@@ -1644,7 +2537,7 @@ namespace TwoMGFX
             }
 
              // Concat Rule
-            tok = scanner.LookAhead(TokenType.VertexShader, TokenType.PixelShader, TokenType.CullMode, TokenType.FillMode, TokenType.AlphaBlendEnable, TokenType.SrcBlend, TokenType.DestBlend, TokenType.BlendOp, TokenType.ColorWriteEnable, TokenType.DepthBias, TokenType.SlopeScaleDepthBias, TokenType.ZEnable, TokenType.ZWriteEnable, TokenType.MultiSampleAntiAlias); // ZeroOrMore Rule
+            tok = scanner.LookAhead(TokenType.VertexShader, TokenType.PixelShader, TokenType.CullMode, TokenType.FillMode, TokenType.AlphaBlendEnable, TokenType.SrcBlend, TokenType.DestBlend, TokenType.BlendOp, TokenType.ColorWriteEnable, TokenType.DepthBias, TokenType.SlopeScaleDepthBias, TokenType.ZEnable, TokenType.ZWriteEnable, TokenType.ZFunc, TokenType.MultiSampleAntiAlias, TokenType.ScissorTestEnable, TokenType.StencilEnable, TokenType.StencilFail, TokenType.StencilFunc, TokenType.StencilMask, TokenType.StencilPass, TokenType.StencilRef, TokenType.StencilWriteMask, TokenType.StencilZFail); // ZeroOrMore Rule
             while (tok.Type == TokenType.VertexShader
                 || tok.Type == TokenType.PixelShader
                 || tok.Type == TokenType.CullMode
@@ -1658,9 +2551,19 @@ namespace TwoMGFX
                 || tok.Type == TokenType.SlopeScaleDepthBias
                 || tok.Type == TokenType.ZEnable
                 || tok.Type == TokenType.ZWriteEnable
-                || tok.Type == TokenType.MultiSampleAntiAlias)
+                || tok.Type == TokenType.ZFunc
+                || tok.Type == TokenType.MultiSampleAntiAlias
+                || tok.Type == TokenType.ScissorTestEnable
+                || tok.Type == TokenType.StencilEnable
+                || tok.Type == TokenType.StencilFail
+                || tok.Type == TokenType.StencilFunc
+                || tok.Type == TokenType.StencilMask
+                || tok.Type == TokenType.StencilPass
+                || tok.Type == TokenType.StencilRef
+                || tok.Type == TokenType.StencilWriteMask
+                || tok.Type == TokenType.StencilZFail)
             {
-                tok = scanner.LookAhead(TokenType.VertexShader, TokenType.PixelShader, TokenType.CullMode, TokenType.FillMode, TokenType.AlphaBlendEnable, TokenType.SrcBlend, TokenType.DestBlend, TokenType.BlendOp, TokenType.ColorWriteEnable, TokenType.DepthBias, TokenType.SlopeScaleDepthBias, TokenType.ZEnable, TokenType.ZWriteEnable, TokenType.MultiSampleAntiAlias); // Choice Rule
+                tok = scanner.LookAhead(TokenType.VertexShader, TokenType.PixelShader, TokenType.CullMode, TokenType.FillMode, TokenType.AlphaBlendEnable, TokenType.SrcBlend, TokenType.DestBlend, TokenType.BlendOp, TokenType.ColorWriteEnable, TokenType.DepthBias, TokenType.SlopeScaleDepthBias, TokenType.ZEnable, TokenType.ZWriteEnable, TokenType.ZFunc, TokenType.MultiSampleAntiAlias, TokenType.ScissorTestEnable, TokenType.StencilEnable, TokenType.StencilFail, TokenType.StencilFunc, TokenType.StencilMask, TokenType.StencilPass, TokenType.StencilRef, TokenType.StencilWriteMask, TokenType.StencilZFail); // Choice Rule
                 switch (tok.Type)
                 { // Choice Rule
                     case TokenType.VertexShader:
@@ -1680,14 +2583,24 @@ namespace TwoMGFX
                     case TokenType.SlopeScaleDepthBias:
                     case TokenType.ZEnable:
                     case TokenType.ZWriteEnable:
+                    case TokenType.ZFunc:
                     case TokenType.MultiSampleAntiAlias:
+                    case TokenType.ScissorTestEnable:
+                    case TokenType.StencilEnable:
+                    case TokenType.StencilFail:
+                    case TokenType.StencilFunc:
+                    case TokenType.StencilMask:
+                    case TokenType.StencilPass:
+                    case TokenType.StencilRef:
+                    case TokenType.StencilWriteMask:
+                    case TokenType.StencilZFail:
                         ParseRender_State_Expression(node); // NonTerminal Rule: Render_State_Expression
                         break;
                     default:
-                        tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected VertexShader, PixelShader, CullMode, FillMode, AlphaBlendEnable, SrcBlend, DestBlend, BlendOp, ColorWriteEnable, DepthBias, SlopeScaleDepthBias, ZEnable, ZWriteEnable, or MultiSampleAntiAlias.", 0x0002, tok));
+                        tree.Errors.Add(new ParseError("Unexpected token '" + tok.Text.Replace("\n", "") + "' found. Expected VertexShader, PixelShader, CullMode, FillMode, AlphaBlendEnable, SrcBlend, DestBlend, BlendOp, ColorWriteEnable, DepthBias, SlopeScaleDepthBias, ZEnable, ZWriteEnable, ZFunc, MultiSampleAntiAlias, ScissorTestEnable, StencilEnable, StencilFail, StencilFunc, StencilMask, StencilPass, StencilRef, StencilWriteMask, or StencilZFail.", 0x0002, tok));
                         break;
                 } // Choice Rule
-            tok = scanner.LookAhead(TokenType.VertexShader, TokenType.PixelShader, TokenType.CullMode, TokenType.FillMode, TokenType.AlphaBlendEnable, TokenType.SrcBlend, TokenType.DestBlend, TokenType.BlendOp, TokenType.ColorWriteEnable, TokenType.DepthBias, TokenType.SlopeScaleDepthBias, TokenType.ZEnable, TokenType.ZWriteEnable, TokenType.MultiSampleAntiAlias); // ZeroOrMore Rule
+            tok = scanner.LookAhead(TokenType.VertexShader, TokenType.PixelShader, TokenType.CullMode, TokenType.FillMode, TokenType.AlphaBlendEnable, TokenType.SrcBlend, TokenType.DestBlend, TokenType.BlendOp, TokenType.ColorWriteEnable, TokenType.DepthBias, TokenType.SlopeScaleDepthBias, TokenType.ZEnable, TokenType.ZWriteEnable, TokenType.ZFunc, TokenType.MultiSampleAntiAlias, TokenType.ScissorTestEnable, TokenType.StencilEnable, TokenType.StencilFail, TokenType.StencilFunc, TokenType.StencilMask, TokenType.StencilPass, TokenType.StencilRef, TokenType.StencilWriteMask, TokenType.StencilZFail); // ZeroOrMore Rule
             }
 
              // Concat Rule

--- a/Tools/2MGFX/PassInfo.cs
+++ b/Tools/2MGFX/PassInfo.cs
@@ -166,6 +166,16 @@ namespace TwoMGFX
             }
         }
 
+        public CompareFunction DepthBufferFunction
+        {
+            set
+            {
+                if (depthStencilState == null)
+                    depthStencilState = new DepthStencilState();
+                depthStencilState.DepthBufferFunction = value;
+            }
+        }
+
         public bool MultiSampleAntiAlias
         {
             set
@@ -173,6 +183,96 @@ namespace TwoMGFX
                 if (rasterizerState == null)
                     rasterizerState = new RasterizerState();
                 rasterizerState.MultiSampleAntiAlias = value;
+            }
+        }
+
+        public bool ScissorTestEnable
+        {
+            set
+            {
+                if (rasterizerState == null)
+                    rasterizerState = new RasterizerState();
+                rasterizerState.ScissorTestEnable = value;
+            }
+        }
+
+        public bool StencilEnable
+        {
+            set
+            {
+                if (depthStencilState == null)
+                    depthStencilState = new DepthStencilState();
+                depthStencilState.StencilEnable = value;
+            }
+        }
+
+        public StencilOperation StencilFail
+        {
+            set
+            {
+                if (depthStencilState == null)
+                    depthStencilState = new DepthStencilState();
+                depthStencilState.StencilFail = value;
+            }
+        }
+
+        public CompareFunction StencilFunc
+        {
+            set
+            {
+                if (depthStencilState == null)
+                    depthStencilState = new DepthStencilState();
+                depthStencilState.StencilFunction = value;
+            }
+        }
+
+        public int StencilMask
+        {
+            set
+            {
+                if (depthStencilState == null)
+                    depthStencilState = new DepthStencilState();
+                depthStencilState.StencilMask = value;
+            }
+        }
+
+        public StencilOperation StencilPass
+        {
+            set
+            {
+                if (depthStencilState == null)
+                    depthStencilState = new DepthStencilState();
+                depthStencilState.StencilPass = value;
+            }
+        }
+
+        public int StencilRef
+        {
+            set
+            {
+                if (depthStencilState == null)
+                    depthStencilState = new DepthStencilState();
+                depthStencilState.ReferenceStencil = value;
+            }
+        }
+
+        public int StencilWriteMask
+        {
+            set
+            {
+                if (depthStencilState == null)
+                    depthStencilState = new DepthStencilState();
+                depthStencilState.StencilWriteMask = value;
+            }
+        }
+
+        public StencilOperation StencilZFail
+        {
+            set
+            {
+                if (depthStencilState == null)
+                    depthStencilState = new DepthStencilState();
+                depthStencilState.StencilDepthBufferFail = value;
             }
         }
 

--- a/Tools/2MGFX/SamplerStateInfo.cs
+++ b/Tools/2MGFX/SamplerStateInfo.cs
@@ -24,6 +24,21 @@ namespace TwoMGFX
         private int _maxMipLevel;
         private float _mipMapLevelOfDetailBias;
 
+        public SamplerStateInfo()
+        {
+            // NOTE: These match the defaults of SamplerState.
+            _minFilter = TextureFilterType.Linear;
+            _magFilter = TextureFilterType.Linear;
+            _mipFilter = TextureFilterType.Linear;
+            _addressU = TextureAddressMode.Wrap;
+            _addressV = TextureAddressMode.Wrap;
+            _addressW = TextureAddressMode.Wrap;
+            _borderColor = Color.White;
+            _maxAnisotropy = 4;
+            _maxMipLevel = 0;
+            _mipMapLevelOfDetailBias = 0.0f;
+        }
+
         public string Name { get; set; }
 
         public string TextureName { get; set; }

--- a/Tools/2MGFX/Scanner.cs
+++ b/Tools/2MGFX/Scanner.cs
@@ -278,6 +278,10 @@ namespace TwoMGFX
             Patterns.Add(TokenType.ZWriteEnable, regex);
             Tokens.Add(TokenType.ZWriteEnable);
 
+            regex = new Regex(@"ZFunc", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.ZFunc, regex);
+            Tokens.Add(TokenType.ZFunc);
+
             regex = new Regex(@"DepthBias", RegexOptions.Compiled | RegexOptions.IgnoreCase);
             Patterns.Add(TokenType.DepthBias, regex);
             Tokens.Add(TokenType.DepthBias);
@@ -294,9 +298,109 @@ namespace TwoMGFX
             Patterns.Add(TokenType.MultiSampleAntiAlias, regex);
             Tokens.Add(TokenType.MultiSampleAntiAlias);
 
+            regex = new Regex(@"ScissorTestEnable", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.ScissorTestEnable, regex);
+            Tokens.Add(TokenType.ScissorTestEnable);
+
             regex = new Regex(@"SlopeScaleDepthBias", RegexOptions.Compiled | RegexOptions.IgnoreCase);
             Patterns.Add(TokenType.SlopeScaleDepthBias, regex);
             Tokens.Add(TokenType.SlopeScaleDepthBias);
+
+            regex = new Regex(@"StencilEnable", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.StencilEnable, regex);
+            Tokens.Add(TokenType.StencilEnable);
+
+            regex = new Regex(@"StencilFail", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.StencilFail, regex);
+            Tokens.Add(TokenType.StencilFail);
+
+            regex = new Regex(@"StencilFunc", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.StencilFunc, regex);
+            Tokens.Add(TokenType.StencilFunc);
+
+            regex = new Regex(@"StencilMask", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.StencilMask, regex);
+            Tokens.Add(TokenType.StencilMask);
+
+            regex = new Regex(@"StencilPass", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.StencilPass, regex);
+            Tokens.Add(TokenType.StencilPass);
+
+            regex = new Regex(@"StencilRef", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.StencilRef, regex);
+            Tokens.Add(TokenType.StencilRef);
+
+            regex = new Regex(@"StencilWriteMask", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.StencilWriteMask, regex);
+            Tokens.Add(TokenType.StencilWriteMask);
+
+            regex = new Regex(@"StencilZFail", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.StencilZFail, regex);
+            Tokens.Add(TokenType.StencilZFail);
+
+            regex = new Regex(@"Never", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.Never, regex);
+            Tokens.Add(TokenType.Never);
+
+            regex = new Regex(@"Less", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.Less, regex);
+            Tokens.Add(TokenType.Less);
+
+            regex = new Regex(@"Equal", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.Equal, regex);
+            Tokens.Add(TokenType.Equal);
+
+            regex = new Regex(@"LessEqual", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.LessEqual, regex);
+            Tokens.Add(TokenType.LessEqual);
+
+            regex = new Regex(@"Greater", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.Greater, regex);
+            Tokens.Add(TokenType.Greater);
+
+            regex = new Regex(@"NotEqual", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.NotEqual, regex);
+            Tokens.Add(TokenType.NotEqual);
+
+            regex = new Regex(@"GreaterEqual", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.GreaterEqual, regex);
+            Tokens.Add(TokenType.GreaterEqual);
+
+            regex = new Regex(@"Always", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.Always, regex);
+            Tokens.Add(TokenType.Always);
+
+            regex = new Regex(@"Keep", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.Keep, regex);
+            Tokens.Add(TokenType.Keep);
+
+            regex = new Regex(@"Zero", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.Zero, regex);
+            Tokens.Add(TokenType.Zero);
+
+            regex = new Regex(@"Replace", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.Replace, regex);
+            Tokens.Add(TokenType.Replace);
+
+            regex = new Regex(@"IncrSat", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.IncrSat, regex);
+            Tokens.Add(TokenType.IncrSat);
+
+            regex = new Regex(@"DecrSat", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.DecrSat, regex);
+            Tokens.Add(TokenType.DecrSat);
+
+            regex = new Regex(@"Invert", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.Invert, regex);
+            Tokens.Add(TokenType.Invert);
+
+            regex = new Regex(@"Incr", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.Incr, regex);
+            Tokens.Add(TokenType.Incr);
+
+            regex = new Regex(@"Decr", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            Patterns.Add(TokenType.Decr, regex);
+            Tokens.Add(TokenType.Decr);
 
             regex = new Regex(@"Red", RegexOptions.Compiled | RegexOptions.IgnoreCase);
             Patterns.Add(TokenType.Red, regex);
@@ -353,10 +457,6 @@ namespace TwoMGFX
             regex = new Regex(@"Max", RegexOptions.Compiled | RegexOptions.IgnoreCase);
             Patterns.Add(TokenType.Max, regex);
             Tokens.Add(TokenType.Max);
-
-            regex = new Regex(@"Zero", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-            Patterns.Add(TokenType.Zero, regex);
-            Tokens.Add(TokenType.Zero);
 
             regex = new Regex(@"One", RegexOptions.Compiled | RegexOptions.IgnoreCase);
             Patterns.Add(TokenType.One, regex);
@@ -604,140 +704,193 @@ namespace TwoMGFX
             BlendOp_Min= 37,
             BlendOp_Max= 38,
             BlendOps= 39,
-            Render_State_CullMode= 40,
-            Render_State_FillMode= 41,
-            Render_State_AlphaBlendEnable= 42,
-            Render_State_SrcBlend= 43,
-            Render_State_DestBlend= 44,
-            Render_State_BlendOp= 45,
-            Render_State_ColorWriteEnable= 46,
-            Render_State_DepthBias= 47,
-            Render_State_SlopeScaleDepthBias= 48,
-            Render_State_ZEnable= 49,
-            Render_State_ZWriteEnable= 50,
-            Render_State_MultiSampleAntiAlias= 51,
-            Render_State_Expression= 52,
-            Pass_Declaration= 53,
-            VertexShader_Pass_Expression= 54,
-            PixelShader_Pass_Expression= 55,
-            AddressMode_Clamp= 56,
-            AddressMode_Wrap= 57,
-            AddressMode_Mirror= 58,
-            AddressMode_Border= 59,
-            AddressMode= 60,
-            TextureFilter_None= 61,
-            TextureFilter_Linear= 62,
-            TextureFilter_Point= 63,
-            TextureFilter_Anisotropic= 64,
-            TextureFilter= 65,
-            Sampler_State_Texture= 66,
-            Sampler_State_MinFilter= 67,
-            Sampler_State_MagFilter= 68,
-            Sampler_State_MipFilter= 69,
-            Sampler_State_Filter= 70,
-            Sampler_State_AddressU= 71,
-            Sampler_State_AddressV= 72,
-            Sampler_State_AddressW= 73,
-            Sampler_State_BorderColor= 74,
-            Sampler_State_MaxMipLevel= 75,
-            Sampler_State_MaxAnisotropy= 76,
-            Sampler_State_MipLodBias= 77,
-            Sampler_State_Expression= 78,
-            Sampler_Register_Expression= 79,
-            Sampler_Declaration= 80,
+            CmpFunc_Never= 40,
+            CmpFunc_Less= 41,
+            CmpFunc_Equal= 42,
+            CmpFunc_LessEqual= 43,
+            CmpFunc_Greater= 44,
+            CmpFunc_NotEqual= 45,
+            CmpFunc_GreaterEqual= 46,
+            CmpFunc_Always= 47,
+            CmpFunc = 48,
+            StencilOp_Keep= 49,
+            StencilOp_Zero= 50,
+            StencilOp_Replace= 51,
+            StencilOp_IncrSat= 52,
+            StencilOp_DecrSat= 53,
+            StencilOp_Invert= 54,
+            StencilOp_Incr= 55,
+            StencilOp_Decr= 56,
+            StencilOp= 57,
+            Render_State_CullMode= 58,
+            Render_State_FillMode= 59,
+            Render_State_AlphaBlendEnable= 60,
+            Render_State_SrcBlend= 61,
+            Render_State_DestBlend= 62,
+            Render_State_BlendOp= 63,
+            Render_State_ColorWriteEnable= 64,
+            Render_State_DepthBias= 65,
+            Render_State_SlopeScaleDepthBias= 66,
+            Render_State_ZEnable= 67,
+            Render_State_ZWriteEnable= 68,
+            Render_State_ZFunc= 69,
+            Render_State_MultiSampleAntiAlias= 70,
+            Render_State_ScissorTestEnable= 71,
+            Render_State_StencilEnable= 72,
+            Render_State_StencilFail= 73,
+            Render_State_StencilFunc= 74,
+            Render_State_StencilMask= 75,
+            Render_State_StencilPass= 76,
+            Render_State_StencilRef= 77,
+            Render_State_StencilWriteMask= 78,
+            Render_State_StencilZFail= 79,
+            Render_State_Expression= 80,
+            Pass_Declaration= 81,
+            VertexShader_Pass_Expression= 82,
+            PixelShader_Pass_Expression= 83,
+            AddressMode_Clamp= 84,
+            AddressMode_Wrap= 85,
+            AddressMode_Mirror= 86,
+            AddressMode_Border= 87,
+            AddressMode= 88,
+            TextureFilter_None= 89,
+            TextureFilter_Linear= 90,
+            TextureFilter_Point= 91,
+            TextureFilter_Anisotropic= 92,
+            TextureFilter= 93,
+            Sampler_State_Texture= 94,
+            Sampler_State_MinFilter= 95,
+            Sampler_State_MagFilter= 96,
+            Sampler_State_MipFilter= 97,
+            Sampler_State_Filter= 98,
+            Sampler_State_AddressU= 99,
+            Sampler_State_AddressV= 100,
+            Sampler_State_AddressW= 101,
+            Sampler_State_BorderColor= 102,
+            Sampler_State_MaxMipLevel= 103,
+            Sampler_State_MaxAnisotropy= 104,
+            Sampler_State_MipLodBias= 105,
+            Sampler_State_Expression= 106,
+            Sampler_Register_Expression= 107,
+            Sampler_Declaration= 108,
 
             //Terminal tokens:
-            BlockComment= 81,
-            Comment = 82,
-            Whitespace= 83,
-            LinePragma= 84,
-            Pass    = 85,
-            Technique= 86,
-            Sampler = 87,
-            SamplerState= 88,
-            VertexShader= 89,
-            PixelShader= 90,
-            Register= 91,
-            Boolean = 92,
-            Number  = 93,
-            HexColor= 94,
-            Identifier= 95,
-            OpenBracket= 96,
-            CloseBracket= 97,
-            Equals  = 98,
-            Colon   = 99,
-            Comma   = 100,
-            Semicolon= 101,
-            Or      = 102,
-            OpenParenthesis= 103,
-            CloseParenthesis= 104,
-            OpenSquareBracket= 105,
-            CloseSquareBracket= 106,
-            LessThan= 107,
-            GreaterThan= 108,
-            Compile = 109,
-            ShaderModel= 110,
-            Code    = 111,
-            EndOfFile= 112,
-            MinFilter= 113,
-            MagFilter= 114,
-            MipFilter= 115,
-            Filter  = 116,
-            Texture = 117,
-            AddressU= 118,
-            AddressV= 119,
-            AddressW= 120,
-            BorderColor= 121,
-            MaxAnisotropy= 122,
-            MaxMipLevel= 123,
-            MipLodBias= 124,
-            Clamp   = 125,
-            Wrap    = 126,
-            Mirror  = 127,
-            Border  = 128,
-            None    = 129,
-            Linear  = 130,
-            Point   = 131,
-            Anisotropic= 132,
-            AlphaBlendEnable= 133,
-            SrcBlend= 134,
-            DestBlend= 135,
-            BlendOp = 136,
-            ColorWriteEnable= 137,
-            ZEnable = 138,
-            ZWriteEnable= 139,
-            DepthBias= 140,
-            CullMode= 141,
-            FillMode= 142,
-            MultiSampleAntiAlias= 143,
-            SlopeScaleDepthBias= 144,
-            Red     = 145,
-            Green   = 146,
-            Blue    = 147,
-            Alpha   = 148,
-            All     = 149,
-            Cw      = 150,
-            Ccw     = 151,
-            Solid   = 152,
-            WireFrame= 153,
-            Add     = 154,
-            Subtract= 155,
-            RevSubtract= 156,
-            Min     = 157,
-            Max     = 158,
-            Zero    = 159,
-            One     = 160,
-            SrcColor= 161,
-            InvSrcColor= 162,
-            SrcAlpha= 163,
-            InvSrcAlpha= 164,
-            DestAlpha= 165,
-            InvDestAlpha= 166,
-            DestColor= 167,
-            InvDestColor= 168,
-            SrcAlphaSat= 169,
-            BlendFactor= 170,
-            InvBlendFactor= 171
+            BlockComment= 109,
+            Comment = 110,
+            Whitespace= 111,
+            LinePragma= 112,
+            Pass    = 113,
+            Technique= 114,
+            Sampler = 115,
+            SamplerState= 116,
+            VertexShader= 117,
+            PixelShader= 118,
+            Register= 119,
+            Boolean = 120,
+            Number  = 121,
+            HexColor= 122,
+            Identifier= 123,
+            OpenBracket= 124,
+            CloseBracket= 125,
+            Equals  = 126,
+            Colon   = 127,
+            Comma   = 128,
+            Semicolon= 129,
+            Or      = 130,
+            OpenParenthesis= 131,
+            CloseParenthesis= 132,
+            OpenSquareBracket= 133,
+            CloseSquareBracket= 134,
+            LessThan= 135,
+            GreaterThan= 136,
+            Compile = 137,
+            ShaderModel= 138,
+            Code    = 139,
+            EndOfFile= 140,
+            MinFilter= 141,
+            MagFilter= 142,
+            MipFilter= 143,
+            Filter  = 144,
+            Texture = 145,
+            AddressU= 146,
+            AddressV= 147,
+            AddressW= 148,
+            BorderColor= 149,
+            MaxAnisotropy= 150,
+            MaxMipLevel= 151,
+            MipLodBias= 152,
+            Clamp   = 153,
+            Wrap    = 154,
+            Mirror  = 155,
+            Border  = 156,
+            None    = 157,
+            Linear  = 158,
+            Point   = 159,
+            Anisotropic= 160,
+            AlphaBlendEnable= 161,
+            SrcBlend= 162,
+            DestBlend= 163,
+            BlendOp = 164,
+            ColorWriteEnable= 165,
+            ZEnable = 166,
+            ZWriteEnable= 167,
+            ZFunc   = 168,
+            DepthBias= 169,
+            CullMode= 170,
+            FillMode= 171,
+            MultiSampleAntiAlias= 172,
+            ScissorTestEnable= 173,
+            SlopeScaleDepthBias= 174,
+            StencilEnable= 175,
+            StencilFail= 176,
+            StencilFunc= 177,
+            StencilMask= 178,
+            StencilPass= 179,
+            StencilRef= 180,
+            StencilWriteMask= 181,
+            StencilZFail= 182,
+            Never   = 183,
+            Less    = 184,
+            Equal   = 185,
+            LessEqual= 186,
+            Greater = 187,
+            NotEqual= 188,
+            GreaterEqual= 189,
+            Always  = 190,
+            Keep    = 191,
+            Zero    = 192,
+            Replace = 193,
+            IncrSat = 194,
+            DecrSat = 195,
+            Invert  = 196,
+            Incr    = 197,
+            Decr    = 198,
+            Red     = 199,
+            Green   = 200,
+            Blue    = 201,
+            Alpha   = 202,
+            All     = 203,
+            Cw      = 204,
+            Ccw     = 205,
+            Solid   = 206,
+            WireFrame= 207,
+            Add     = 208,
+            Subtract= 209,
+            RevSubtract= 210,
+            Min     = 211,
+            Max     = 212,
+            One     = 213,
+            SrcColor= 214,
+            InvSrcColor= 215,
+            SrcAlpha= 216,
+            InvSrcAlpha= 217,
+            DestAlpha= 218,
+            InvDestAlpha= 219,
+            DestColor= 220,
+            InvDestColor= 221,
+            SrcAlphaSat= 222,
+            BlendFactor= 223,
+            InvBlendFactor= 224
     }
 
     public class Token


### PR DESCRIPTION
This PR adds some missing render states into the MGFX parsing (stencil, scissor test, zfunc).

It also fixes the MGFX defaults for sampler states to match XNA.

Fixes https://github.com/mono/MonoGame/issues/2641.
