### PR TITLE
Windows UAP GamePad Fix

### DIFF
--- a/MonoGame.Framework/Input/GamePad.XInput.cs
+++ b/MonoGame.Framework/Input/GamePad.XInput.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Xna.Framework.Input
 {
     static partial class GamePad
     {
+        internal static bool Back;
+
         private static readonly SharpDX.XInput.Controller[] _controllers = new[]
         {
             new SharpDX.XInput.Controller(SharpDX.XInput.UserIndex.One),
@@ -136,25 +138,39 @@ namespace Microsoft.Xna.Framework.Input
             return ret;
         }
 
+        private static GamePadState GetDefaultState()
+        {
+            var state = new GamePadState();
+            state.Buttons = new GamePadButtons(Back ? Buttons.Back : 0);
+            return state;
+        }
+
         private static GamePadState PlatformGetState(int index, GamePadDeadZone deadZoneMode)
         {
             // If the device was disconneced then wait for 
             // the timeout to elapsed before we test it again.
             if (!_connected[index] && _timeout[index] > DateTime.UtcNow.Ticks)
-                return new GamePadState();
+                return GetDefaultState();
 
             // Try to get the controller state.
-            SharpDX.XInput.State xistate;
-            var controller = _controllers[index];
-            _connected[index] = controller.GetState(out xistate);
-            var gamepad = xistate.Gamepad;
+            var gamepad = new SharpDX.XInput.Gamepad();
+            try
+            {
+                SharpDX.XInput.State xistate;
+                var controller = _controllers[index];
+                _connected[index] = controller.GetState(out xistate);
+                gamepad = xistate.Gamepad;
+            }
+            catch (Exception ex)
+            {
+            }
 
             // If the device is disconnected retry it after the
             // timeout period has elapsed to avoid the overhead.
             if (!_connected[index])
             {
                 _timeout[index] = DateTime.UtcNow.Ticks + TimeoutTicks;
-                return new GamePadState();
+                return GetDefaultState();
             }
 
             var thumbSticks = new GamePadThumbSticks(
@@ -267,6 +283,13 @@ namespace Microsoft.Xna.Framework.Input
 
             if (rightTrigger >= SharpDX.XInput.Gamepad.TriggerThreshold)
                 ret |= Buttons.RightTrigger;
+
+            // Check for the hardware back button.
+            if (Back)
+            {
+                ret |= Buttons.Back;
+                Back = false;
+            }
 
             return new GamePadButtons(ret);
         }

--- a/MonoGame.Framework/Input/GamePad.XInput.cs
+++ b/MonoGame.Framework/Input/GamePad.XInput.cs
@@ -286,10 +286,7 @@ namespace Microsoft.Xna.Framework.Input
 
             // Check for the hardware back button.
             if (Back)
-            {
                 ret |= Buttons.Back;
-                Back = false;
-            }
 
             return new GamePadButtons(ret);
         }

--- a/MonoGame.Framework/WindowsUAP/UAPGamePlatform.cs
+++ b/MonoGame.Framework/WindowsUAP/UAPGamePlatform.cs
@@ -15,6 +15,8 @@ using Windows.ApplicationModel.Activation;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml;
+using Windows.UI.Core;
+using Microsoft.Xna.Framework.Input;
 
 namespace Microsoft.Xna.Framework
 {
@@ -93,12 +95,20 @@ namespace Microsoft.Xna.Framework
                 }
             }
 
+            SystemNavigationManager.GetForCurrentView().BackRequested += BackRequested;
+
             Game.PreviousExecutionState = PreviousExecutionState;
         }
 
         public override GameRunBehavior DefaultRunBehavior
         {
             get { return GameRunBehavior.Synchronous; }
+        }
+
+        private static void BackRequested(object sender, BackRequestedEventArgs e)
+        {
+            GamePad.Back = true;
+            e.Handled = true;
         }
 
         public override void RunLoop()
@@ -111,6 +121,7 @@ namespace Microsoft.Xna.Framework
             CompositionTarget.Rendering += (o, a) =>
             {
 				UAPGameWindow.Instance.Tick();
+                GamePad.Back = false;
             };
         }
         


### PR DESCRIPTION
This fixes `GamePad` support on Windows UAP under Windows Phone.

Also adds hardware back button support.

Fixes #3819 .
