### PR TITLE
Array type EffectParameter(s) now show element value(s) in debugger.

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/EffectParameter.cs
+++ b/MonoGame.Framework/Graphics/Effect/EffectParameter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Text;
 using System.Diagnostics;
 
@@ -105,57 +106,67 @@ namespace Microsoft.Xna.Framework.Graphics
                 if (!string.IsNullOrEmpty(Semantic))                
                     semanticStr = string.Concat(" <", Semantic, ">");
 
-                string valueStr;
-                if (Data == null)
-                    valueStr = "(null)";
-                else
-                {
-                    switch (ParameterClass)
-                    {
-                        // Object types are stored directly in the Data property.
-                        // Display Data's string value.
-                        case EffectParameterClass.Object:
-                            valueStr = Data.ToString();
-                            break;
-
-                        // Matrix types are stored in a float[16] which we don't really have room for.
-                        // Display "...".
-                        case EffectParameterClass.Matrix:
-                            valueStr = "...";
-                            break;
-
-                        // Scalar types are stored as a float[1].
-                        // Display the first (and only) element's string value.                    
-                        case EffectParameterClass.Scalar:
-                            valueStr = (Data as Array).GetValue(0).ToString();
-                            break;
-
-                        // Vector types are stored as an Array<Type>.
-                        // Display the string value of each array element.
-                        case EffectParameterClass.Vector:
-                            var array = Data as Array;
-                            var arrayStr = new string[array.Length];
-                            var idx = 0;
-                            foreach (var e in array)
-                            {
-                                arrayStr[idx] = array.GetValue(idx).ToString();
-                                idx++;
-                            }
-
-                            valueStr = string.Join(" ", arrayStr);
-                            break;
-
-                        // Handle additional cases here...
-                        default:
-                            valueStr = Data.ToString();
-                            break;
-                    }
-                }
-                
-                return string.Concat("[", ParameterClass, " ", ParameterType, "]", semanticStr, " ", Name, " : ", valueStr);
+                return string.Concat("[", ParameterClass, " ", ParameterType, "]", semanticStr, " ", Name, " : ", GetDataValueString());
             }
         }
 
+        private string GetDataValueString()
+        {
+            string valueStr;
+
+            if (Data == null)
+            {
+                if (Elements == null)
+                    valueStr = "(null)";
+                else                
+                    valueStr = string.Join(", ", Elements.Select(e => e.GetDataValueString()));                
+            }
+            else
+            {
+                switch (ParameterClass)
+                {
+                        // Object types are stored directly in the Data property.
+                        // Display Data's string value.
+                    case EffectParameterClass.Object:
+                        valueStr = Data.ToString();
+                        break;
+
+                        // Matrix types are stored in a float[16] which we don't really have room for.
+                        // Display "...".
+                    case EffectParameterClass.Matrix:
+                        valueStr = "...";
+                        break;
+
+                        // Scalar types are stored as a float[1].
+                        // Display the first (and only) element's string value.                    
+                    case EffectParameterClass.Scalar:
+                        valueStr = (Data as Array).GetValue(0).ToString();
+                        break;
+
+                        // Vector types are stored as an Array<Type>.
+                        // Display the string value of each array element.
+                    case EffectParameterClass.Vector:
+                        var array = Data as Array;
+                        var arrayStr = new string[array.Length];
+                        var idx = 0;
+                        foreach (var e in array)
+                        {
+                            arrayStr[idx] = array.GetValue(idx).ToString();
+                            idx++;
+                        }
+
+                        valueStr = string.Join(" ", arrayStr);
+                        break;
+
+                        // Handle additional cases here...
+                    default:
+                        valueStr = Data.ToString();
+                        break;
+                }
+            }
+
+            return string.Concat("{", valueStr, "}");                
+        }
 
         public bool GetValueBoolean ()
 		{
@@ -877,5 +888,5 @@ namespace Microsoft.Xna.Framework.Graphics
 				Elements[i].SetValue (value[i]);
             StateKey = unchecked(NextStateKey++);
 		}
-	}
+	}    
 }


### PR DESCRIPTION
Eg, the following will be seen in watch window...
```[Vector Single] PointLightPosition : {{1 0 0}, {0 1 0}}```

Previously all you would see was...
```[Vector Single] PointLightPosition : (null)```
