### PR TITLE
Open audio content files in read mode

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
@@ -298,7 +298,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
 
         private void Read(string filename)
         {
-            using (var fs = new FileStream(filename, FileMode.Open))
+            // Must be opened in read mode otherwise it fails to open read-only files (found in some source control systems)
+            using (var fs = new FileStream(filename, FileMode.Open, FileAccess.Read))
             {
                 var data = new byte[fs.Length];
                 fs.Read(data, 0, data.Length);


### PR DESCRIPTION
Using FileStream to open files, FileAccess.Read must be specified so it can handle files that are flagged as read-only. These are found in source control systems such as Perforce, among others.

Fixes #3873