### PR TITLE
[Gtk Pipeline] Fixed null crash when viewing project properties

### DIFF
--- a/Tools/Pipeline/Gtk/Widgets/PropertiesView.cs
+++ b/Tools/Pipeline/Gtk/Widgets/PropertiesView.cs
@@ -33,16 +33,16 @@ namespace MonoGame.Tools.Pipeline
             propertygridtable1.Initalize (window);
         }
 
-        public static string ObsoleteText(Enum value)
+        public static Dictionary<string, object> GetDictionary(Type type)
         {
-            var fi = value.GetType().GetField(value.ToString());
-            var attributes = (ObsoleteAttribute[])
-                fi.GetCustomAttributes(typeof(ObsoleteAttribute), false);
+            Dictionary<string, object> ret = new Dictionary<string, object>();
+            string[] names = Enum.GetNames(type);
+            Array objects = Enum.GetValues(type);
 
-            if (attributes != null && attributes.Length > 0)
-                return attributes[0].Message;
+            for (int i = 0; i < names.Length; i++)
+                ret.Add(names[i], objects.GetValue(i));
 
-            return "";
+            return ret;
         }
 
         public void Load(List<object> cobjects, string name, string location)
@@ -95,9 +95,7 @@ namespace MonoGame.Tools.Pipeline
                     if (value == null)
                         value = "";
 
-                    Dictionary<string, object> data = Enum.GetValues (typeof(BuildAction))
-                        .Cast<BuildAction> ()
-                        .ToDictionary (t => t.ToString(), t => (object)t);
+                    Dictionary<string, object> data = GetDictionary(typeof(BuildAction));
                     propertygridtable1.AddEntry (p.Name, value, 
                         PropertyGridTable.EntryType.Combo,(s,e) => { 
                             foreach (object o in currentObjects) 
@@ -127,9 +125,7 @@ namespace MonoGame.Tools.Pipeline
                     if (value == null)
                         value = "";
 
-                    Dictionary<string, object> data = Enum.GetValues (typeof(GraphicsProfile))
-                        .Cast<GraphicsProfile> ()
-                        .ToDictionary (t => t.ToString(), t => (object)t);
+                    Dictionary<string, object> data = GetDictionary(typeof(GraphicsProfile));
                     propertygridtable1.AddEntry (p.Name, value, 
                         PropertyGridTable.EntryType.Combo,(s,e) => { 
                             foreach (object o in currentObjects) 
@@ -142,19 +138,7 @@ namespace MonoGame.Tools.Pipeline
                     if (value == null)
                         value = "";
 
-                    Dictionary<string, object> data = Enum.GetValues (typeof(TP.TargetPlatform))
-                        .Cast<TP.TargetPlatform> ()
-                        .ToDictionary (t => ObsoleteText(t) != "" ? "[!] " + t.ToString() : t.ToString(), t => (object)t);
-
-                    try
-                    {
-                        if (ObsoleteText((TP.TargetPlatform)Enum.Parse(typeof(TP.TargetPlatform), value.ToString())) != "")
-                        {
-                            value = "[!] " + value;
-                        }
-                    }
-                    catch { }
-
+                    Dictionary<string, object> data = GetDictionary(typeof(TP.TargetPlatform));
                     propertygridtable1.AddEntry (p.Name, value, 
                         PropertyGridTable.EntryType.Combo,(s,e) => { 
                             foreach (object o in currentObjects) 
@@ -349,9 +333,8 @@ namespace MonoGame.Tools.Pipeline
                 if (p1.Type == typeof(MaterialProcessorDefaultEffect)) {
                     if (value == null)
                         value = "";
-                    Dictionary<string, object> data = Enum.GetValues (typeof(MaterialProcessorDefaultEffect))
-                        .Cast<MaterialProcessorDefaultEffect> ()
-                        .ToDictionary (t => t.ToString(), t => (object)t);
+
+                    Dictionary<string, object> data = GetDictionary(typeof(MaterialProcessorDefaultEffect));
                     var defaultValue = (MaterialProcessorDefaultEffect)p1.DefaultValue;
                     propertygridtable1.AddProcEntry (p1.Name, (object)value ?? (object)defaultValue,
                         PropertyGridTable.EntryType.Combo,(s,e) => { 
@@ -366,9 +349,8 @@ namespace MonoGame.Tools.Pipeline
                 if (p1.Type == typeof(TextureProcessorOutputFormat)) {
                     if (value == null)
                         value = "";
-                    Dictionary<string, object> data = Enum.GetValues (typeof(TextureProcessorOutputFormat))
-                        .Cast<TextureProcessorOutputFormat> ()
-                        .ToDictionary (t => t.ToString(), t => (object)t);
+                    
+                    Dictionary<string, object> data = GetDictionary(typeof(TextureProcessorOutputFormat));
                     var defaultValue = (TextureProcessorOutputFormat)p1.DefaultValue;
                     propertygridtable1.AddProcEntry (p1.Name, (object)value ?? (object)defaultValue,
                         PropertyGridTable.EntryType.Combo,(s,e) => { 


### PR DESCRIPTION
Because of https://github.com/mono/MonoGame/blob/develop/MonoGame.Framework.Content.Pipeline/TargetPlatform.cs#L100 when WindowsGL or Linux were read they were automatically repinted to DesktopGL, and then with the old Dictionary creating code it was trying to add multiple DesktopGL keys which in turn caused a crash. This fixes it.

Also I can't check if WindowsGL and Linux are obsolete anymore because of the same reason.