### PR TITLE
Fixes for FBX importer

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/OpenAssetImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/OpenAssetImporter.cs
@@ -165,6 +165,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                 // --> Leave default settings, handle transformation pivots explicitly.
                 //importer.SetConfig(new Assimp.Configs.FBXPreservePivotsConfig(false));
 
+                // Set flag to remove degenerate faces (points and lines).
+                // This flag is very important when PostProcessSteps.FindDegenerates is used
+                // because FindDegenerates converts degenerate triangles to points and lines!
+                importer.SetConfig(new Assimp.Configs.RemoveDegeneratePrimitivesConfig(true));
+
                 // Note about Assimp post-processing:
                 // Keep post-processing to a minimum. The ModelImporter should import
                 // the model as is. We don't want to lose any information, i.e. empty


### PR DESCRIPTION
Here are a few improvements for the FBX importer (OpenAssetImporter).

- The bone weights were only collected up to indicesCount instead of vertexCount. Missing bone weights weren't handled.
- The content pipeline currently only handles indexed triangle lists. But Assimp may return points and lines for degenerate triangles. These degenerate triangles need to be removed.
- The importer now supports skinned model where the root bone has a transformation.
An example was given here: https://github.com/mono/MonoGame/issues/3672.