### PR TITLE
Add GraphicsCapabilities.SupportsVertexTextures

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
@@ -101,6 +101,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal bool SupportsDepthClamp { get; private set; }
 
+        internal bool SupportsVertexTextures { get; private set; }
+
         internal void Initialize(GraphicsDevice device)
         {
 			SupportsNonPowerOfTwo = GetNonPowerOfTwo(device);
@@ -183,6 +185,12 @@ namespace Microsoft.Xna.Framework.Graphics
             SupportsDepthClamp = device.GraphicsProfile == GraphicsProfile.HiDef;
 #elif OPENGL
             SupportsDepthClamp = device._extensions.Contains("GL_ARB_depth_clamp");
+#endif
+
+#if DIRECTX
+            SupportsVertexTextures = device.GraphicsProfile == GraphicsProfile.HiDef;
+#elif OPENGL
+            SupportsVertexTextures = false; // For now, until we implement vertex textures in OpenGL.
 #endif
         }
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -217,10 +217,10 @@ namespace Microsoft.Xna.Framework.Graphics
 
             PlatformSetup();
 
-            VertexTextures = new TextureCollection(MaxVertexTextureSlots, true);
+            VertexTextures = new TextureCollection(this, MaxVertexTextureSlots, true);
             VertexSamplerStates = new SamplerStateCollection(this, MaxVertexTextureSlots, true);
 
-            Textures = new TextureCollection(MaxTextureSlots, false);
+            Textures = new TextureCollection(this, MaxTextureSlots, false);
             SamplerStates = new SamplerStateCollection(this, MaxTextureSlots, false);
 
             _blendStateAdditive = BlendState.Additive.Clone();

--- a/MonoGame.Framework/Graphics/SamplerStateCollection.DirectX.cs
+++ b/MonoGame.Framework/Graphics/SamplerStateCollection.DirectX.cs
@@ -27,6 +27,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal void PlatformSetSamplers(GraphicsDevice device)
         {
+            if (_applyToVertexStage && !device.GraphicsCapabilities.SupportsVertexTextures)
+                return;
+
             // Skip out if nothing has changed.
             if (_d3dDirty == 0)
                 return;

--- a/MonoGame.Framework/Graphics/TextureCollection.DirectX.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.DirectX.cs
@@ -12,14 +12,13 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal void ClearTargets(GraphicsDevice device, RenderTargetBinding[] targets)
         {
+            if (_applyToVertexStage && !device.GraphicsCapabilities.SupportsVertexTextures)
+                return;
+
             if (_applyToVertexStage)
-            {
                 ClearTargets(targets, device._d3dContext.VertexShader);
-            }
             else
-            {
                 ClearTargets(targets, device._d3dContext.PixelShader);
-            }
         }
 
         private void ClearTargets(RenderTargetBinding[] targets, SharpDX.Direct3D11.CommonShaderStage shaderStage)

--- a/MonoGame.Framework/Graphics/TextureCollection.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.cs
@@ -2,16 +2,20 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
+
 namespace Microsoft.Xna.Framework.Graphics
 {
     public sealed partial class TextureCollection
     {
+        private readonly GraphicsDevice _graphicsDevice;
         private readonly Texture[] _textures;
         private readonly bool _applyToVertexStage;
         private int _dirty;
 
-        internal TextureCollection(int maxTextures, bool applyToVertexStage)
+        internal TextureCollection(GraphicsDevice graphicsDevice, int maxTextures, bool applyToVertexStage)
         {
+            _graphicsDevice = graphicsDevice;
             _textures = new Texture[maxTextures];
             _applyToVertexStage = applyToVertexStage;
             _dirty = int.MaxValue;
@@ -26,6 +30,9 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             set
             {
+                if (_applyToVertexStage && !_graphicsDevice.GraphicsCapabilities.SupportsVertexTextures)
+                    throw new NotSupportedException("Vertex textures are not supported on this device.");
+
                 if (_textures[index] == value)
                     return;
 
@@ -53,6 +60,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal void SetTextures(GraphicsDevice device)
         {
+            if (_applyToVertexStage && !device.GraphicsCapabilities.SupportsVertexTextures)
+                return;
             PlatformSetTextures(device);
         }
     }


### PR DESCRIPTION
and use it to guard against applying vertex textures on devices that don't support them. Fixes #3828.