### PR TITLE
Add support in IntermediateSerializer for classes inherited from generic collection types

### DIFF
--- a/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
+++ b/Build/Projects/MonoGame.Framework.Content.Pipeline.definition
@@ -360,6 +360,7 @@
     <Compile Include="Serialization\Intermediate\EnumSerializer.cs" />    
     <Compile Include="Serialization\Intermediate\ExternalReferenceSerializer.cs" />    
     <Compile Include="Serialization\Intermediate\FloatSerializer.cs" />
+    <Compile Include="Serialization\Intermediate\GenericCollectionHelper.cs" />
     <Compile Include="Serialization\Intermediate\IntermediateReader.cs" />
     <Compile Include="Serialization\Intermediate\IntermediateSerializer.cs" />
     <Compile Include="Serialization\Intermediate\IntermediateWriter.cs" />

--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -664,6 +664,9 @@
     <Content Include="Assets\Xml\25_StructArrayNoElements.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Assets\Xml\26_ChildCollections.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
 
     <Content Include="Assets\Fonts\Default.xnb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/GenericCollectionHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/GenericCollectionHelper.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
+{
+    internal class GenericCollectionHelper
+    {
+        public static bool IsGenericCollectionType(Type type, bool checkAncestors)
+        {
+            return GetCollectionElementType(type, checkAncestors) != null;
+        }
+
+        private static Type GetCollectionElementType(Type type, bool checkAncestors)
+        {
+            if (!checkAncestors && type.BaseType != null && FindCollectionInterface(type.BaseType) != null)
+                return null;
+
+            var collectionInterface = FindCollectionInterface(type);
+            if (collectionInterface == null)
+                return null;
+
+            return collectionInterface.GetGenericArguments()[0];
+        }
+
+        private static Type FindCollectionInterface(Type type)
+        {
+            var interfaces = type.FindInterfaces((t, o) =>
+            {
+                if (t.IsGenericType)
+                    return t.GetGenericTypeDefinition() == typeof(ICollection<>);
+                return false;
+            }, null);
+
+            return (interfaces.Length == 1)
+                ? interfaces[0]
+                : null;
+        }
+
+        private readonly ContentTypeSerializer _contentSerializer;
+        private readonly PropertyInfo _countProperty;
+        private readonly MethodInfo _addMethod;
+
+        public GenericCollectionHelper(IntermediateSerializer serializer, Type type)
+        {
+            var collectionElementType = GetCollectionElementType(type, false);
+            _contentSerializer = serializer.GetTypeSerializer(collectionElementType);
+
+            var collectionType = typeof(ICollection<>).MakeGenericType(collectionElementType);
+            _countProperty = collectionType.GetProperty("Count");
+            _addMethod = collectionType.GetMethod("Add", new[] { collectionElementType });
+        }
+
+        public bool ObjectIsEmpty(object list)
+        {
+            return (int) _countProperty.GetValue(list, null) == 0;
+        }
+
+        public void ScanChildren(ContentTypeSerializer.ChildCallback callback, object collection)
+        {
+            foreach (var item in (IEnumerable) collection)
+                if (item != null)
+                    callback(_contentSerializer, item);
+        }
+
+        public void Serialize(IntermediateWriter output, object collection, ContentSerializerAttribute format)
+        {
+            var itemFormat = new ContentSerializerAttribute();
+            itemFormat.ElementName = format.CollectionItemName;
+            foreach (var item in (IEnumerable) collection)
+                output.WriteObject(item, itemFormat, _contentSerializer);
+        }
+
+        public void Deserialize(IntermediateReader input, object collection, ContentSerializerAttribute format)
+        {
+            var itemFormat = new ContentSerializerAttribute();
+            itemFormat.ElementName = format.CollectionItemName;
+            while (input.MoveToElement(format.CollectionItemName))
+                _addMethod.Invoke(collection, new[] { input.ReadObject<object>(itemFormat, _contentSerializer) });
+        }
+    }
+}

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateSerializer.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
         private Dictionary<string, string> _namespaceLookup;
 
         private Dictionary<Type, ContentTypeSerializer> _serializers;
+        private Dictionary<Type, GenericCollectionHelper> _collectionHelpers;
 
         private Dictionary<Type, Type> _genericSerializerTypes;
 
@@ -160,7 +161,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
             {
                 serializer = new EnumSerializer(type);
             }
-            else if (typeof(IList).IsAssignableFrom(type))
+            else if (typeof(IList).IsAssignableFrom(type) && !GenericCollectionHelper.IsGenericCollectionType(type, true))
             {
                 // Special handling for non-generic IList types. By the time we get here,
                 // generic collection types will already have been handled by one of the known serializers.
@@ -187,6 +188,20 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
             return serializer;
         }
 
+        internal GenericCollectionHelper GetCollectionHelper(Type type)
+        {
+            if (_collectionHelpers == null)
+                _collectionHelpers = new Dictionary<Type, GenericCollectionHelper>();
+
+            GenericCollectionHelper result;
+            if (!_collectionHelpers.TryGetValue(type, out result))
+            {
+                result = new GenericCollectionHelper(this, type);
+                _collectionHelpers.Add(type, result);
+            }
+            return result;
+        }
+
         public static void Serialize<T>(XmlWriter output, T value, string referenceRelocationPath)
         {
             var serializer = new IntermediateSerializer();
@@ -197,7 +212,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
             // Write the asset.
             var format = new ContentSerializerAttribute { ElementName = "Asset" };
-            writer.WriteObjectInternal(value, format, serializer.GetTypeSerializer(typeof(T)), typeof(object));
+            writer.WriteObject<object>(value, format);
 
             // Process the shared resources and external references.
             writer.WriteSharedResources();

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/IntermediateWriter.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
                     Xml.WriteAttributeString("Null", "true");
                 }
-                else if (value.GetType() != declaredType && !IsNullableType(declaredType))
+                else if (value.GetType() != typeSerializer.TargetType && !IsNullableType(declaredType))
                 {
                     Xml.WriteStartAttribute("Type");
                     WriteTypeName(value.GetType());

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ReflectiveSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ReflectiveSerializer.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
         private readonly List<ElementInfo> _elements = new List<ElementInfo>();
 
         private ContentTypeSerializer _baseSerializer;
+        private GenericCollectionHelper _collectionHelper;
 
         private bool GetElementInfo(IntermediateSerializer serializer, MemberInfo member, out ElementInfo info)
         {
@@ -131,6 +132,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
                 if (GetElementInfo(serializer, field, out info))
                     _elements.Add(info);                
             }
+
+            if (GenericCollectionHelper.IsGenericCollectionType(TargetType, false))
+                _collectionHelper = serializer.GetCollectionHelper(TargetType);
         }
 
         public override bool CanDeserializeIntoExistingObject
@@ -191,6 +195,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
                 }
             }
 
+            if (_collectionHelper != null)
+                _collectionHelper.Deserialize(input, result, format);
+
             return result;
         }
 
@@ -198,6 +205,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
         {
             if (_baseSerializer != null)
                 return _baseSerializer.ObjectIsEmpty(value);
+            if (_collectionHelper != null)
+                return _collectionHelper.ObjectIsEmpty(value);
             return false;
         }
 
@@ -223,6 +232,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
 
                 elementSerializer.ScanChildren(serializer, callback, elementValue);
             }
+
+            if (_collectionHelper != null)
+                _collectionHelper.ScanChildren(callback, value);
         }
 
         protected internal override void Serialize(IntermediateWriter output, object value, ContentSerializerAttribute format)
@@ -241,6 +253,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
                 else
                     output.WriteObjectInternal(elementValue, info.Attribute, info.Serializer, info.Serializer.TargetType);
             }
+
+            if (_collectionHelper != null)
+                _collectionHelper.Serialize(output, value, format);
         }
     }
 }

--- a/Test/Assets/Xml/26_ChildCollections.xml
+++ b/Test/Assets/Xml/26_ChildCollections.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<XnaContent>
+  <Asset Type="ChildCollections">
+    <Children>
+      <Item>
+        <Name>Foo</Name>
+      </Item>
+      <Item>
+        <Name>Bar</Name>
+      </Item>
+    </Children>
+  </Asset>
+</XnaContent>

--- a/Test/ContentPipeline/AssetTestClasses.cs
+++ b/Test/ContentPipeline/AssetTestClasses.cs
@@ -436,6 +436,47 @@ class GenericClass<T>
 }
 #endregion
 
+#region ChildCollections
+public class ChildCollections
+{
+    private readonly ChildrenCollection _children;
+
+    [ContentSerializer]
+    public ChildrenCollection Children
+    {
+        get { return _children; }
+    }
+
+    public ChildCollections()
+    {
+        _children = new ChildrenCollection(this);
+    }
+}
+
+public class ChildrenCollection : ChildCollection<ChildCollections, ChildCollectionChild>
+{
+    public ChildrenCollection(ChildCollections parent) : base(parent)
+    {
+    }
+
+    protected override ChildCollections GetParent(ChildCollectionChild child)
+    {
+        return child.Parent;
+    }
+
+    protected override void SetParent(ChildCollectionChild child, ChildCollections parent)
+    {
+        child.Parent = parent;
+    }
+}
+
+public class ChildCollectionChild : ContentItem
+{
+    [ContentSerializerIgnore]
+    public ChildCollections Parent { get; set; }
+}
+#endregion
+
 class StructArrayNoElements
 {
     public Vector2[] Vector2ArrayNoElements = new Vector2[] {};

--- a/Test/ContentPipeline/IntermediateDeserializerTest.cs
+++ b/Test/ContentPipeline/IntermediateDeserializerTest.cs
@@ -550,5 +550,21 @@ namespace MonoGame.Tests.ContentPipeline
                 Assert.AreEqual(0, structArrayNoElems.Vector2ArrayNoElements.Length);
             });
         }
+
+        [Test]
+        public void ChildCollections()
+        {
+            // ChildCollection is a ContentPipeline-only type, so we don't need to / shouldn't
+            // test running it through ContentCompiler.
+            Deserialize<ChildCollections>("26_ChildCollections.xml", childCollections =>
+            {
+                Assert.IsNotNull(childCollections.Children);
+                Assert.AreEqual(2, childCollections.Children.Count);
+                Assert.AreEqual(childCollections, childCollections.Children[0].Parent);
+                Assert.AreEqual("Foo", childCollections.Children[0].Name);
+                Assert.AreEqual(childCollections, childCollections.Children[1].Parent);
+                Assert.AreEqual("Bar", childCollections.Children[1].Name);
+            });
+        }
     }
 }

--- a/Test/ContentPipeline/IntermediateSerializerTest.cs
+++ b/Test/ContentPipeline/IntermediateSerializerTest.cs
@@ -457,5 +457,18 @@ namespace MonoGame.Tests.ContentPipeline
                 B = new GenericClass<float> { Value = 4.2f }
             });
         }
+
+        [Test]
+        public void ChildCollections()
+        {
+            SerializeAndAssert("26_ChildCollections.xml", new ChildCollections
+            {
+                Children =
+                {
+                    new ChildCollectionChild { Name = "Foo" },
+                    new ChildCollectionChild { Name = "Bar" }
+                }
+            });
+        }
     }
 }

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -655,6 +655,12 @@
     <Content Include="Assets\Xml\24_GenericTypes.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Assets\Xml\25_StructArrayNoElements.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\Xml\26_ChildCollections.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Assets\Xml\19_FontDescription.xml">


### PR DESCRIPTION
This enables serialization of, for example,

```
public class MyCollection : Collection<T> {}

public class ClassToSerialize
{
    public MyCollection Children { get; set; }
}
```

where previously we only supported direct use of generic collection types:

```
public class ClassToSerialize
{
    public List<T> Children { get; set; }
}
```