### PR TITLE
[Gtk Pipeline] Changed Save As dialog no button to say no instead of close without saving

### DIFF
--- a/Tools/Pipeline/Gtk/MainWindow.cs
+++ b/Tools/Pipeline/Gtk/MainWindow.cs
@@ -156,7 +156,7 @@ namespace MonoGame.Tools.Pipeline
             var dialog = new MessageDialog(this, DialogFlags.Modal, MessageType.Question, ButtonsType.None, "Do you want to save the project first?");
             dialog.Title = "Save";
 
-            dialog.AddButton("Close without Saving", (int)ResponseType.No);
+            dialog.AddButton("No", (int)ResponseType.No);
             dialog.AddButton("Cancel", (int)ResponseType.Cancel);
             dialog.AddButton("Save", (int)ResponseType.Yes);
 


### PR DESCRIPTION
Save as dialog can be called when the project is not saved and user clicks on build., when I modified it last time I forgot about it. 