### PR TITLE
Allow MonoGame to be embedded inside GTK# applications (when using OpenTK)

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -1074,9 +1074,7 @@
     <Compile Include="Input\KeyboardUtil.OpenTK.cs">
       <Platforms>Angle,Linux,WindowsGL</Platforms>
     </Compile>
-    <Compile Include="Desktop\IEmbedContext.cs">
-      <Platforms>Angle,Linux,WindowsGL</Platforms>
-    </Compile>
+    <Compile Include="Desktop\IEmbedContext.cs" />
 
 
     <!-- iOS Platform -->

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -1074,6 +1074,9 @@
     <Compile Include="Input\KeyboardUtil.OpenTK.cs">
       <Platforms>Angle,Linux,WindowsGL</Platforms>
     </Compile>
+    <Compile Include="Desktop\IEmbedContext.cs">
+      <Platforms>Angle,Linux,WindowsGL</Platforms>
+    </Compile>
 
 
     <!-- iOS Platform -->

--- a/MonoGame.Framework/Desktop/IEmbedContext.cs
+++ b/MonoGame.Framework/Desktop/IEmbedContext.cs
@@ -1,0 +1,18 @@
+﻿namespace Microsoft.Xna.Framework
+{
+    public interface IEmbedContext
+    {
+#if (WINDOWS && OPENGL) || LINUX || ANGLE
+        OpenTK.Graphics.IGraphicsContext GraphicsContext { get; }
+
+        OpenTK.Platform.IWindowInfo WindowInfo { get; }
+
+        System.Drawing.Point PointToClient(System.Drawing.Point point);
+
+        Rectangle GetClientBounds();
+
+        event System.EventHandler OnResize;
+#endif
+    }
+}
+

--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -91,11 +91,11 @@ namespace Microsoft.Xna.Framework
         private Toolkit toolkit;
         private int isExiting; // int, so we can use Interlocked.Increment
         
-		public OpenTKGamePlatform(Game game)
+        public OpenTKGamePlatform(Game game, IEmbedContext embedContext)
             : base(game)
         {
             toolkit = Toolkit.Init();
-            _view = new OpenTKGameWindow(game);
+            _view = new OpenTKGameWindow(game, embedContext);
             this.Window = _view;
 
 			// Setup our OpenALSoundController to handle our SoundBuffer pools
@@ -174,13 +174,17 @@ namespace Microsoft.Xna.Framework
 
         public override void BeforeInitialize()
         {
-            _view.Window.Visible = true;
+            if (_view.Window != null)
+            {
+                _view.Window.Visible = true;
+            }
+
             base.BeforeInitialize();
         }
 
         public override bool BeforeUpdate(GameTime gameTime)
         {
-            IsActive = _view.Window.Focused;
+            IsActive = _view.Window == null || _view.Window.Focused;
 
             // Update our OpenAL sound buffer pools
             if (soundControllerInstance != null)
@@ -218,6 +222,13 @@ namespace Microsoft.Xna.Framework
 
             var graphicsDeviceManager = (GraphicsDeviceManager)
                 Game.Services.GetService(typeof(IGraphicsDeviceManager));
+
+            if (_view.Window == null)
+            {
+                // Embedded mode.
+                graphicsDeviceManager.PreferredBackBufferWidth = bounds.Width;
+                graphicsDeviceManager.PreferredBackBufferHeight = bounds.Height;
+            }
 
             if (graphicsDeviceManager.IsFullScreen)
             {

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -69,7 +69,11 @@ namespace Microsoft.Xna.Framework
             _components = new GameComponentCollection();
             _content = new ContentManager(_services);
 
+#if (WINDOWS && OPENGL) || LINUX || ANGLE
             Platform = GamePlatform.Create(this, embedContext);
+#else
+            Platform = GamePlatform.Create(this, null);
+#endif
             Platform.Activated += OnActivated;
             Platform.Deactivated += OnDeactivated;
             _services.AddService(typeof(GamePlatform), Platform);

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -55,8 +55,12 @@ namespace Microsoft.Xna.Framework
 
 
         private bool _suppressDraw;
-        
+
+#if (WINDOWS && OPENGL) || LINUX || ANGLE
+        public Game(IEmbedContext embedContext = null)
+#else
         public Game()
+#endif
         {
             _instance = this;
 
@@ -65,7 +69,7 @@ namespace Microsoft.Xna.Framework
             _components = new GameComponentCollection();
             _content = new ContentManager(_services);
 
-            Platform = GamePlatform.Create(this);
+            Platform = GamePlatform.Create(this, embedContext);
             Platform.Activated += OnActivated;
             Platform.Deactivated += OnDeactivated;
             _services.AddService(typeof(GamePlatform), Platform);

--- a/MonoGame.Framework/GamePlatform.cs
+++ b/MonoGame.Framework/GamePlatform.cs
@@ -26,14 +26,14 @@ namespace Microsoft.Xna.Framework
         #endregion
 
         #region Construction/Destruction
-        public static GamePlatform Create(Game game)
+        public static GamePlatform Create(Game game, IEmbedContext embedContext)
         {
 #if IOS
             return new iOSGamePlatform(game);
 #elif MONOMAC
             return new MacGamePlatform(game);
 #elif (WINDOWS && OPENGL) || LINUX || ANGLE
-            return new OpenTKGamePlatform(game);
+            return new OpenTKGamePlatform(game, embedContext);
 #elif ANDROID
             return new AndroidGamePlatform(game);
 #elif PSM

--- a/MonoGame.Framework/Input/Mouse.cs
+++ b/MonoGame.Framework/Input/Mouse.cs
@@ -69,12 +69,15 @@ namespace Microsoft.Xna.Framework.Input
 
         static OpenTK.INativeWindow Window;
 
+        static IEmbedContext EmbedContext;
+
         internal static void setWindows(GameWindow window)
         {
             PrimaryWindow = window;
             if (window is OpenTKGameWindow)
             {
                 Window = (window as OpenTKGameWindow).Window;
+                EmbedContext = (window as OpenTKGameWindow).EmbedContext;
             }
         }
 
@@ -134,9 +137,18 @@ namespace Microsoft.Xna.Framework.Input
 #elif (WINDOWS && OPENGL) || LINUX || ANGLE
 
             var state = OpenTK.Input.Mouse.GetCursorState();
-            var pc = ((OpenTKGameWindow)window).Window.PointToClient(new System.Drawing.Point(state.X, state.Y));
-            window.MouseState.X = pc.X;
-            window.MouseState.Y = pc.Y;
+            if (((OpenTKGameWindow)window).Window != null)
+            {
+                var pc = ((OpenTKGameWindow)window).Window.PointToClient(new System.Drawing.Point(state.X, state.Y));
+                window.MouseState.X = pc.X;
+                window.MouseState.Y = pc.Y;
+            }
+            else
+            {
+                var pc = EmbedContext.PointToClient(new System.Drawing.Point(state.X, state.Y));
+                window.MouseState.X = pc.X;
+                window.MouseState.Y = pc.Y;
+            }
 
             window.MouseState.LeftButton = (ButtonState)state.LeftButton;
             window.MouseState.RightButton = (ButtonState)state.RightButton;


### PR DESCRIPTION
This change allows MonoGame to be embedded inside GTK# applications when using OpenTK (so WindowsGL, Linux and Mac w/ Angle).  This is so that I can do this inside MonoDevelop:

![protogameeditor](https://cloud.githubusercontent.com/assets/504826/7005343/71f29df8-dcba-11e4-812c-252e75f03689.png)

This is done by implementing `IEmbedContext` in the main application and passing it to the game when creating it.

An example standalone implementation of the embed context (with just a normal `GLWidget` in a standard GTK# application) is:

```csharp
using System;
using Microsoft.Xna.Framework;
using Gtk;

namespace ProtogameEditor
{
    public class EditorHostEmbedContext : IEmbedContext
    {
        private Gtk.Widget _glWidget;

        public OpenTK.Graphics.IGraphicsContext GraphicsContext
        {
            get;
            set;
        }

        public OpenTK.Platform.IWindowInfo WindowInfo
        {
            get;
            set;
        }

        public Gtk.Widget GLWidget
        {
            get
            {
                return this._glWidget;
            }
            set
            {
                if (this._glWidget != null)
                {
                    this._glWidget.ConfigureEvent -= this.Resize;
                }

                this._glWidget = value;

                if (this._glWidget != null)
                {
                    this._glWidget.ConfigureEvent += this.Resize;
                }
            }
        }

        public System.Drawing.Point PointToClient(System.Drawing.Point point)
        {
            int x, y;
            if (this.GLWidget.GdkWindow == null)
            {
                return new System.Drawing.Point(0, 0);
            }

            this.GLWidget.GdkWindow.GetOrigin(out x, out y);
            return new System.Drawing.Point(
                point.X - x,
                point.Y - y);
        }

        public Rectangle GetClientBounds()
        {
            return new Rectangle(
                0,
                0,
                this.GLWidget.Allocation.Width,
                this.GLWidget.Allocation.Height);
        }

        public event System.EventHandler OnResize;

        public void Resize(object sender, ConfigureEventArgs e)
        {
            if (this.OnResize != null)
            {
                this.OnResize(this, new System.EventArgs());
            }
        }
    }
}
```

and then using it in an application like this (the dependency injection kernel is just passing in the EditorHostEmbedContext as the first argument to the game constructor):

```csharp
using Gtk;
using Protogame;
using Ninject;
using Microsoft.Xna.Framework;
using ProtogameEditor;

namespace ProtogameEditorHost
{
    public static class Program
    {
        public static void Main(string[] args)
        {
            Application.Init();

            var window = new HostWindow();
            window.Show();

            var editor = new IDEEditor();

            var kernel = editor.CreateEditorKernel<EditorHostEmbedContext>();

            var context = kernel.Get<IEmbedContext>();

            EditorGame game = null;

            while (true)
            {
                Application.RunIteration();

                if (window.GLWidget.WindowInfo != null && game == null)
                {
                    ((EditorHostEmbedContext)context).GraphicsContext = window.GLWidget.GraphicsContext;
                    ((EditorHostEmbedContext)context).WindowInfo = window.GLWidget.WindowInfo;
                    ((EditorHostEmbedContext)context).GLWidget = window.GLWidget;

                    game = new EditorGame(kernel);
                }

                if (game != null)
                {
                    game.RunOneFrame();
                }
            }
        }
    }
}
```