### PR TITLE
[pipeline] Added support for attaching the mono debugger to MGCB via the pipeline tool

### DIFF
--- a/Tools/MGCB/Program.cs
+++ b/Tools/MGCB/Program.cs
@@ -31,7 +31,13 @@ namespace MGCB
             
             // Launch debugger if requested.
             if (content.LaunchDebugger)
-                System.Diagnostics.Debugger.Launch();
+            {
+                try {
+                    System.Diagnostics.Debugger.Launch();
+                } catch (NotImplementedException) {
+                    // not implemented under Mono
+                }
+            }
 
             // Print a startup message.            
             var buildStarted = DateTime.Now;

--- a/Tools/Pipeline/Gtk/MainWindow.GUI.cs
+++ b/Tools/Pipeline/Gtk/MainWindow.GUI.cs
@@ -46,7 +46,7 @@ namespace MonoGame.Tools.Pipeline
 		
 		private global::Gtk.Action CleanAction;
 		
-		private global::Gtk.Action DebugModeAction;
+		private global::Gtk.ToggleAction DebugModeAction;
 		
 		private global::Gtk.Action HelpAction;
 		
@@ -143,7 +143,7 @@ namespace MonoGame.Tools.Pipeline
 			this.CleanAction = new global::Gtk.Action ("CleanAction", global::Mono.Unix.Catalog.GetString ("Clean"), null, null);
 			this.CleanAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Clean");
 			w1.Add (this.CleanAction, null);
-			this.DebugModeAction = new global::Gtk.Action ("DebugModeAction", global::Mono.Unix.Catalog.GetString ("Debug Mode"), null, null);
+			this.DebugModeAction = new global::Gtk.ToggleAction ("DebugModeAction", global::Mono.Unix.Catalog.GetString ("Debug Mode"), null, null);
 			this.DebugModeAction.ShortLabel = global::Mono.Unix.Catalog.GetString ("Debug Mode");
 			w1.Add (this.DebugModeAction, null);
 			this.HelpAction = new global::Gtk.Action ("HelpAction", global::Mono.Unix.Catalog.GetString ("Help"), null, null);
@@ -182,7 +182,7 @@ namespace MonoGame.Tools.Pipeline
 			this.vbox2 = new global::Gtk.VBox ();
 			this.vbox2.Name = "vbox2";
 			// Container child vbox2.Gtk.Box+BoxChild
-			this.UIManager.AddUiFromString ("<ui><menubar name='menubar1'><menu name='FileAction' action='FileAction'><menuitem name='NewAction' action='NewAction'/><menuitem name='OpenAction' action='OpenAction'/><menuitem name='OpenRecentAction' action='OpenRecentAction'/><menuitem name='CloseAction' action='CloseAction'/><separator/><menuitem name='ImportAction' action='ImportAction'/><separator/><menuitem name='SaveAction' action='SaveAction'/><menuitem name='SaveAsAction' action='SaveAsAction'/><separator/><menuitem name='ExitAction' action='ExitAction'/></menu><menu name='EditAction' action='EditAction'><menuitem name='UndoAction' action='UndoAction'/><menuitem name='RedoAction' action='RedoAction'/><separator/><menu name='AddAction' action='AddAction'><menuitem name='NewItemAction' action='NewItemAction'/><menuitem name='NewFolderAction' action='NewFolderAction'/><separator/><menuitem name='ExistingItemAction' action='ExistingItemAction'/><menuitem name='ExistingFolderAction' action='ExistingFolderAction'/></menu><separator/><menuitem name='RenameAction' action='RenameAction'/><menuitem name='DeleteAction' action='DeleteAction'/></menu><menu name='BuildAction' action='BuildAction'><menuitem name='BuildAction1' action='BuildAction1'/><menuitem name='RebuildAction' action='RebuildAction'/><menuitem name='CleanAction' action='CleanAction'/><menuitem name='CancelBuildAction' action='CancelBuildAction'/></menu><menu name='HelpAction' action='HelpAction'><menuitem name='ViewHelpAction' action='ViewHelpAction'/><separator/><menuitem name='AboutAction' action='AboutAction'/></menu></menubar></ui>");
+			this.UIManager.AddUiFromString ("<ui><menubar name='menubar1'><menu name='FileAction' action='FileAction'><menuitem name='NewAction' action='NewAction'/><menuitem name='OpenAction' action='OpenAction'/><menuitem name='OpenRecentAction' action='OpenRecentAction'/><menuitem name='CloseAction' action='CloseAction'/><separator/><menuitem name='ImportAction' action='ImportAction'/><separator/><menuitem name='SaveAction' action='SaveAction'/><menuitem name='SaveAsAction' action='SaveAsAction'/><separator/><menuitem name='ExitAction' action='ExitAction'/></menu><menu name='EditAction' action='EditAction'><menuitem name='UndoAction' action='UndoAction'/><menuitem name='RedoAction' action='RedoAction'/><separator/><menu name='AddAction' action='AddAction'><menuitem name='NewItemAction' action='NewItemAction'/><menuitem name='NewFolderAction' action='NewFolderAction'/><separator/><menuitem name='ExistingItemAction' action='ExistingItemAction'/><menuitem name='ExistingFolderAction' action='ExistingFolderAction'/></menu><separator/><menuitem name='RenameAction' action='RenameAction'/><menuitem name='DeleteAction' action='DeleteAction'/></menu><menu name='BuildAction' action='BuildAction'><menuitem name='BuildAction1' action='BuildAction1'/><menuitem name='RebuildAction' action='RebuildAction'/><menuitem name='CleanAction' action='CleanAction'/><menuitem name='CancelBuildAction' action='CancelBuildAction'/><separator name='sep1'/><menuitem name='DebugModeAction' action='DebugModeAction'/></menu><menu name='HelpAction' action='HelpAction'><menuitem name='ViewHelpAction' action='ViewHelpAction'/><separator/><menuitem name='AboutAction' action='AboutAction'/></menu></menubar></ui>");
 			this.menubar1 = ((global::Gtk.MenuBar)(this.UIManager.GetWidget ("/menubar1")));
 			this.menubar1.Name = "menubar1";
 			this.vbox2.Add (this.menubar1);
@@ -280,6 +280,8 @@ namespace MonoGame.Tools.Pipeline
 			this.NewFolderAction.Activated += new global::System.EventHandler (this.OnNewFolderActionActivated);
 			this.ExistingItemAction.Activated += new global::System.EventHandler (this.OnAddItemActionActivated);
 			this.ExistingFolderAction.Activated += new global::System.EventHandler (this.OnAddFolderActionActivated);
+			this.DebugModeAction.Activated += new global::System.EventHandler (this.OnDebugModeActionActivated); 
+			this.CancelBuildAction.Activated += new global::System.EventHandler (this.OnCancelBuildActionActivated);
 		}
 	}
 }


### PR DESCRIPTION
One feature that was missing in the pipeline tool was the ability to
debug your extensions via the UI. This commit adds that support
by providing the appropriate command line arguments to mono
which will cause the app to pause and wait for the debugger to
attach. A suitable warning message is included to make sure
the developer knows they are in debug mode.

If you want to specify your won debugger port this can be done
by exporting the MONO_DEBUGGER_PORT environment variable 
BEFORE running the pipeline tool. e.g.

export MONO_DEBUGGER_PORT=1235