### PR TITLE
Removed WindowsGL and Linux target platforms

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/PathHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PathHelper.cs
@@ -65,7 +65,6 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             switch (targetPlatform)
             {
                 case TargetPlatform.Windows:
-                case TargetPlatform.WindowsGL:
                 case TargetPlatform.WindowsPhone8:
                 case TargetPlatform.WindowsStoreApp:
                     return NormalizeWindows(path);

--- a/MonoGame.Framework.Content.Pipeline/TargetPlatform.cs
+++ b/MonoGame.Framework.Content.Pipeline/TargetPlatform.cs
@@ -90,20 +90,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         /// <summary>
         /// Sony PlayStation4
         /// </summary>
-        PlayStation4,
-
-        /// <summary>
-        /// All desktop versions of Windows using OpenGL.
-        /// (MonoGame)
-        /// </summary>
-        [Obsolete("This platform is obsolete, use DesktopGL instead")]
-        WindowsGL = DesktopGL,
-
-        /// <summary>
-        /// Linux-based PCs
-        /// (MonoGame)
-        /// </summary>
-        [Obsolete("This platform is obsolete, use DesktopGL instead")]
-        Linux = DesktopGL
+        PlayStation4
     }
 }


### PR DESCRIPTION
We really need to remove WindowsGL and Linux as target platforms, on Windows Pipeline Tool instead of property grid loading WindowsGL, Linux and DesktopGL names, it loads Linux name 3 times.