### PR TITLE
Windows 10 Support Pt.2

### DIFF
--- a/ProjectTemplates/VisualStudio2015/WindowsUAP/Application.csproj
+++ b/ProjectTemplates/VisualStudio2015/WindowsUAP/Application.csproj
@@ -116,27 +116,6 @@
     <Reference Include="MonoGame.Framework">
        <HintPath>$(MSBuildProgramFiles32)\MonoGame\v3.0\Assemblies\WindowsUAP\MonoGame.Framework.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX">
-       <HintPath>$(MSBuildProgramFiles32)\MonoGame\v3.0\Assemblies\WindowsUAP\SharpDX.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.XInput">
-       <HintPath>$(MSBuildProgramFiles32)\MonoGame\v3.0\Assemblies\WindowsUAP\SharpDX.XInput.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.Direct2D1">
-       <HintPath>$(MSBuildProgramFiles32)\MonoGame\v3.0\Assemblies\WindowsUAP\SharpDX.Direct2D1.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.Direct3D11">
-       <HintPath>$(MSBuildProgramFiles32)\MonoGame\v3.0\Assemblies\WindowsUAP\SharpDX.Direct3D11.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.DXGI">
-       <HintPath>$(MSBuildProgramFiles32)\MonoGame\v3.0\Assemblies\WindowsUAP\SharpDX.DXGI.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.MediaFoundation">
-       <HintPath>$(MSBuildProgramFiles32)\MonoGame\v3.0\Assemblies\WindowsUAP\SharpDX.MediaFoundation.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.XAudio2">
-       <HintPath>$(MSBuildProgramFiles32)\MonoGame\v3.0\Assemblies\WindowsUAP\SharpDX.XAudio2.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App.xaml.cs">

--- a/ProjectTemplates/VisualStudio2015/WindowsUAP/GamePage.xaml
+++ b/ProjectTemplates/VisualStudio2015/WindowsUAP/GamePage.xaml
@@ -8,15 +8,5 @@
     mc:Ignorable="d">
 
   <SwapChainPanel x:Name="swapChainPanel" />
-	
-  <Page.BottomAppBar>
-    <AppBar x:Name="bottomAppBar" Padding="10,0,10,0">
-      <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
-        <AppBarButton AutomationProperties.Name="Sample Button"
-                      AutomationProperties.AutomationId="SampleAppBarButton"
-                      Click="AppBarButton_Click"/>
-      </StackPanel>
-    </AppBar>
-  </Page.BottomAppBar>
-  
+	  
 </Page>

--- a/ProjectTemplates/VisualStudio2015/WindowsUAP/GamePage.xaml.cs
+++ b/ProjectTemplates/VisualStudio2015/WindowsUAP/GamePage.xaml.cs
@@ -33,8 +33,5 @@ namespace $safeprojectname$
             _game = MonoGame.Framework.XamlGame<Game1>.Create(launchArguments, Window.Current.CoreWindow, swapChainPanel);
 		}
 
-		private void AppBarButton_Click(object sender, RoutedEventArgs e)
-		{
-		}
 	}
 }

--- a/default.build
+++ b/default.build
@@ -5,6 +5,7 @@
   <property name="mdtooldir" value="/Applications/MonoDevelop.app/Contents/MacOS"/>
   <property name="psmtooldir" value="C:\Program Files (x86)\SCE\PSM\tools\PsmStudio\bin" />
   <property name="msbuild12dir" value="C:\Program Files (x86)\MSBuild\12.0\Bin" />
+  <property name="msbuild14dir" value="C:\Program Files (x86)\MSBuild\14.0\Bin" />
 
   <!-- Temporary work around so that we don't need to change the targets on the build server -->
   <target name="build" depends="build_code,run_tests,build_docs,build_installer" />
@@ -33,6 +34,7 @@
     <call target="build_windows8" />
     <call target="build_windowsphone" />
     <call target="build_windowsphone81" />
+    <call target="build_windows10" />
     <call target="build_psm" />
     <call target="build_web" />
     <call target="build_linux"/>
@@ -171,6 +173,16 @@
         <exec program="Protobuild" commandline="-generate WindowsPhone81" />
         <exec program="${msbuild12dir}\msbuild.exe " commandline='MonoGame.Framework.WindowsPhone81.sln /t:Clean /p:Configuration=Release /p:Platform="Any CPU"' />
         <exec program="${msbuild12dir}\msbuild.exe " commandline='MonoGame.Framework.WindowsPhone81.sln /t:Build /p:Configuration=Release /p:Platform="Any CPU"' />
+      </if>
+    </if>
+  </target>
+
+  <target name="build_windows10" description="Build Windows 10 UAP" depends="clean">
+    <if test="${os == 'Win32NT'}">
+      <if test="${file::exists('c:\Program Files (x86)\MSBuild\Microsoft\WindowsXaml\v14.0\Microsoft.Windows.UI.Xaml.CSharp.targets')}">
+        <exec program="Protobuild" commandline="-generate WindowsUAP" />
+        <exec program="${msbuild14dir}\msbuild.exe " commandline='MonoGame.Framework.WindowsUAP.sln /t:Clean /p:Configuration=Release /p:Platform="Any CPU"' />
+        <exec program="${msbuild14dir}\msbuild.exe " commandline='MonoGame.Framework.WindowsUAP.sln /t:Build /p:Configuration=Release /p:Platform="Any CPU"' />
       </if>
     </if>
   </target>


### PR DESCRIPTION
This PR cleans up the template project a bit removing some references to SharpDX and removing the unnecessary AppBar XAML.

We also added Win10 building into the build script.  It won't run until we get the Win10 build agent running.
