### PR TITLE
Do not call MakeCurrent if context is already current on iOS

### DIFF
--- a/MonoGame.Framework/iOS/iOSGameView.cs
+++ b/MonoGame.Framework/iOS/iOSGameView.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Xna.Framework {
 				_glapi = new Gles11Api ();
 			}
 
-			__renderbuffergraphicsContext.MakeCurrent (null);
+			this.MakeCurrent();
 		}
 
 		private void DestroyContext ()
@@ -205,10 +205,7 @@ namespace Microsoft.Xna.Framework {
 
 		private void CreateFramebuffer ()
 		{
-			AssertNotDisposed ();
-			AssertValidContext ();
-
-			__renderbuffergraphicsContext.MakeCurrent (null);
+			this.MakeCurrent();
 			
 			// HACK:  GraphicsDevice itself should be calling
 			//        glViewport, so we shouldn't need to do it
@@ -311,25 +308,26 @@ namespace Microsoft.Xna.Framework {
 		//        normal call to Present in Game.Tick should cover
 		//        this.  For now, iOSGamePlatform will call Present
 		//        in the Draw/Update loop handler.
-		[Obsolete("Remove iOSGameView.Present once GraphicsDevice.Present fully expresses this")]
 		public void Present ()
 		{
-			AssertNotDisposed ();
-			AssertValidContext ();
+            AssertNotDisposed ();
+            AssertValidContext ();
 
-			__renderbuffergraphicsContext.MakeCurrent (null);
+            this.MakeCurrent();
             GL.BindRenderbuffer (All.Renderbuffer, this._colorbuffer);
             __renderbuffergraphicsContext.SwapBuffers();
 		}
 
-		// FIXME: This functionality belongs iMakeCurrentn GraphicsDevice.
-		[Obsolete("Move the functionality of iOSGameView.MakeCurrent into GraphicsDevice")]
+		// FIXME: This functionality belongs in GraphicsDevice.
 		public void MakeCurrent ()
 		{
 			AssertNotDisposed ();
 			AssertValidContext ();
 
-			__renderbuffergraphicsContext.MakeCurrent (null);
+            if (!__renderbuffergraphicsContext.IsCurrent)
+            {
+			    __renderbuffergraphicsContext.MakeCurrent (null);
+            }
 		}
 
 		public override void LayoutSubviews ()


### PR DESCRIPTION
`GraphicsContext.MakeCurrent` is not free and doesn't test if the context is already current.

This change also removes the `Obsolete` attribute on the `MakeCurrent()` method: the comment is enough to convey what needs to be done here and doesn't generate superfluous warnings (the warning generated by such an attribute is misleading in this case).

Note: on Android, MonoGame does call `GraphicsContext.IsCurrent()` however there is a bug in the OpenTK implementation that will make it return false in all cases. A workaround is explained [here](http://stackoverflow.com/questions/3091937/call-to-check-if-a-current-eglcontext-exists-in-android) but requires to fix OpenTK. It might be possible to go around OpenTK though.