### PR TITLE
Fix for #3816 plus few extra

### DIFF
--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -92,6 +92,7 @@ namespace MonoGame.Tools.Pipeline
         {            
             Debug.Assert(ProjectOpen, "OnProjectModified called with no project open?");
             ProjectDirty = true;
+            View.UpdateProperties(_project);
         }
 
         public void OnReferencesModified()
@@ -99,6 +100,7 @@ namespace MonoGame.Tools.Pipeline
             Debug.Assert(ProjectOpen, "OnReferencesModified called with no project open?");
             ProjectDirty = true;
             ResolveTypes();
+            View.UpdateProperties(_project);
         }
 
         public void OnItemModified(ContentItem contentItem)

--- a/Tools/Pipeline/Gtk/MainWindow.cs
+++ b/Tools/Pipeline/Gtk/MainWindow.cs
@@ -123,6 +123,8 @@ namespace MonoGame.Tools.Pipeline
                 _controller.OpenProject(OpenProjectPath);
                 OpenProjectPath = null;
             }
+
+            projectview1.ExpandBase();
         }
 
         protected void OnDeleteEvent (object sender, DeleteEventArgs a)
@@ -442,6 +444,7 @@ namespace MonoGame.Tools.Pipeline
         protected void OnOpenActionActivated (object sender, EventArgs e)
         {
             _controller.OpenProject();
+            projectview1.ExpandBase();
         }
 
         protected void OnCloseActionActivated (object sender, EventArgs e)
@@ -687,7 +690,11 @@ namespace MonoGame.Tools.Pipeline
 
                 // We need a local to make the delegate work correctly.
                 var localProject = project;
-                recentItem.Activated += (sender, args) => _controller.OpenProject(localProject);
+                recentItem.Activated += delegate
+                {
+                    _controller.OpenProject(localProject);
+                    projectview1.ExpandBase();
+                };
 
                 m.Insert (recentItem, 0);
             }

--- a/Tools/Pipeline/Gtk/Widgets/ProjectView.cs
+++ b/Tools/Pipeline/Gtk/Widgets/ProjectView.cs
@@ -166,9 +166,13 @@ namespace MonoGame.Tools.Pipeline
         
             if(!treeview1.Model.GetIterFromString (out iter, "0"))
                 iter = listStore.AppendValues (ICON_BASE, basename, ID_BASE);
-            treeview1.ExpandRow(treeview1.Model.GetPath(iter), false);
 
             return iter;
+        }
+
+        public void ExpandBase()
+        {
+            treeview1.ExpandRow(treeview1.Model.GetPath(GetBaseIter()), false);
         }
 
         public void Close()

--- a/Tools/Pipeline/Windows/PipelineProjectProxy.cs
+++ b/Tools/Pipeline/Windows/PipelineProjectProxy.cs
@@ -132,6 +132,7 @@ namespace MonoGame.Tools.Pipeline
             set { _project.Icon = value; }
         }
 
+        [Browsable(false)]
         public bool Exists
         {
             get { return _project.Exists; }

--- a/Tools/Pipeline/Windows/ReferenceDialog.cs
+++ b/Tools/Pipeline/Windows/ReferenceDialog.cs
@@ -89,6 +89,7 @@ namespace MonoGame.Tools.Pipeline
                     if (svc.ShowDialog(form) == DialogResult.OK)
                     {
                         lines = form.Lines;
+                        MainView._controller.OnProjectModified();
                     }
                 }
             }


### PR DESCRIPTION
Changes done:
- Win Pipeline: Fixed "Exists" visible in project properties, this parameter is used just to display missing indicator and should not be visible
- Win Pipeline: Fix for #3816
- Gtk Pipeline: Fix for not being able to save after modifying any project properties
- Gtk Pipeline: Fixed project base not automatically expanding when opening and there being only 1 item

Side note, I can open WinForms pipeline from linux, tho it looks awful :| good for fixing bugs at least.
![untitled3](https://cloud.githubusercontent.com/assets/6773302/7477388/c1f7915a-f353-11e4-949b-d2dfdb064d18.png)
