### PR TITLE
Dxt non-multiple-of-four textures

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
@@ -163,6 +163,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             return (x & (x - 1)) == 0;
         }
 
+        public static bool IsMultipleOfFour(int x)
+        {
+            return x % 4 == 0;
+        }
+
         /// <summary>
         /// Returns the next power of two. Returns same value if already is PoT.
         /// </summary>
@@ -305,6 +310,14 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             {
                 if (!IsPowerOfTwo(texData.Width) || !IsPowerOfTwo(texData.Height))
                     throw new PipelineException("DXT Compressed textures width and height must be powers of two in GraphicsProfile.Reach.");                
+            }
+
+            if (!IsMultipleOfFour(texData.Width) || !IsMultipleOfFour(texData.Height))
+            {                
+                throw new PipelineException(
+                    "Invalid texture. Face 0 is sized {0}x{1}, but textures using DXT compressed formats must be multiples of four.",
+                    texData.Width,
+                    texData.Height);
             }
 
             var pixelData = texData.GetPixelData();

--- a/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessor.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 			}
 			catch(Exception ex)
 			{
-				context.Logger.LogImportantMessage ("Could not compress texture {0}", ex.ToString());
+				context.Logger.LogImportantMessage ("Could not compress texture : {0}", ex.ToString());
 				TextureFormat = TextureProcessorOutputFormat.Color;
 			}
 

--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -403,7 +403,22 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             if (_shared)
                 desc.OptionFlags |= SharpDX.Direct3D11.ResourceOptionFlags.Shared;
-
+            
+            if (_format == SurfaceFormat.Dxt1 ||
+                _format == SurfaceFormat.Dxt5)
+            {
+                if (width % 4 != 0 || height % 4 != 1)
+                {
+                    // Note that the sharpdx call immediately below this will in fact fail
+                    // in this case. However it fails with an extremely unhelpful message. 
+                    // The message we write here matches the one given by XNA.
+                    //
+                    // Note that XNA also throws this exception for Dxt3, however since that call
+                    // actually works with sharpdx...
+                    throw new System.ArgumentException("DXT compressed texture sizes must be multiples of four.");
+                }
+            }
+                
             return new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice, desc);
         }
 

--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -405,16 +405,14 @@ namespace Microsoft.Xna.Framework.Graphics
                 desc.OptionFlags |= SharpDX.Direct3D11.ResourceOptionFlags.Shared;
             
             if (_format == SurfaceFormat.Dxt1 ||
+                _format == SurfaceFormat.Dxt3 ||
                 _format == SurfaceFormat.Dxt5)
             {
-                if (width % 4 != 0 || height % 4 != 1)
+                if (width % 4 != 0 || height % 4 != 0)
                 {
                     // Note that the sharpdx call immediately below this will in fact fail
                     // in this case. However it fails with an extremely unhelpful message. 
                     // The message we write here matches the one given by XNA.
-                    //
-                    // Note that XNA also throws this exception for Dxt3, however since that call
-                    // actually works with sharpdx...
                     throw new System.ArgumentException("DXT compressed texture sizes must be multiples of four.");
                 }
             }


### PR DESCRIPTION
Being more explicit about Mo4 requirements for dxt textures.