### PR TITLE
Fix for Curve.Evaluate ArgumentOutOfRangeException

### DIFF
--- a/MonoGame.Framework/Curve.cs
+++ b/MonoGame.Framework/Curve.cs
@@ -101,6 +101,16 @@ namespace Microsoft.Xna.Framework
         /// <returns>Value at the position on this <see cref="Curve"/>.</returns>
         public float Evaluate(float position)
         {
+            if (_keys.Count == 0)
+            {
+            	return 0f;
+            }
+						
+            if (_keys.Count == 1)
+            {
+            	return _keys[0].Value;
+            }
+			
             CurveKey first = _keys[0];
             CurveKey last = _keys[_keys.Count - 1];
 

--- a/Test/Framework/CurveTest.cs
+++ b/Test/Framework/CurveTest.cs
@@ -62,6 +62,27 @@ namespace MonoGame.Tests.Framework
         }
 
         [Test]
+        public void EvaluateNoKeys()
+        {
+            var curve = new Curve();
+
+            var result = curve.Evaluate(1.25f);
+
+            Assert.AreEqual(0f, result);
+        }
+
+        [Test]
+        public void EvaluateOneKey()
+        {
+            var curve = new Curve();
+            curve.Keys.Add(new CurveKey(1, -1));
+
+            var result = curve.Evaluate(1.25f);
+
+            Assert.AreEqual(-1f, result);
+        }
+
+        [Test]
         public void ComputeTangent()
         {
             var key1 = new CurveKey(-0.5f, 1.5f); 


### PR DESCRIPTION
A call to Curve.Evaluate will throw an ArgumentOutOfRangeException if no keys have been added to the curve. This scenario however is handled in XNA.

e.g.

var curve = new Curve();
curve.Evaluate(1f);

Suggest adding code similar to the following to fix the issue

MonoGame/MonoGame.Framework/Curve.cs

public float Evaluate(float position)
{
    if (_keys.Count == 0)
    {
        return 0f;
    }               

    if (_keys.Count == 1)
    {
        return _keys[0].Value;
    }

    //REST OF CODE...

Possible unit tests...

    [Test]
    public void EvaluateNoKeys()
    {
        var curve = new Curve();

        var result = curve.Evaluate(1.25f);

        Assert.AreEqual(0f, result);
    }

    [Test]
    public void EvaluateOneKey()
    {
        var curve = new Curve();
        curve.Keys.Add(new CurveKey(1, -1));

        var result = curve.Evaluate(1.25f);

        Assert.AreEqual(-1f, result);
    }

See issue...https://github.com/mono/MonoGame/issues/3924