### PR TITLE
Update SpriteBatch.cs

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Xna.Framework.Graphics
 		public SpriteBatch (GraphicsDevice graphicsDevice)
 		{
 			if (graphicsDevice == null) {
-				throw new ArgumentException ("graphicsDevice");
+				throw new ArgumentNullException ("graphicsDevice", "The GraphicsDevice must not be null when creating new resources.");
 			}	
 
 			this.GraphicsDevice = graphicsDevice;


### PR DESCRIPTION
Fixes error message in #3798 when trying to construct a SpriteBatch with a null GraphicsDevice. I've tested this on XNA and the behavior is correct. I've copied the exact exception message as well.