### PR TITLE
Free pinned memory in GetData

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -127,6 +127,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             var d3dContext = GraphicsDevice._d3dContext;
             using (var stagingTex = new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice, desc))
+            {
                 lock (d3dContext)
                 {
                     int subresourceIndex = CalculateSubresourceIndex(arraySlice, level);
@@ -148,35 +149,41 @@ namespace Microsoft.Xna.Framework.Graphics
                     }
 
                     // Copy the data to the array.
-                    SharpDX.DataStream stream;
-                    var databox = d3dContext.MapSubresource(stagingTex, 0, SharpDX.Direct3D11.MapMode.Read, SharpDX.Direct3D11.MapFlags.None, out stream);
-
-                    var elementSize = _format.GetSize();
-                    var rowSize = elementSize * elementsInRow;
-                    if (rowSize == databox.RowPitch)
-                        stream.ReadRange(data, startIndex, elementCount);
-                    else
+                    SharpDX.DataStream stream = null;
+                    try
                     {
-                        // Some drivers may add pitch to rows.
-                        // We need to copy each row separatly and skip trailing zeros.
-                        stream.Seek(startIndex, SeekOrigin.Begin);
+                        var databox = d3dContext.MapSubresource(stagingTex, 0, SharpDX.Direct3D11.MapMode.Read, SharpDX.Direct3D11.MapFlags.None, out stream);
 
-                        int elementSizeInByte = Marshal.SizeOf(typeof(T));
-                        for (var row = 0; row < rows; row++)
+                        var elementSize = _format.GetSize();
+                        var rowSize = elementSize * elementsInRow;
+                        if (rowSize == databox.RowPitch)
+                            stream.ReadRange(data, startIndex, elementCount);
+                        else
                         {
-                            int i;
-                            for (i = row * rowSize / elementSizeInByte; i < (row + 1) * rowSize / elementSizeInByte; i++)
-                                data[i] = stream.Read<T>();
+                            // Some drivers may add pitch to rows.
+                            // We need to copy each row separatly and skip trailing zeros.
+                            stream.Seek(startIndex, SeekOrigin.Begin);
 
-                            if (i >= elementCount)
-                                break;
+                            int elementSizeInByte = Marshal.SizeOf(typeof(T));
+                            for (var row = 0; row < rows; row++)
+                            {
+                                int i;
+                                for (i = row * rowSize / elementSizeInByte; i < (row + 1) * rowSize / elementSizeInByte; i++)
+                                    data[i] = stream.Read<T>();
 
-                            stream.Seek(databox.RowPitch - rowSize, SeekOrigin.Current);
+                                if (i >= elementCount)
+                                    break;
+
+                                stream.Seek(databox.RowPitch - rowSize, SeekOrigin.Current);
+                            }
                         }
                     }
-
-                    stream.Dispose();
+                    finally
+                    {
+                        SharpDX.Utilities.Dispose( ref stream);
+                    }
                 }
+            }
         }
 
         private int CalculateSubresourceIndex(int arraySlice, int level)


### PR DESCRIPTION
Make sure memory pinned using GCHandle.Alloc is freed when finished.
Added some try..finally and using blocks to ensure resources are disposed if an error occurs.

Tests: 486 executed, 486 passed, 6 ignored

Fixes #3797