### PR TITLE
Renormalize tangent frame after transformation.

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/MeshContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/MeshContent.cs
@@ -69,7 +69,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                         channel.Name.StartsWith("Tangent"))
                     {
                         for (int i = 0; i < vector3Channel.Count; i++)
-                            vector3Channel[i] = Vector3.TransformNormal(vector3Channel[i], inverseTranspose);
+                        {
+                            Vector3 normal = vector3Channel[i];
+                            Vector3.TransformNormal(ref normal, ref inverseTranspose, out normal);
+                            Vector3.Normalize(ref normal, out normal);
+                            vector3Channel[i] = normal;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Tangent frames (normal, tangent, binormal vectors) need to be re-normalized after transformation. This is necessary, for example, when a scale factor is applied to a model in the content pipeline.