### PR TITLE
Docs fixes

### DIFF
--- a/MonoGame.Framework/BoundingFrustum.cs
+++ b/MonoGame.Framework/BoundingFrustum.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Xna.Framework
         #region Properties
 
         /// <summary>
-        /// Gets or sets the <see cref="Matrix"/> of the frustum.
+        /// The transformation <see cref="Matrix"/> of this frustum.
         /// </summary>
         public Matrix Matrix
         {
@@ -123,7 +123,7 @@ namespace Microsoft.Xna.Framework
         #region Constructors
 
         /// <summary>
-        /// Creates a new instance of <see cref="BoundingFrustum"/> class.
+        /// Constructs a bounding frustum.
         /// </summary>
         /// <param name="value">Combined matrix which usually is (View * Projection).</param>
         public BoundingFrustum(Matrix value)

--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -16,6 +16,20 @@ namespace Microsoft.Xna.Framework
     [DebuggerDisplay("{DebugDisplayString,nq}")]
     public struct Color : IEquatable<Color>
     {
+        #region Private Fields
+
+        /// <summary>
+        /// ARGB.
+        /// </summary>
+        private uint _packedValue;
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Private static initializator for colors.
+        /// </summary>
         static Color()
         {
             TransparentBlack = new Color(0);
@@ -162,9 +176,7 @@ namespace Microsoft.Xna.Framework
             Yellow = new Color(0xff00ffff);
             YellowGreen = new Color(0xff32cd9a);
         }
-	// ARGB
-        private uint _packedValue;
-	  
+
         private Color(uint packedValue)
         {
             _packedValue = packedValue;
@@ -174,8 +186,8 @@ namespace Microsoft.Xna.Framework
 			//_packedValue = (packedValue & 0xff00ff00) | ((packedValue & 0x000000ff) << 16) | ((packedValue & 0x00ff0000) >> 16);
         }
 
-	/// <summary>
-        /// Creates a new instance of <see cref="Color"/> struct.
+        /// <summary>
+        /// Constructs a color.
         /// </summary>
         /// <param name="color">A <see cref="Vector4"/> representing color.</param>
         public Color(Vector4 color)
@@ -188,8 +200,8 @@ namespace Microsoft.Xna.Framework
             A = (byte)MathHelper.Clamp(color.W * 255, Byte.MinValue, Byte.MaxValue);
         }
 
-	/// <summary>
-        /// Creates a new instance of <see cref="Color"/> struct.
+        /// <summary>
+        /// Constructs a color.
         /// </summary>
         /// <param name="color">A <see cref="Vector3"/> representing color.</param>
         public Color(Vector3 color)
@@ -202,8 +214,8 @@ namespace Microsoft.Xna.Framework
             A = 255;
         }
 	
-	/// <summary>
-        /// Creates a new instance of <see cref="Color"/> struct.
+	    /// <summary>
+        /// Constructs a color.
         /// </summary>
         /// <param name="color">A <see cref="Color"/> for RGB values of new <see cref="Color"/> instance.</param>
         /// <param name="alpha">Alpha component value.</param>
@@ -216,9 +228,9 @@ namespace Microsoft.Xna.Framework
             B = color.B;
             A = (byte)MathHelper.Clamp(alpha, Byte.MinValue, Byte.MaxValue);
         }
-	
-	/// <summary>
-        /// Creates a new instance of <see cref="Color"/> struct.
+
+        /// <summary>
+        /// Constructs a color.
         /// </summary>
         /// <param name="color">A <see cref="Color"/> for RGB values of new <see cref="Color"/> instance.</param>
         /// <param name="alpha">Alpha component value.</param>
@@ -231,9 +243,9 @@ namespace Microsoft.Xna.Framework
             B = color.B;
             A = (byte)MathHelper.Clamp(alpha * 255, Byte.MinValue, Byte.MaxValue);
         }
-	
-	/// <summary>
-        /// Creates a new instance of <see cref="Color"/> struct.
+
+        /// <summary>
+        /// Constructs a color.
         /// </summary>
         /// <param name="r">Red component value.</param>
         /// <param name="g">Green component value.</param>
@@ -247,9 +259,9 @@ namespace Microsoft.Xna.Framework
             B = (byte)MathHelper.Clamp(b * 255, Byte.MinValue, Byte.MaxValue);
             A = 255;
         }
-	
-	/// <summary>
-        /// Creates a new instance of <see cref="Color"/> struct.
+
+        /// <summary>
+        /// Constructs a color.
         /// </summary>
         /// <param name="r">Red component value.</param>
         /// <param name="g">Green component value.</param>
@@ -263,8 +275,8 @@ namespace Microsoft.Xna.Framework
             A = (byte)255;
         }
 
-	/// <summary>
-        /// Creates a new instance of <see cref="Color"/> struct.
+        /// <summary>
+        /// Constructs a color.
         /// </summary>
         /// <param name="r">Red component value.</param>
         /// <param name="g">Green component value.</param>
@@ -278,9 +290,9 @@ namespace Microsoft.Xna.Framework
             B = (byte)MathHelper.Clamp(b, Byte.MinValue, Byte.MaxValue);
             A = (byte)MathHelper.Clamp(alpha, Byte.MinValue, Byte.MaxValue);
         }
-	
-	/// <summary>
-        /// Creates a new instance of <see cref="Color"/> struct.
+
+        /// <summary>
+        /// Constructs a color.
         /// </summary>
         /// <param name="r">Red component value.</param>
         /// <param name="g">Green component value.</param>
@@ -296,8 +308,31 @@ namespace Microsoft.Xna.Framework
             A = (byte)MathHelper.Clamp(alpha * 255, Byte.MinValue, Byte.MaxValue);
         }
 
+        #endregion
+
+        #region Public Properties
+
         /// <summary>
-        /// Gets or sets the blue component.
+        /// The alpha component of this color.
+        /// </summary>
+        [DataMember]
+        public byte A
+        {
+            get
+            {
+                unchecked
+                {
+                    return (byte)(this._packedValue >> 24);
+                }
+            }
+            set
+            {
+                this._packedValue = (this._packedValue & 0x00ffffff) | ((uint)value << 24);
+            }
+        }
+
+        /// <summary>
+        /// The blue component of this color.
         /// </summary>
         [DataMember]
         public byte B
@@ -316,7 +351,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Gets or sets the green component.
+        /// The green component of this color.
         /// </summary>
         [DataMember]
         public byte G
@@ -335,7 +370,17 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Gets or sets the red component.
+        /// The packed value of this color.
+        /// </summary>
+        [CLSCompliant(false)]
+        public uint PackedValue
+        {
+            get { return _packedValue; }
+            set { _packedValue = value; }
+        }
+
+        /// <summary>
+        /// The red component of this color.
         /// </summary>
         [DataMember]
         public byte R
@@ -353,70 +398,8 @@ namespace Microsoft.Xna.Framework
             }
         }
 
-        /// <summary>
-        /// Gets or sets the alpha component.
-        /// </summary>
-        [DataMember]
-        public byte A
-        {
-            get
-            {
-                unchecked
-                {
-                    return (byte)(this._packedValue >> 24);
-                }
-            }
-            set
-            {
-                this._packedValue = (this._packedValue & 0x00ffffff) | ((uint)value << 24);
-            }
-        }
-		
-	/// <summary>
-        /// Compares whether two <see cref="Color"/> instances are equal.
-        /// </summary>
-        /// <param name="a"><see cref="Color"/> instance on the left of the equal sign.</param>
-        /// <param name="b"><see cref="Color"/> instance on the right of the equal sign.</param>
-        /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
-        public static bool operator ==(Color a, Color b)
-        {
-            return (a.A == b.A &&
-                a.R == b.R &&
-                a.G == b.G &&
-                a.B == b.B);
-        }
-	
-	/// <summary>
-        /// Compares whether two <see cref="Color"/> instances are not equal.
-        /// </summary>
-        /// <param name="a"><see cref="Color"/> instance on the left of the not equal sign.</param>
-        /// <param name="b"><see cref="Color"/> instance on the right of the not equal sign.</param>
-        /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>	
-        public static bool operator !=(Color a, Color b)
-        {
-            return !(a == b);
-        }
-
-        /// <summary>
-        /// Gets the hash code of this <see cref="Color"/>.
-        /// </summary>
-        /// <returns>Hash code of this <see cref="Color"/>.</returns>
-        public override int GetHashCode()
-        {
-            return this._packedValue.GetHashCode();
-        }
-	
-        /// <summary>
-        /// Compares whether current instance is equal to specified object.
-        /// </summary>
-        /// <param name="obj">The <see cref="Color"/> to compare.</param>
-        /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
-        public override bool Equals(object obj)
-        {
-            return ((obj is Color) && this.Equals((Color)obj));
-        }
-
         #region Color Bank
+
         /// <summary>
         /// TransparentBlack color (R:0,G:0,B:0,A:0).
         /// </summary>
@@ -425,7 +408,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// Transparent color (R:0,G:0,B:0,A:0).
         /// </summary>
@@ -434,8 +417,8 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-	
-	/// <summary>
+
+        /// <summary>
         /// AliceBlue color (R:240,G:248,B:255,A:255).
         /// </summary>
         public static Color AliceBlue
@@ -443,7 +426,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// AntiqueWhite color (R:250,G:235,B:215,A:255).
         /// </summary>
@@ -452,43 +435,43 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// Aqua color (R:0,G:255,B:255,A:255).
         /// </summary>
-	public static Color Aqua
+        public static Color Aqua
         {
             get;
             private set;
         }
-	
-	/// <summary>
+
+        /// <summary>
         /// Aquamarine color (R:127,G:255,B:212,A:255).
         /// </summary>
         public static Color Aquamarine
-    {
-        get;
-        private set;
-    }
-        
-        /// <summary>
-        /// Azure color (R:240,G:255,B:255,A:255).
-        /// </summary>
-	public static Color Azure
         {
             get;
             private set;
         }
-	
-	/// <summary>
+
+        /// <summary>
+        /// Azure color (R:240,G:255,B:255,A:255).
+        /// </summary>
+        public static Color Azure
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
         /// Beige color (R:245,G:245,B:220,A:255).
         /// </summary>
         public static Color Beige
-    {
-        get;
-        private set;
-    }
-        
+        {
+            get;
+            private set;
+        }
+
         /// <summary>
         /// Bisque color (R:255,G:228,B:196,A:255).
         /// </summary>
@@ -497,7 +480,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// Black color (R:0,G:0,B:0,A:255).
         /// </summary>
@@ -506,7 +489,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// BlanchedAlmond color (R:255,G:235,B:205,A:255).
         /// </summary>
@@ -515,7 +498,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// Blue color (R:0,G:0,B:255,A:255).
         /// </summary>
@@ -524,7 +507,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// BlueViolet color (R:138,G:43,B:226,A:255).
         /// </summary>
@@ -533,7 +516,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// Brown color (R:165,G:42,B:42,A:255).
         /// </summary>
@@ -542,7 +525,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// BurlyWood color (R:222,G:184,B:135,A:255).
         /// </summary>
@@ -551,7 +534,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// CadetBlue color (R:95,G:158,B:160,A:255).
         /// </summary>
@@ -560,7 +543,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// Chartreuse color (R:127,G:255,B:0,A:255).
         /// </summary>
@@ -569,7 +552,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-         
+
         /// <summary>
         /// Chocolate color (R:210,G:105,B:30,A:255).
         /// </summary>
@@ -578,7 +561,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// Coral color (R:255,G:127,B:80,A:255).
         /// </summary>
@@ -587,7 +570,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// CornflowerBlue color (R:100,G:149,B:237,A:255).
         /// </summary>
@@ -596,25 +579,25 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// Cornsilk color (R:255,G:248,B:220,A:255).
         /// </summary>
-	public static Color Cornsilk
+        public static Color Cornsilk
         {
             get;
             private set;
         }
-	
-	/// <summary>
+
+        /// <summary>
         /// Crimson color (R:220,G:20,B:60,A:255).
         /// </summary>
         public static Color Crimson
-    {
-        get;
-        private set;
-    }
-        
+        {
+            get;
+            private set;
+        }
+
         /// <summary>
         /// Cyan color (R:0,G:255,B:255,A:255).
         /// </summary>
@@ -623,25 +606,25 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// DarkBlue color (R:0,G:0,B:139,A:255).
         /// </summary>
-	public static Color DarkBlue
+        public static Color DarkBlue
         {
             get;
             private set;
         }
-	
-	/// <summary>
+
+        /// <summary>
         /// DarkCyan color (R:0,G:139,B:139,A:255).
         /// </summary>
         public static Color DarkCyan
-    {
-        get;
-        private set;
-    }
-        
+        {
+            get;
+            private set;
+        }
+
         /// <summary>
         /// DarkGoldenrod color (R:184,G:134,B:11,A:255).
         /// </summary>
@@ -650,25 +633,25 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// DarkGray color (R:169,G:169,B:169,A:255).
         /// </summary>
-	public static Color DarkGray
+        public static Color DarkGray
         {
             get;
             private set;
         }
-	
-	/// <summary>
+
+        /// <summary>
         /// DarkGreen color (R:0,G:100,B:0,A:255).
         /// </summary>
         public static Color DarkGreen
-    {
-        get;
-        private set;
-    }
-        
+        {
+            get;
+            private set;
+        }
+
         /// <summary>
         /// DarkKhaki color (R:189,G:183,B:107,A:255).
         /// </summary>
@@ -722,8 +705,8 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
-	/// <summary>
+
+        /// <summary>
         /// DarkSalmon color (R:233,G:150,B:122,A:255).
         /// </summary>
         public static Color DarkSalmon
@@ -776,7 +759,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-         
+
         /// <summary>
         /// DeepPink color (R:255,G:20,B:147,A:255).
         /// </summary>
@@ -839,8 +822,8 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
-	/// <summary>
+
+        /// <summary>
         /// Fuchsia color (R:255,G:0,B:255,A:255).
         /// </summary>
         public static Color Fuchsia
@@ -928,7 +911,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// IndianRed color (R:205,G:92,B:92,A:255).
         /// </summary>
@@ -937,7 +920,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// Indigo color (R:75,G:0,B:130,A:255).
         /// </summary>
@@ -946,7 +929,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// Ivory color (R:255,G:255,B:240,A:255).
         /// </summary>
@@ -955,7 +938,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// Khaki color (R:240,G:230,B:140,A:255).
         /// </summary>
@@ -964,7 +947,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// Lavender color (R:230,G:230,B:250,A:255).
         /// </summary>
@@ -973,7 +956,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// LavenderBlush color (R:255,G:240,B:245,A:255).
         /// </summary>
@@ -982,7 +965,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// LawnGreen color (R:124,G:252,B:0,A:255).
         /// </summary>
@@ -1018,7 +1001,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// LightCyan color (R:224,G:255,B:255,A:255).
         /// </summary>
@@ -1036,7 +1019,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// LightGray color (R:211,G:211,B:211,A:255).
         /// </summary>
@@ -1486,7 +1469,7 @@ namespace Microsoft.Xna.Framework
             private set;
         }
 
-    	/// <summary>
+        /// <summary>
         /// SaddleBrown color (R:139,G:69,B:19,A:255).
         /// </summary>
         public static Color SaddleBrown
@@ -1494,7 +1477,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-    	 
+
         /// <summary>
         /// Salmon color (R:250,G:128,B:114,A:255).
         /// </summary>
@@ -1503,7 +1486,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// SandyBrown color (R:244,G:164,B:96,A:255).
         /// </summary>
@@ -1512,7 +1495,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// SeaGreen color (R:46,G:139,B:87,A:255).
         /// </summary>
@@ -1521,8 +1504,8 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
-    	/// <summary>
+
+        /// <summary>
         /// SeaShell color (R:255,G:245,B:238,A:255).
         /// </summary>
         public static Color SeaShell
@@ -1530,8 +1513,8 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
-    	/// <summary>
+
+        /// <summary>
         /// Sienna color (R:160,G:82,B:45,A:255).
         /// </summary>
         public static Color Sienna
@@ -1539,8 +1522,8 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
-    	/// <summary>
+
+        /// <summary>
         /// Silver color (R:192,G:192,B:192,A:255).
         /// </summary>
         public static Color Silver
@@ -1548,25 +1531,25 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
-       /// <summary>
-       /// SkyBlue color (R:135,G:206,B:235,A:255).
-       /// </summary>
-       public static Color SkyBlue
+
+        /// <summary>
+        /// SkyBlue color (R:135,G:206,B:235,A:255).
+        /// </summary>
+        public static Color SkyBlue
         {
             get;
             private set;
         }
-       
+
         /// <summary>
         /// SlateBlue color (R:106,G:90,B:205,A:255).
         /// </summary>
         public static Color SlateBlue
-       {
-           get;
-           private set;
-       }
-      
+        {
+            get;
+            private set;
+        }
+
         /// <summary>
         /// SlateGray color (R:112,G:128,B:144,A:255).
         /// </summary>
@@ -1575,7 +1558,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-      
+
         /// <summary>
         /// Snow color (R:255,G:250,B:250,A:255).
         /// </summary>
@@ -1584,7 +1567,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-      
+
         /// <summary>
         /// SpringGreen color (R:0,G:255,B:127,A:255).
         /// </summary>
@@ -1593,7 +1576,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-      
+
         /// <summary>
         /// SteelBlue color (R:70,G:130,B:180,A:255).
         /// </summary>
@@ -1602,7 +1585,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-      
+
         /// <summary>
         /// Tan color (R:210,G:180,B:140,A:255).
         /// </summary>
@@ -1611,7 +1594,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-       
+
         /// <summary>
         /// Teal color (R:0,G:128,B:128,A:255).
         /// </summary>
@@ -1620,7 +1603,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-       
+
         /// <summary>
         /// Thistle color (R:216,G:191,B:216,A:255).
         /// </summary>
@@ -1629,7 +1612,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-       
+
         /// <summary>
         /// Tomato color (R:255,G:99,B:71,A:255).
         /// </summary>
@@ -1638,8 +1621,8 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
-    	/// <summary>
+
+        /// <summary>
         /// Turquoise color (R:64,G:224,B:208,A:255).
         /// </summary>
         public static Color Turquoise
@@ -1647,7 +1630,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// Violet color (R:238,G:130,B:238,A:255).
         /// </summary>
@@ -1656,25 +1639,25 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// Wheat color (R:245,G:222,B:179,A:255).
         /// </summary>
-	public static Color Wheat
+        public static Color Wheat
         {
             get;
             private set;
         }
-	
+
         /// <summary>
         /// White color (R:255,G:255,B:255,A:255).
         /// </summary>
         public static Color White
-    {
-        get;
-        private set;
-    }
-       
+        {
+            get;
+            private set;
+        }
+
         /// <summary>
         /// WhiteSmoke color (R:245,G:245,B:245,A:255).
         /// </summary>
@@ -1683,7 +1666,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// Yellow color (R:255,G:255,B:0,A:255).
         /// </summary>
@@ -1692,7 +1675,7 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
-        
+
         /// <summary>
         /// YellowGreen color (R:154,G:205,B:50,A:255).
         /// </summary>
@@ -1701,75 +1684,12 @@ namespace Microsoft.Xna.Framework
             get;
             private set;
         }
+
         #endregion
 
-        /// <summary>
-        /// Performs linear interpolation of <see cref="Color"/>.
-        /// </summary>
-        /// <param name="value1">Source <see cref="Color"/>.</param>
-        /// <param name="value2">Destination <see cref="Color"/>.</param>
-        /// <param name="amount">Interpolation factor.</param>
-        /// <returns>Interpolated <see cref="Color"/>.</returns>
-        public static Color Lerp(Color value1, Color value2, Single amount)
-        {
-			amount = MathHelper.Clamp(amount, 0, 1);
-            return new Color(   
-                (int)MathHelper.Lerp(value1.R, value2.R, amount),
-                (int)MathHelper.Lerp(value1.G, value2.G, amount),
-                (int)MathHelper.Lerp(value1.B, value2.B, amount),
-                (int)MathHelper.Lerp(value1.A, value2.A, amount) );
-        }
-		
-	/// <summary>
-        /// Multiply <see cref="Color"/> by value.
-        /// </summary>
-        /// <param name="value">Source <see cref="Color"/>.</param>
-        /// <param name="scale">Multiplicator.</param>
-        /// <returns>Multiplication result.</returns>
-	public static Color Multiply(Color value, float scale)
-	{
-	    return new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
-	}
-	
-	/// <summary>
-        /// Multiply <see cref="Color"/> by value.
-        /// </summary>
-        /// <param name="value">Source <see cref="Color"/>.</param>
-        /// <param name="scale">Multiplicator.</param>
-        /// <returns>Multiplication result.</returns>
-	public static Color operator *(Color value, float scale)
-        {
-            return new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
-        }
+        #endregion
 
-        /// <summary>
-        /// Returns the color in a 0-to-1 normalized <see cref="Vector3"/> format.
-        /// </summary>
-        /// <returns>A <see cref="Vector3"/> representation for this object.</returns>
-        public Vector3 ToVector3()
-        {
-            return new Vector3(R / 255.0f, G / 255.0f, B / 255.0f);
-        }
-
-        /// <summary>
-        /// Returns the color in a 0-to-1 normalized <see cref="Vector4"/> format.
-        /// </summary>
-        /// <returns>A <see cref="Vector4"/> representation for this object.</returns>
-        public Vector4 ToVector4()
-        {
-            return new Vector4(R / 255.0f, G / 255.0f, B / 255.0f, A / 255.0f);
-        }
-	
-	/// <summary>
-        /// Gets or sets packed value of this <see cref="Color"/>.
-        /// </summary>
-        [CLSCompliant(false)]
-        public UInt32 PackedValue
-        {
-            get { return _packedValue; }
-            set { _packedValue = value; }
-        }
-
+        #region Internal Properties
 
         internal string DebugDisplayString
         {
@@ -1784,28 +1704,71 @@ namespace Microsoft.Xna.Framework
             }
         }
 
+        #endregion
+
+        #region Operators
 
         /// <summary>
-        /// Returns a <see cref="String"/> representation of this <see cref="Color"/> in the format:
-        /// {R:[red] G:[green] B:[blue] A:[alpha]}
+        /// Multiplies the components of color by a scalar.
         /// </summary>
-        /// <returns><see cref="String"/> representation of this <see cref="Color"/>.</returns>
-	public override string ToString ()
-	{
-        StringBuilder sb = new StringBuilder(25);
-        sb.Append("{R:");
-        sb.Append(R);
-        sb.Append(" G:");
-        sb.Append(G);
-        sb.Append(" B:");
-        sb.Append(B);
-        sb.Append(" A:");
-        sb.Append(A);
-        sb.Append("}");
-        return sb.ToString();
-	}
+        /// <param name="value">Source <see cref="Vector2"/> on the left of the mul sign.</param>
+        /// <param name="scale">Scalar value on the right of the mul sign.</param>
+        /// <returns>>Result of the color multiplication with a scalar.</returns>
+        public static Color operator *(Color value, float scale)
+        {
+            return new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
+        }
+
+        /// <summary>
+        /// Compares whether two <see cref="Color"/> instances are equal.
+        /// </summary>
+        /// <param name="a"><see cref="Color"/> instance on the left of the equal sign.</param>
+        /// <param name="b"><see cref="Color"/> instance on the right of the equal sign.</param>
+        /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        public static bool operator ==(Color a, Color b)
+        {
+            return (a.A == b.A &&
+                a.R == b.R &&
+                a.G == b.G &&
+                a.B == b.B);
+        }
 	
-	/// <summary>
+	    /// <summary>
+        /// Compares whether two <see cref="Color"/> instances are not equal.
+        /// </summary>
+        /// <param name="a"><see cref="Color"/> instance on the left of the not equal sign.</param>
+        /// <param name="b"><see cref="Color"/> instance on the right of the not equal sign.</param>
+        /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>	
+        public static bool operator !=(Color a, Color b)
+        {
+            return !(a == b);
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Compares whether current instance is equal to specified object.
+        /// </summary>
+        /// <param name="obj">The <see cref="Object"/> to compare.</param>
+        /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        public override bool Equals(object obj)
+        {
+            return ((obj is Color) && this.Equals((Color)obj));
+        }
+
+        /// <summary>
+        /// Compares whether current instance is equal to specified <see cref="Color"/>.
+        /// </summary>
+        /// <param name="other">The <see cref="Color"/> to compare.</param>
+        /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        public bool Equals(Color other)
+        {
+            return this.PackedValue == other.PackedValue;
+        }
+
+        /// <summary>
         /// Translate a non-premultipled alpha <see cref="Color"/> to a <see cref="Color"/> that contains premultiplied alpha.
         /// </summary>
         /// <param name="vector">A <see cref="Vector4"/> representing color.</param>
@@ -1814,8 +1777,8 @@ namespace Microsoft.Xna.Framework
         {
             return new Color(vector.X * vector.W, vector.Y * vector.W, vector.Z * vector.W, vector.W);
         }
-	
-	/// <summary>
+
+        /// <summary>
         /// Translate a non-premultipled alpha <see cref="Color"/> to a <see cref="Color"/> that contains premultiplied alpha.
         /// </summary>
         /// <param name="r">Red component value.</param>
@@ -1825,19 +1788,82 @@ namespace Microsoft.Xna.Framework
         /// <returns>A <see cref="Color"/> which contains premultiplied alpha data.</returns>
         public static Color FromNonPremultiplied(int r, int g, int b, int a)
         {
-            return new Color((byte)(r * a / 255),(byte)(g * a / 255), (byte)(b * a / 255), a);
+            return new Color((byte)(r * a / 255), (byte)(g * a / 255), (byte)(b * a / 255), a);
         }
 
-        #region IEquatable<Color> Members
-	
-	/// <summary>
-        /// Compares whether current instance is equal to specified <see cref="Color"/>.
+        /// <summary>
+        /// Gets the hash code of this <see cref="Color"/>.
         /// </summary>
-        /// <param name="other">The <see cref="Color"/> to compare.</param>
-        /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
-        public bool Equals(Color other)
+        /// <returns>Hash code of this <see cref="Color"/>.</returns>
+        public override int GetHashCode()
         {
-	    return this.PackedValue == other.PackedValue;
+            return this._packedValue.GetHashCode();
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Color"/> that contains linear interpolation of the colors.
+        /// </summary>
+        /// <param name="value1">The first <see cref="Color"/>.</param>
+        /// <param name="value2">The second <see cref="Color"/>.</param>
+        /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
+        /// <returns>Interpolated <see cref="Color"/>.</returns>
+        public static Color Lerp(Color value1, Color value2, Single amount)
+        {
+            amount = MathHelper.Clamp(amount, 0, 1);
+            return new Color(
+                (int)MathHelper.Lerp(value1.R, value2.R, amount),
+                (int)MathHelper.Lerp(value1.G, value2.G, amount),
+                (int)MathHelper.Lerp(value1.B, value2.B, amount),
+                (int)MathHelper.Lerp(value1.A, value2.A, amount));
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Color"/> that contains a multiplication of <see cref="Color"/> and a scalar.
+        /// </summary>
+        /// <param name="value">Source <see cref="Color"/>.</param>
+        /// <param name="scale">Scalar value.</param>
+        /// <returns>Result of the color multiplication with a scalar.</returns>
+        public static Color Multiply(Color value, float scale)
+        {
+            return new Color((int)(value.R * scale), (int)(value.G * scale), (int)(value.B * scale), (int)(value.A * scale));
+        }
+
+        /// <summary>
+        /// Returns a <see cref="String"/> representation of this <see cref="Color"/> in the format:
+        /// {R:[red] G:[green] B:[blue] A:[alpha]}
+        /// </summary>
+        /// <returns><see cref="String"/> representation of this <see cref="Color"/>.</returns>
+        public override string ToString()
+        {
+            var sb = new StringBuilder(25);
+            sb.Append("{R:");
+            sb.Append(R);
+            sb.Append(" G:");
+            sb.Append(G);
+            sb.Append(" B:");
+            sb.Append(B);
+            sb.Append(" A:");
+            sb.Append(A);
+            sb.Append("}");
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Gets a <see cref="Vector3"/> representation for this object.
+        /// </summary>
+        /// <returns>A <see cref="Vector3"/> representation for this object.</returns>
+        public Vector3 ToVector3()
+        {
+            return new Vector3(R / 255.0f, G / 255.0f, B / 255.0f);
+        }
+
+        /// <summary>
+        /// Gets a <see cref="Vector4"/> representation for this object.
+        /// </summary>
+        /// <returns>A <see cref="Vector3"/> representation for this object.</returns>
+        public Vector4 ToVector4()
+        {
+            return new Vector4(R / 255.0f, G / 255.0f, B / 255.0f, A / 255.0f);
         }
 
         #endregion

--- a/MonoGame.Framework/Curve.cs
+++ b/MonoGame.Framework/Curve.cs
@@ -3,7 +3,6 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.ComponentModel;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
@@ -35,7 +34,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Gets the collection of curve keys.
+        /// The collection of curve keys.
         /// </summary>
         [DataMember]
         public CurveKeyCollection Keys
@@ -44,7 +43,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Gets or sets how to handle weighting values that are greater than the last control point in the curve.
+        /// A <see cref="CurveLoopType"/> which controls how to handle weighting values that are greater than the last control point in the curve.
         /// </summary>
         [DataMember]
         public CurveLoopType PostLoop
@@ -54,7 +53,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Gets or sets how to handle weighting values that are less than the first control point in the curve.
+        /// A <see cref="CurveLoopType"/> which controls how to handle weighting values that are less than the first control point in the curve.
         /// </summary>
         [DataMember]
         public CurveLoopType PreLoop
@@ -68,7 +67,7 @@ namespace Microsoft.Xna.Framework
         #region Public Constructors
 
         /// <summary>
-        /// Creates a new instance of <see cref="Curve"/> class.
+        /// Constructs a curve.
         /// </summary>
         public Curve()
         {

--- a/MonoGame.Framework/Graphics/Viewport.cs
+++ b/MonoGame.Framework/Graphics/Viewport.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
         /// <summary>
-        /// Creates a new instance of <see cref="Viewport"/> struct.
+        /// Constructs a viewport.
         /// </summary>
         /// <param name="x">The x coordinate of the upper-left corner of the view bounds in pixels.</param>
         /// <param name="y">The y coordinate of the upper-left corner of the view bounds in pixels.</param>
@@ -175,7 +175,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
         /// <summary>
-        /// Creates a new instance of <see cref="Viewport"/> struct.
+        /// Constructs a viewport.
         /// </summary>
         /// <param name="x">The x coordinate of the upper-left corner of the view bounds in pixels.</param>
         /// <param name="y">The y coordinate of the upper-left corner of the view bounds in pixels.</param>

--- a/MonoGame.Framework/Point.cs
+++ b/MonoGame.Framework/Point.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Xna.Framework
     {
         #region Private Fields
 
-        private static Point zeroPoint = new Point();
+        private static readonly Point zeroPoint = new Point();
 
         #endregion
 
@@ -67,7 +67,7 @@ namespace Microsoft.Xna.Framework
         #region Constructors
 
         /// <summary>
-        /// Creates a new instance of <see cref="Point"/> struct, with the specified position.
+        /// Constructs a point.
         /// </summary>
         /// <param name="x">The x coordinate in 2d-space.</param>
         /// <param name="y">The y coordinate in 2d-space.</param>
@@ -78,7 +78,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new instance of <see cref="Point"/> struct, with the specified position.
+        /// Constructs a point.
         /// </summary>
         /// <param name="value">The x and y coordinates in 2d-space.</param>
         public Point(int value)
@@ -201,9 +201,9 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Gets a two-component <see cref="Vector2"/> representation for this object.
+        /// Gets a <see cref="Vector2"/> representation for this object.
         /// </summary>
-        /// <returns>A two-component <see cref="Vector2"/> representation for this object.</returns>
+        /// <returns>A <see cref="Vector2"/> representation for this object.</returns>
         public Vector2 ToVector2()
         {
             return new Vector2(X, Y);

--- a/MonoGame.Framework/Rectangle.cs
+++ b/MonoGame.Framework/Rectangle.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Xna.Framework
     {
         #region Private Fields
 
-        private static Rectangle emptyRectangle = new Rectangle();
+        private static readonly Rectangle emptyRectangle = new Rectangle();
 
         #endregion
 
@@ -172,8 +172,7 @@ namespace Microsoft.Xna.Framework
         #region Constructors
 
         /// <summary>
-        /// Creates a new instance of <see cref="Rectangle"/> struct, with the specified
-        /// position, width, and height.
+        /// Constructs a rectangle.
         /// </summary>
         /// <param name="x">The x coordinate of the top-left corner of the created <see cref="Rectangle"/>.</param>
         /// <param name="y">The y coordinate of the top-left corner of the created <see cref="Rectangle"/>.</param>
@@ -188,8 +187,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new instance of <see cref="Rectangle"/> struct, with the specified
-        /// location and size.
+        /// Constructs a rectangle.
         /// </summary>
         /// <param name="location">The x and y coordinates of the top-left corner of the created <see cref="Rectangle"/>.</param>
         /// <param name="size">The width and height of the created <see cref="Rectangle"/>.</param>

--- a/MonoGame.Framework/Vector2.cs
+++ b/MonoGame.Framework/Vector2.cs
@@ -20,10 +20,10 @@ namespace Microsoft.Xna.Framework
     {
         #region Private Fields
 
-        private static Vector2 zeroVector = new Vector2(0f, 0f);
-        private static Vector2 unitVector = new Vector2(1f, 1f);
-        private static Vector2 unitXVector = new Vector2(1f, 0f);
-        private static Vector2 unitYVector = new Vector2(0f, 1f);
+        private static readonly Vector2 zeroVector = new Vector2(0f, 0f);
+        private static readonly Vector2 unitVector = new Vector2(1f, 1f);
+        private static readonly Vector2 unitXVector = new Vector2(1f, 0f);
+        private static readonly Vector2 unitYVector = new Vector2(0f, 1f);
 
         #endregion
 
@@ -97,7 +97,7 @@ namespace Microsoft.Xna.Framework
         #region Constructors
 
         /// <summary>
-        /// Creates a new instance of <see cref="Vector2"/> struct, with the specified position.
+        /// Constructs a vector for 2d space.
         /// </summary>
         /// <param name="x">The x coordinate in 2d-space.</param>
         /// <param name="y">The y coordinate in 2d-space.</param>
@@ -108,7 +108,7 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
-        /// Creates a new instance of <see cref="Vector2"/> struct, with the specified position.
+        /// Constructs a vector for 2d space.
         /// </summary>
         /// <param name="value">The x and y coordinates in 2d-space.</param>
         public Vector2(float value)


### PR DESCRIPTION
Batch of doc fixes.
Changes:
 -All private fields for properties are now also readonly.
 -Unification to all constructors
 -Unification to transform methods such as ToVector2
-Properties docs are rewrited in form without get and set
-Rewrited Color to more readable form.