### PR TITLE
Clean up hanging references

### DIFF
--- a/MonoGame.Framework/GamePlatform.cs
+++ b/MonoGame.Framework/GamePlatform.cs
@@ -337,6 +337,9 @@ namespace Microsoft.Xna.Framework
         {
             if (!disposed)
             {
+                Mouse.PrimaryWindow = null;
+                TouchPanel.PrimaryWindow = null;
+
                 disposed = true;
             }
         }

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -251,6 +251,7 @@ namespace MonoGame.Framework
                 }
                 Microsoft.Xna.Framework.Media.MediaManagerState.CheckShutdown();
             }
+            Keyboard.SetKeys(null);
 
             base.Dispose(disposing);
         }

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -67,7 +67,7 @@ namespace MonoGame.Framework
         static private ReaderWriterLockSlim _allWindowsReaderWriterLockSlim = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
         static private List<WinFormsGameWindow> _allWindows = new List<WinFormsGameWindow>();
 
-        private readonly WinFormsGamePlatform _platform;
+        private WinFormsGamePlatform _platform;
 
         private bool _isResizable;
 
@@ -508,6 +508,11 @@ namespace MonoGame.Framework
                     _form = null;
                 }
             }
+            _platform = null;
+            Game = null;
+            Mouse.SetWindows(null);
+            Device.KeyboardInput -= OnRawKeyEvent;
+            Device.RegisterDevice(UsagePage.Generic, UsageId.GenericKeyboard, DeviceFlags.Remove);
         }
 
         public override void BeginScreenDeviceChange(bool willBeFullScreen)


### PR DESCRIPTION
This PR fixes up some hanging references held by static fields after Game.Exit was called.

Git normalized some inconsistent line endings on commit.