### PR TITLE
Fix ReflectiveReader for properties with private setters

### DIFF
--- a/MonoGame.Framework/Utilities/ReflectionHelpers.cs
+++ b/MonoGame.Framework/Utilities/ReflectionHelpers.cs
@@ -113,6 +113,10 @@ namespace Microsoft.Xna.Framework.Utilities
             if (getMethod == null || !getMethod.IsPublic)
                 return false;
 
+            var setMethod = GetPropertySetMethod(property);
+            if (setMethod == null || !setMethod.IsPublic)
+                return false;
+
             return true;
         }
 


### PR DESCRIPTION
This fixes loading types that include properties like this:

    public SomeProperty { get; private set; }