### PR TITLE
[DX] Fix rounding error at SetClientBounds()

### DIFF
--- a/MonoGame.Framework/Windows8/MetroGameWindow.cs
+++ b/MonoGame.Framework/Windows8/MetroGameWindow.cs
@@ -174,10 +174,10 @@ namespace Microsoft.Xna.Framework
         private void SetClientBounds(double width, double height)
         {
             var dpi = DisplayProperties.LogicalDpi;
-            var pwidth = width * dpi / 96.0;
-            var pheight = height * dpi / 96.0;
+            var pwidth = (int)Math.Round(width * dpi / 96.0);
+            var pheight = (int)Math.Round(height * dpi / 96.0);
 
-            _clientBounds = new Rectangle(0, 0, (int)pwidth, (int)pheight);
+            _clientBounds = new Rectangle(0, 0, pwidth, pheight);
         }
 
         private void Window_SizeChanged(CoreWindow sender, WindowSizeChangedEventArgs args)


### PR DESCRIPTION
_clientBounds was 800x479 on a L620 device and 799x479 on the emulator.
After the fix _clientBounds is set to 800x480.