### PR TITLE
[Gtk Pipeline] Better text strict list

### DIFF
--- a/Tools/Pipeline/Gtk/Dialogs/NewTemplateDialog.GUI.cs
+++ b/Tools/Pipeline/Gtk/Dialogs/NewTemplateDialog.GUI.cs
@@ -80,7 +80,12 @@ namespace MonoGame.Tools.Pipeline
 			// Container child vbox2.Gtk.Box+BoxChild
 			this.label2 = new global::Gtk.Label ();
 			this.label2.Name = "label2";
-			this.label2.LabelProp = global::Mono.Unix.Catalog.GetString ("Only Letters, numbers, space and \"_\" are allowed.");
+
+            #if GTK3
+            if(Global.GtkMajorVersion == 3 && Global.GtkMinorVersion >= 8)
+                Gtk3Wrapper.gtk_widget_set_opacity(label2.Handle, 0.7);
+            #endif
+
 			this.vbox2.Add (this.label2);
 			global::Gtk.Box.BoxChild w7 = ((global::Gtk.Box.BoxChild)(this.vbox2 [this.label2]));
 

--- a/Tools/Pipeline/Gtk/Dialogs/NewTemplateDialog.cs
+++ b/Tools/Pipeline/Gtk/Dialogs/NewTemplateDialog.cs
@@ -74,7 +74,7 @@ namespace MonoGame.Tools.Pipeline
             TreeIter iter;
 
             if (entry1.Text != "") {
-                if (MainWindow.CheckString (entry1.Text, MainWindow.AllowedCharacters)) {
+                if (MainWindow.CheckString (entry1.Text, MainWindow.NotAllowedCharacters)) {
                     if (treeview1.Selection.GetSelected (out iter)) {
                         buttonOk.Sensitive = true;
                         label2.Visible = false;
@@ -89,6 +89,17 @@ namespace MonoGame.Tools.Pipeline
             } else {
                 buttonOk.Sensitive = false;
                 label2.Visible = false;
+            }
+
+            if(label2.Visible)
+            {
+                var chars = MainWindow.NotAllowedCharacters.ToCharArray();
+                string notallowedchars = chars[0].ToString();
+
+                for (int i = 1; i < chars.Length; i++)
+                    notallowedchars += ", " + chars[i];
+
+                this.label2.LabelProp = "Your name contains one of not allowed letters: " + notallowedchars;
             }
         }
 

--- a/Tools/Pipeline/Gtk/Dialogs/TextEditorDialog.GUI.cs
+++ b/Tools/Pipeline/Gtk/Dialogs/TextEditorDialog.GUI.cs
@@ -50,7 +50,12 @@ namespace MonoGame.Tools.Pipeline
 			this.label3 = new global::Gtk.Label ();
 			this.label3.HeightRequest = 0;
 			this.label3.Name = "label3";
-			this.label3.LabelProp = global::Mono.Unix.Catalog.GetString ("Only Letters, numbers, space and \"_\" are allowed.");
+
+            #if GTK3
+            if(Global.GtkMajorVersion == 3 && Global.GtkMinorVersion >= 8)
+                Gtk3Wrapper.gtk_widget_set_opacity(label3.Handle, 0.7);
+            #endif
+
 			w1.Add (this.label3);
 			global::Gtk.Box.BoxChild w4 = ((global::Gtk.Box.BoxChild)(w1 [this.label3]));
 			w4.Position = 2;

--- a/Tools/Pipeline/Gtk/Dialogs/TextEditorDialog.cs
+++ b/Tools/Pipeline/Gtk/Dialogs/TextEditorDialog.cs
@@ -17,7 +17,7 @@ namespace MonoGame.Tools.Pipeline
             this.Title = title;
 
             buttonOk = (Button)this.AddButton("Ok", ResponseType.Ok);
-            buttonOk.Sensitive = false;
+            buttonOk.Sensitive = !strictmode;
 
             this.AddButton("Cancel", ResponseType.Cancel);
             this.DefaultResponse = ResponseType.Ok;
@@ -41,7 +41,7 @@ namespace MonoGame.Tools.Pipeline
                 return;
 
             if (entry1.Text != "") {
-                if (MainWindow.CheckString (entry1.Text, MainWindow.AllowedCharacters)) {
+                if (MainWindow.CheckString (entry1.Text, MainWindow.NotAllowedCharacters)) {
                     buttonOk.Sensitive = true;
                     label3.Visible = false;
                 } else {
@@ -51,6 +51,17 @@ namespace MonoGame.Tools.Pipeline
             } else {
                 buttonOk.Sensitive = false;
                 label3.Visible = false;
+            }
+
+            if(label3.Visible)
+            {
+                var chars = MainWindow.NotAllowedCharacters.ToCharArray();
+                string notallowedchars = chars[0].ToString();
+
+                for (int i = 1; i < chars.Length; i++)
+                    notallowedchars += ", " + chars[i];
+
+                this.label3.LabelProp = "Your name contains one of not allowed letters: " + notallowedchars;
             }
         }
 

--- a/Tools/Pipeline/Gtk/Gtk3Integration.cs
+++ b/Tools/Pipeline/Gtk/Gtk3Integration.cs
@@ -28,6 +28,9 @@ namespace MonoGame.Tools.Pipeline
         [DllImport (gtklibpath, CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr gtk_dialog_new_with_buttons (string title, IntPtr parent, int flags);
 
+        [DllImport (gtklibpath, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr gtk_widget_set_opacity (IntPtr widget, double opacity);
+
         [DllImport (giolibpath, CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr g_file_new_for_path (string path);
 

--- a/Tools/Pipeline/Gtk/MainWindow.cs
+++ b/Tools/Pipeline/Gtk/MainWindow.cs
@@ -12,12 +12,24 @@ namespace MonoGame.Tools.Pipeline
 {
     partial class MainWindow : Window, IView
     {
-        public static string AllowedCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 _.()";
+        public static string LinuxNotAllowedCharacters = "/"; 
+        public static string MacNotAllowedCharacters = ":";
 
-        public static bool CheckString(string s, string allowedCharacters)
+        public static string NotAllowedCharacters
         {
-            for (int i = 0; i < s.Length; i++) 
-                if (!allowedCharacters.Contains (s.Substring (i, 1)))
+            get
+            {
+                if (Global.DesktopEnvironment == "OSX")
+                    return MacNotAllowedCharacters;
+                else
+                    return LinuxNotAllowedCharacters;
+            }
+        }
+
+        public static bool CheckString(string s, string notallowedCharacters)
+        {
+            for (int i = 0; i < notallowedCharacters.Length; i++) 
+                if (s.Contains (notallowedCharacters.Substring (i, 1)))
                     return false;
 
             return true;


### PR DESCRIPTION
Talking about when creating new folder/new item.

Stuff done:
 - Made not allowed list of characters instead of the allowed one
 - Set platform specific lists
 - Made error text have less alpha in Gtk 3.8 or later (around the same alpha as https://github.com/gnome-design-team/gnome-mockups/blob/master/nautilus/nautilus-next/create-folder-wires.png)