### PR TITLE
[ContentPipeline] Ignore Identity bone

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/OpenAssetImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/OpenAssetImporter.cs
@@ -805,6 +805,18 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                     }
                 }
 
+                // Ignore identity bone
+                if (scaleKeys.Count == 1 && rotationKeys.Count == 1 && translationKeys.Count == 1)
+                {
+                    if(scaleKeys[0].Time == 0 &&
+                       rotationKeys[0].Time == 0 &&
+                       translationKeys[0].Time == 0 &&
+                       scaleKeys[0].Value == new Vector3D(1,1,1) &&
+                       rotationKeys[0].Value == new Assimp.Quaternion(1,0,0,0) &&
+                       translationKeys[0].Value == new Vector3D(0,0,0))
+                    continue;
+                }
+                
                 // Get all unique keyframe times. (Assuming that no two key frames
                 // have the same time, which is usually a safe assumption.)
                 var times = scaleKeys.Select(k => k.Time)


### PR DESCRIPTION
Animations usually have a ROOT/PIVOT bone. XNA remove this kind of bone. 
As can be seen from my tests in #3825 the same animation had 22 Bones when importing XNA animations and 23 Bones when importing MG animations.
