### PR TITLE
Windows 10 TextInput Support

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -240,7 +240,7 @@
       <Platforms>Windows8,WindowsPhone81</Platforms>
     </Compile>
     <Compile Include="TextInputEventArgs.cs">
-      <Platforms>Angle,Linux,MacOS,Windows,WindowsGL</Platforms>
+      <Platforms>Angle,Linux,MacOS,Windows,WindowsGL,WindowsUAP</Platforms>
     </Compile>
     <Compile Include="Threading.cs">
       <Platforms>Android,Angle,iOS,Linux,MacOS,Ouya,PSMobile,WindowsGL,WindowsPhone</Platforms>

--- a/MonoGame.Framework/GameWindow.cs
+++ b/MonoGame.Framework/GameWindow.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Xna.Framework {
 		public event EventHandler<EventArgs> OrientationChanged;
 		public event EventHandler<EventArgs> ScreenDeviceNameChanged;
 
-#if WINDOWS || LINUX || ANGLE
+#if WINDOWS || WINDOWS_UAP  || LINUX || ANGLE
 
         /// <summary>
 		/// Use this event to retrieve text for objects like textbox's.
@@ -139,7 +139,7 @@ namespace Microsoft.Xna.Framework {
 				ScreenDeviceNameChanged (this, EventArgs.Empty);
 		}
 
-#if WINDOWS || LINUX || ANGLE
+#if WINDOWS || WINDOWS_UAP || LINUX || ANGLE
 		protected void OnTextInput(object sender, TextInputEventArgs e)
 		{
 			if (TextInput != null)

--- a/MonoGame.Framework/WindowsUAP/UAPGameWindow.cs
+++ b/MonoGame.Framework/WindowsUAP/UAPGameWindow.cs
@@ -108,6 +108,8 @@ namespace Microsoft.Xna.Framework
 
             _coreWindow.Activated += Window_FocusChanged;
 
+			_coreWindow.CharacterReceived += Window_CharacterReceived;
+
             var bounds = _coreWindow.Bounds;
             SetClientBounds(bounds.Width, bounds.Height);
 
@@ -182,6 +184,11 @@ namespace Microsoft.Xna.Framework
             // the client size changed event.
             OnClientSizeChanged();
         }
+
+		private void Window_CharacterReceived(CoreWindow sender, CharacterReceivedEventArgs args)
+		{
+			OnTextInput(sender, new TextInputEventArgs((char)args.KeyCode));
+		}
 
         private static DisplayOrientation ToOrientation(DisplayOrientations orientations)
         {


### PR DESCRIPTION
This PR adds support for the `event GameWindow.TextInput` to the Windows 10 UAP platform.