### PR TITLE
[Win Pipeline] Menu/context menu improvements

### DIFF
--- a/Tools/Pipeline/Windows/MainView.Designer.cs
+++ b/Tools/Pipeline/Windows/MainView.Designer.cs
@@ -65,6 +65,7 @@ namespace MonoGame.Tools.Pipeline
             this.existingItemToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.existingFolderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this._renameMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._deleteMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._buildMenu = new System.Windows.Forms.ToolStripMenuItem();
             this._buildMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -85,13 +86,12 @@ namespace MonoGame.Tools.Pipeline
             this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripMenuItem5 = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem6 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
+            this._treeSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this._treeOpenFileLocationMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._treeRebuildMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
+            this._treeRenameMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._treeDeleteMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.renameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.renameToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             _toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             _toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             _toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
@@ -299,7 +299,7 @@ namespace MonoGame.Tools.Pipeline
             this.toolStripSeparator2,
             this._addMenuItem,
             this.toolStripSeparator1,
-            this.renameToolStripMenuItem,
+            this._renameMenuItem,
             this._deleteMenuItem});
             this.editToolStripMenuItem.Name = "editToolStripMenuItem";
             this.editToolStripMenuItem.Size = new System.Drawing.Size(39, 20);
@@ -377,6 +377,13 @@ namespace MonoGame.Tools.Pipeline
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
             this.toolStripSeparator1.Size = new System.Drawing.Size(149, 6);
+            // 
+            // _renameMenuItem
+            // 
+            this._renameMenuItem.Name = "_renameMenuItem";
+            this._renameMenuItem.Size = new System.Drawing.Size(152, 22);
+            this._renameMenuItem.Text = "Rename";
+            this._renameMenuItem.Click += new System.EventHandler(this.OnRenameItemClick);
             // 
             // _deleteMenuItem
             // 
@@ -480,14 +487,14 @@ namespace MonoGame.Tools.Pipeline
             this._treeContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this._treeOpenFileMenuItem,
             this._treeAddMenu,
-            this.toolStripSeparator6,
+            this._treeSeparator1,
             this._treeOpenFileLocationMenuItem,
             this._treeRebuildMenuItem,
             this.toolStripSeparator4,
-            this.renameToolStripMenuItem1,
+            this._treeRenameMenuItem,
             this._treeDeleteMenuItem});
             this._treeContextMenu.Name = "itemContextMenu";
-            this._treeContextMenu.Size = new System.Drawing.Size(174, 170);
+            this._treeContextMenu.Size = new System.Drawing.Size(174, 148);
             this._treeContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.MainMenuMenuActivate);
             // 
             // _treeOpenFileMenuItem
@@ -542,10 +549,10 @@ namespace MonoGame.Tools.Pipeline
             this.toolStripMenuItem6.Text = "Existing Folder...";
             this.toolStripMenuItem6.Click += new System.EventHandler(this.OnAddFolderClick);
             // 
-            // toolStripSeparator6
+            // _treeSeparator1
             // 
-            this.toolStripSeparator6.Name = "toolStripSeparator6";
-            this.toolStripSeparator6.Size = new System.Drawing.Size(170, 6);
+            this._treeSeparator1.Name = "_treeSeparator1";
+            this._treeSeparator1.Size = new System.Drawing.Size(170, 6);
             // 
             // _treeOpenFileLocationMenuItem
             // 
@@ -566,6 +573,13 @@ namespace MonoGame.Tools.Pipeline
             this.toolStripSeparator4.Name = "toolStripSeparator4";
             this.toolStripSeparator4.Size = new System.Drawing.Size(170, 6);
             // 
+            // _treeRenameMenuItem
+            // 
+            this._treeRenameMenuItem.Name = "_treeRenameMenuItem";
+            this._treeRenameMenuItem.Size = new System.Drawing.Size(173, 22);
+            this._treeRenameMenuItem.Text = "Rename";
+            this._treeRenameMenuItem.Click += new System.EventHandler(this.OnRenameItemClick);
+            // 
             // _treeDeleteMenuItem
             // 
             this._treeDeleteMenuItem.Name = "_treeDeleteMenuItem";
@@ -573,20 +587,6 @@ namespace MonoGame.Tools.Pipeline
             this._treeDeleteMenuItem.Size = new System.Drawing.Size(173, 22);
             this._treeDeleteMenuItem.Text = "&Delete";
             this._treeDeleteMenuItem.Click += new System.EventHandler(this.OnDeleteItemClick);
-            // 
-            // renameToolStripMenuItem
-            // 
-            this.renameToolStripMenuItem.Name = "renameToolStripMenuItem";
-            this.renameToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
-            this.renameToolStripMenuItem.Text = "Rename";
-            this.renameToolStripMenuItem.Click += new System.EventHandler(this.OnRenameItemClick);
-            // 
-            // renameToolStripMenuItem1
-            // 
-            this.renameToolStripMenuItem1.Name = "renameToolStripMenuItem1";
-            this.renameToolStripMenuItem1.Size = new System.Drawing.Size(173, 22);
-            this.renameToolStripMenuItem1.Text = "Rename";
-            this.renameToolStripMenuItem1.Click += new System.EventHandler(this.OnRenameItemClick);
             // 
             // MainView
             // 
@@ -657,7 +657,7 @@ namespace MonoGame.Tools.Pipeline
         private System.Windows.Forms.ToolStripMenuItem _treeRebuildMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
         private System.Windows.Forms.ToolStripMenuItem _debuggerMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
+        private System.Windows.Forms.ToolStripSeparator _treeSeparator1;
         private System.Windows.Forms.ToolStripMenuItem _treeOpenFileMenuItem;
         private System.Windows.Forms.ToolStripMenuItem _treeOpenFileLocationMenuItem;
         private ToolStripMenuItem _openRecentMenuItem;
@@ -673,8 +673,8 @@ namespace MonoGame.Tools.Pipeline
         private ToolStripSeparator toolStripSeparator7;
         private ToolStripMenuItem toolStripMenuItem5;
         private ToolStripMenuItem toolStripMenuItem6;
-        private ToolStripMenuItem renameToolStripMenuItem;
-        private ToolStripMenuItem renameToolStripMenuItem1;
+        private ToolStripMenuItem _renameMenuItem;
+        private ToolStripMenuItem _treeRenameMenuItem;
     }
 }
 

--- a/Tools/Pipeline/Windows/MainView.cs
+++ b/Tools/Pipeline/Windows/MainView.cs
@@ -198,22 +198,29 @@ namespace MonoGame.Tools.Pipeline
                 _treeView.SelectedNode = node;
             }
 
-            if (node.Tag is ContentItem)
+            if (_treeView.SelectedNodes.Count() == 1)
+            {
+                _treeSeparator1.Visible = true;
+                _treeOpenFileLocationMenuItem.Visible = true;
+                _treeRenameMenuItem.Visible = true;
+
+                if (node.Tag is ContentItem)
+                    _treeAddMenu.Visible = false;
+                else
+                    _treeAddMenu.Visible = true;
+
+                if (node.Tag is FolderItem)
+                    _treeOpenFileMenuItem.Visible = false;
+                else
+                    _treeOpenFileMenuItem.Visible = true;
+            }
+            else
             {
                 _treeAddMenu.Visible = false;
-            }
-            else
-            {
-                _treeAddMenu.Visible = true;
-            }
-
-            if (node.Tag is FolderItem)
-            {
                 _treeOpenFileMenuItem.Visible = false;
-            }
-            else
-            {
-                _treeOpenFileMenuItem.Visible = true;
+                _treeOpenFileLocationMenuItem.Visible = false;
+                _treeRenameMenuItem.Visible = false;
+                _treeSeparator1.Visible = false;
             }
 
             _treeContextMenu.Show(_treeView, contextMenuLocation);
@@ -727,6 +734,7 @@ namespace MonoGame.Tools.Pipeline
             var notBuilding = !_controller.ProjectBuilding;
             var projectOpen = _controller.ProjectOpen;
             var projectOpenAndNotBuilding = projectOpen && notBuilding;
+            var count = _treeView.SelectedNodes.Count();
 
             // Update the state of all menu items.
 
@@ -740,8 +748,9 @@ namespace MonoGame.Tools.Pipeline
 
             _exitMenuItem.Enabled = notBuilding;
 
-            _addMenuItem.Enabled = projectOpen;
-            _deleteMenuItem.Enabled = projectOpen;
+            _addMenuItem.Enabled = projectOpen & count <= 1;
+            _deleteMenuItem.Enabled = projectOpen & count > 0;
+            _renameMenuItem.Enabled = projectOpen & count == 1;
 
             _buildMenuItem.Enabled = projectOpenAndNotBuilding;
 


### PR DESCRIPTION
Stuff done:
- Context Menu: "Open File Location" should only be visible when one item is selected
- Context Menu: "Add Menu" should only be visible if one item is selected and it's not a file
- Context Menu: "Open File" should only be visible if one item is selected and it's a file
- Context Menu: "Rename" should be visible only if one item is selected
- Menu: "Add" menu should only be enabled if one or less items are selected
- Menu: "Delete" menu should only be enabled if one or more items are selected
- Menu: "Rename" menu should only be enabled if exactly one item is selected