### PR TITLE
Remove PipelineProject parameter from PipelineProject constractor

### DIFF
--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -68,14 +68,13 @@ namespace MonoGame.Tools.Pipeline
 
         public event Action OnBuildFinished;
 
-        public PipelineController(IView view, PipelineProject project)
+        public PipelineController(IView view)
         {
             _actionStack = new ActionStack();
             Selection = new Selection();
 
             View = view;
             View.Attach(this);
-            _project = project;
             ProjectOpen = false;
 
             _templateItems = new List<ContentItemTemplate>();

--- a/Tools/Pipeline/Program.cs
+++ b/Tools/Pipeline/Program.cs
@@ -34,8 +34,7 @@ namespace MonoGame.Tools.Pipeline
                 view.OpenProjectPath = projectFilePath;
             }
 
-            var model = new PipelineProject();
-            var controller = new PipelineController(view, model);   
+            var controller = new PipelineController(view);
             Application.Run(view);
 #endif
 #if LINUX || MONOMAC
@@ -43,8 +42,7 @@ namespace MonoGame.Tools.Pipeline
 			Gtk.Application.Init ();
 			MainWindow win = new MainWindow ();
 			win.Show (); 
-			var model = new PipelineProject();
-			new PipelineController(win, model);  
+			new PipelineController(win);
 			if (args != null && args.Length > 0)
 			{
 				var projectFilePath = string.Join(" ", args);


### PR DESCRIPTION
PipelineController creates a new PipelineProject on
.NewProject(),OpenProject(),ImportProject(), etc. You get this object
via IView.SetTreeRoot()
The initial PipelineProject is never used, the controller cannot be used
in that state (without initialized with one of the above methods)
because of ResolvedTypes(), importers,etc