### PR TITLE
Preprocessor error line numbers

### DIFF
--- a/Test/Assets/Effects/PreprocessorTest.fx
+++ b/Test/Assets/Effects/PreprocessorTest.fx
@@ -10,7 +10,9 @@
 This is a C style comment.
 */
 
-#define
+#if foo(TEST)
+
+#endif
 
 #if TEST == 0
 Foo

--- a/Test/Assets/Effects/PreprocessorTest.fx
+++ b/Test/Assets/Effects/PreprocessorTest.fx
@@ -6,6 +6,12 @@
 
 #define TEST 1
 
+/*
+This is a C style comment.
+*/
+
+#define
+
 #if TEST == 0
 Foo
 #elif TEST == 1

--- a/Tools/2MGFX/Preprocessor.cs
+++ b/Tools/2MGFX/Preprocessor.cs
@@ -46,8 +46,9 @@ namespace TwoMGFX
                         if (tokenText != null)
                         {
                             // Need to preserve line breaks so that line numbers are correct.
-                            var lineBreaks = string.Join("", token.getText().Where(x => x == '\n'));
-                            result.Append(lineBreaks);
+                            foreach (var c in tokenText)
+                                if (c == '\n')
+                                    result.Append(c);
                         }
                         break;
                     }
@@ -124,32 +125,16 @@ namespace TwoMGFX
             {
                 if (!_dependencies.Contains(_path))
                     _dependencies.Add(_path);
-                return new MGFileLexerSource(_path);
+                return new MGStringLexerSource(File.ReadAllText(_path), true, _path);
             }
         }
 
-        private interface IMGLexerSource
-        {
-            string Path { get; }
-        }
-
-        private class MGFileLexerSource : FileLexerSource, IMGLexerSource
-        {
-            public string Path { get; private set; }
-
-            public MGFileLexerSource(string path)
-                : base(path)
-            {
-                Path = path;
-            }
-        }
-
-        private class MGStringLexerSource : StringLexerSource, IMGLexerSource
+        private class MGStringLexerSource : StringLexerSource
         {
             public string Path { get; private set; }
 
             public MGStringLexerSource(string str, bool ppvalid, string fileName)
-                : base(str, ppvalid, fileName)
+                : base(str.Replace("\r\n", "\n"), ppvalid, fileName)
             {
                 Path = fileName;
             }
@@ -176,7 +161,7 @@ namespace TwoMGFX
 
             private string GetPath(Source source)
             {
-                return ((IMGLexerSource) source).Path;
+                return ((MGStringLexerSource) source).Path;
             }
 
             public void handleSourceChange(Source source, string ev)


### PR DESCRIPTION
Related to #3853. This PR improves the line numbers reported in preprocessor error messages, but as mentioned in [this comment](https://github.com/mono/MonoGame/issues/3853#issuecomment-116190926) they are still not correct.

Preprocessor errors now use the correct filename, rather than always reporting errors on the root file.