### PR TITLE
Add Int32Reader. Fixes Song loading on iOS

### DIFF
--- a/MonoGame.Framework/Content/ContentTypeReaderManager.cs
+++ b/MonoGame.Framework/Content/ContentTypeReaderManager.cs
@@ -116,6 +116,7 @@ namespace Microsoft.Xna.Framework.Content
                 var hSoundEffectReader = new SoundEffectReader();
                 var hSongReader = new SongReader();
                 var hModelReader = new ModelReader();
+                var hInt32Reader = new Int32Reader();
 
                 // At the moment the Video class doesn't exist
                 // on all platforms... Allow it to compile anyway.


### PR DESCRIPTION
Was getting stripped when doing Full Linking.
Probably needed to load the duration from the xnb file?