### PR TITLE
Linux GameWindow Icon Fix

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
@@ -36,6 +36,9 @@ or conditions. You may have additional consumer rights under your local laws whi
 permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
 purpose and non-infringement.
 */
+using MonoGame.Utilities;
+
+
 #endregion License
 
 #region Using Statements
@@ -127,6 +130,18 @@ namespace Microsoft.Xna.Framework
         {
             get { return new Microsoft.Xna.Framework.Point(window.Location.X,window.Location.Y); }
             set { window.Location = new System.Drawing.Point(value.X,value.Y); }
+        }
+
+        public override System.Drawing.Icon Icon
+        {
+            get
+            {
+                return window.Icon;
+            }
+            set
+            {
+                window.Icon = value;
+            }
         }
 #endif
         protected internal override void SetSupportedOrientations(DisplayOrientation orientations)
@@ -331,11 +346,17 @@ namespace Microsoft.Xna.Framework
 
             window.KeyPress += OnKeyPress;
 
-            // Set the window icon.
-            var assembly = Assembly.GetEntryAssembly();
-            if(assembly != null)
-                window.Icon = Icon.ExtractAssociatedIcon(assembly.Location);
-            Title = MonoGame.Utilities.AssemblyHelper.GetDefaultWindowTitle();
+            //make sure that the game is not running on linux
+            //on Linux people may want to use mkbundle to
+            //create native Linux binaries
+            if (CurrentPlatform.OS != OS.Linux)
+            {
+                // Set the window icon.
+                var assembly = Assembly.GetEntryAssembly();
+                if (assembly != null)
+                    window.Icon = Icon.ExtractAssociatedIcon(assembly.Location);
+                Title = MonoGame.Utilities.AssemblyHelper.GetDefaultWindowTitle();
+            }
 
             updateClientBounds = false;
             clientBounds = new Rectangle(window.ClientRectangle.X, window.ClientRectangle.Y,

--- a/MonoGame.Framework/GameWindow.cs
+++ b/MonoGame.Framework/GameWindow.cs
@@ -31,6 +31,10 @@ namespace Microsoft.Xna.Framework {
         public abstract Point Position { get; set; }
 #endif
 
+#if DESKTOPGL
+        public abstract System.Drawing.Icon Icon { get; set; }
+#endif
+
 		public abstract DisplayOrientation CurrentOrientation { get; }
 
 		public abstract IntPtr Handle { get; }

--- a/Test/Framework/MockWindow.cs
+++ b/Test/Framework/MockWindow.cs
@@ -21,6 +21,9 @@ namespace MonoGame.Tests.Framework
 #if (WINDOWS && !WINRT) || LINUX
         public override Point Position { get; set; }
 #endif
+#if DESKTOPGL
+        public override System.Drawing.Icon Icon { get; set; } 
+#endif
 
         public override DisplayOrientation CurrentOrientation
         {


### PR DESCRIPTION
This fixes the following:
 - not being able to set window icon when on Linux / OS X (#3822)
 - not being able to use mkbundle with MonoGame, mkbundle is a way of bundling c# exe into a native Linux binary that does not require mono for running it. (
<br>old docs: http://www.mono-project.com/archived/guiderunning_mono_applications/
<br>usage with MonoGame: http://youtu.be/rU5TxvD3rzU )

