### PR TITLE
Fix [WP8.1] MonoGame.Framework.StorageDevice throws NotSupportedExcep…

### DIFF
--- a/MonoGame.Framework/Storage/StorageDevice.cs
+++ b/MonoGame.Framework/Storage/StorageDevice.cs
@@ -71,6 +71,7 @@ using MonoGame.Utilities;
 using Microsoft.Xna.Framework;
 using System;
 using System.IO;
+using System.Threading.Tasks;
 
 #if WINRT
 using Windows.Storage;
@@ -239,15 +240,39 @@ namespace Microsoft.Xna.Framework.Storage
 		
 		private IAsyncResult OpenContainer (string displayName, AsyncCallback callback, object state)
 		{
-			try {
-				OpenContainerAsynchronous AsynchronousOpen = new OpenContainerAsynchronous (Open);
+
+#if WINDOWS || MONOMAC
+            try
+            {
+                OpenContainerAsynchronous AsynchronousOpen = new OpenContainerAsynchronous(Open);
 #if WINRT
                 containerDelegate = AsynchronousOpen;
 #endif
-                return AsynchronousOpen.BeginInvoke (displayName, callback, state);
-			} finally {
-			}
-		}
+                return AsynchronousOpen.BeginInvoke(displayName, callback, state);
+            }
+            finally
+            {
+            }
+#else
+            var tcs = new TaskCompletionSource<StorageContainer>(state);
+            var task = Task.Run<StorageContainer>(() => Open(displayName));
+            task.ContinueWith(t =>
+            {
+                // Copy the task result into the returned task.
+                if (t.IsFaulted)
+                    tcs.TrySetException(t.Exception.InnerExceptions);
+                else if (t.IsCanceled)
+                    tcs.TrySetCanceled();
+                else
+                    tcs.TrySetResult(t.Result);
+
+                // Invoke the user callback if necessary.
+                if (callback != null)
+                    callback(tcs.Task);
+            });
+            return tcs.Task;
+#endif
+        }
 	
 		// Private method to handle the creation of the StorageDevice
 		private StorageContainer Open (string displayName) 
@@ -255,42 +280,43 @@ namespace Microsoft.Xna.Framework.Storage
 			storageContainer = new StorageContainer(this, displayName, this.player);
 			return storageContainer;
 		}
-		
-		//
-		// Summary:
-		//     Begins the process for displaying the storage device selector user interface,
-		//     and for specifying a callback implemented when the player chooses a device.
-		//     Reference page contains links to related code samples.
-		//
-		// Parameters:
-		//   callback:
-		//     An AsyncCallback that represents the method called when the player chooses
-		//     a device.
-		//
-		//   state:
-		//     A user-created object used to uniquely identify the request, or null.
-		public static IAsyncResult BeginShowSelector (AsyncCallback callback, object state)
-		{
-			return BeginShowSelector (0, 0, callback, state);
-		}
-		//
-		// Summary:
-		//     Begins the process for displaying the storage device selector user interface;
-		//     specifies the callback implemented when the player chooses a device. Reference
-		//     page contains links to related code samples.
-		//
-		// Parameters:
-		//   player:
-		//     The PlayerIndex that represents the player who requested the save operation.
-		//     On Windows, the only valid option is PlayerIndex.One.
-		//
-		//   callback:
-		//     An AsyncCallback that represents the method called when the player chooses
-		//     a device.
-		//
-		//   state:
-		//     A user-created object used to uniquely identify the request, or null.
-		public static IAsyncResult BeginShowSelector (PlayerIndex player, AsyncCallback callback, object state)
+
+        //
+        // Summary:
+        //     Begins the process for displaying the storage device selector user interface,
+        //     and for specifying a callback implemented when the player chooses a device.
+        //     Reference page contains links to related code samples.
+        //
+        // Parameters:
+        //   callback:
+        //     An AsyncCallback that represents the method called when the player chooses
+        //     a device.
+        //
+        //   state:
+        //     A user-created object used to uniquely identify the request, or null.
+        public static IAsyncResult BeginShowSelector (AsyncCallback callback, object state)
+        {
+        	return BeginShowSelector (0, 0, callback, state);
+        }
+
+        //
+        // Summary:
+        //     Begins the process for displaying the storage device selector user interface;
+        //     specifies the callback implemented when the player chooses a device. Reference
+        //     page contains links to related code samples.
+        //
+        // Parameters:
+        //   player:
+        //     The PlayerIndex that represents the player who requested the save operation.
+        //     On Windows, the only valid option is PlayerIndex.One.
+        //
+        //   callback:
+        //     An AsyncCallback that represents the method called when the player chooses
+        //     a device.
+        //
+        //   state:
+        //     A user-created object used to uniquely identify the request, or null.
+        public static IAsyncResult BeginShowSelector (PlayerIndex player, AsyncCallback callback, object state)
 		{
 			return BeginShowSelector (player, 0, 0, callback, state);
 		}
@@ -316,13 +342,33 @@ namespace Microsoft.Xna.Framework.Storage
 		//     A user-created object used to uniquely identify the request, or null.
 		public static IAsyncResult BeginShowSelector (int sizeInBytes, int directoryCount, AsyncCallback callback, object state)
 		{
-			var del = new ShowSelectorAsynchronousShowNoPlayer (Show);
+#if WINDOWS || MONOMAC
+            var del = new ShowSelectorAsynchronousShowNoPlayer (Show);
 
 #if WINRT
             showDelegate = del;
 #endif
 			return del.BeginInvoke(sizeInBytes, directoryCount, callback, state);
-		}
+#else
+            var tcs = new TaskCompletionSource<StorageDevice>(state);
+            var task = Task.Run<StorageDevice>(() => Show (sizeInBytes, directoryCount));
+            task.ContinueWith(t =>
+            {
+                // Copy the task result into the returned task.
+                if (t.IsFaulted)
+                    tcs.TrySetException(t.Exception.InnerExceptions);
+                else if (t.IsCanceled)
+                    tcs.TrySetCanceled();
+                else
+                    tcs.TrySetResult(t.Result);
+
+                // Invoke the user callback if necessary.
+                if (callback != null)
+                    callback(tcs.Task);
+            });
+            return tcs.Task;
+#endif
+        }
 
 		
 		//
@@ -352,11 +398,31 @@ namespace Microsoft.Xna.Framework.Storage
 		//     A user-created object used to uniquely identify the request, or null.
 		public static IAsyncResult BeginShowSelector (PlayerIndex player, int sizeInBytes, int directoryCount, AsyncCallback callback, object state)
 		{
-			var del = new ShowSelectorAsynchronousShow (Show);
+#if WINDOWS || MONOMAC
+            var del = new ShowSelectorAsynchronousShow (Show);
 #if WINRT
             showDelegate = del;
 #endif
             return del.BeginInvoke(player, sizeInBytes, directoryCount, callback, state);
+#else
+            var tcs = new TaskCompletionSource<StorageDevice>(state);
+            var task = Task.Run<StorageDevice>(() => Show(player, sizeInBytes, directoryCount));
+            task.ContinueWith(t =>
+            {
+                // Copy the task result into the returned task.
+                if (t.IsFaulted)
+                    tcs.TrySetException(t.Exception.InnerExceptions);
+                else if (t.IsCanceled)
+                    tcs.TrySetCanceled();
+                else
+                    tcs.TrySetResult(t.Result);
+
+                // Invoke the user callback if necessary.
+                if (callback != null)
+                    callback(tcs.Task);
+            });
+            return tcs.Task;
+#endif
         }
 	
 		// Private method to handle the creation of the StorageDevice
@@ -365,12 +431,12 @@ namespace Microsoft.Xna.Framework.Storage
 			return new StorageDevice(player, sizeInBytes, directoryCount);
 		}
 
-		private static StorageDevice Show (int sizeInBytes, int directoryCount)
+        private static StorageDevice Show (int sizeInBytes, int directoryCount)
 		{
 			return new StorageDevice (null, sizeInBytes, directoryCount);
 		}
-		
-		/*
+
+        /*
 		//
 		//
 		// Parameters:
@@ -382,17 +448,20 @@ namespace Microsoft.Xna.Framework.Storage
 		}			
         */
 
-		//
-		// Summary:
-		//     Ends the process for opening a StorageContainer.
-		//
-		// Parameters:
-		//   result:
-		//     The IAsyncResult returned from BeginOpenContainer.
-		public StorageContainer EndOpenContainer (IAsyncResult result)
+        //
+        // Summary:
+        //     Ends the process for opening a StorageContainer.
+        //
+        // Parameters:
+        //   result:
+        //     The IAsyncResult returned from BeginOpenContainer.
+        public StorageContainer EndOpenContainer (IAsyncResult result)
 		{
-			StorageContainer returnValue = null;
-			try {
+
+#if WINDOWS || MONOMAC
+            StorageContainer returnValue = null;
+            try
+            {
 #if WINRT
                 // AsyncResult does not exist in WinRT
                 var asyncResult = containerDelegate as OpenContainerAsynchronous;
@@ -406,30 +475,41 @@ namespace Microsoft.Xna.Framework.Storage
 				}
                 containerDelegate = null;
 #else
-				// Retrieve the delegate.
-				AsyncResult asyncResult = result as AsyncResult;
-				if (asyncResult != null)
-				{
-					var asyncDelegate = asyncResult.AsyncDelegate as OpenContainerAsynchronous;
+                // Retrieve the delegate.
+                AsyncResult asyncResult = result as AsyncResult;
+                if (asyncResult != null)
+                {
+                    var asyncDelegate = asyncResult.AsyncDelegate as OpenContainerAsynchronous;
 
-					// Wait for the WaitHandle to become signaled.
-					result.AsyncWaitHandle.WaitOne();
+                    // Wait for the WaitHandle to become signaled.
+                    result.AsyncWaitHandle.WaitOne();
 
-					// Call EndInvoke to retrieve the results.
-					if (asyncDelegate != null)
-						returnValue = asyncDelegate.EndInvoke(result);
-				}
+                    // Call EndInvoke to retrieve the results.
+                    if (asyncDelegate != null)
+                        returnValue = asyncDelegate.EndInvoke(result);
+                }
 #endif
             }
             finally
             {
-				// Close the wait handle.
-				result.AsyncWaitHandle.Dispose ();	 
-			}
-			
-			return returnValue;
+                // Close the wait handle.
+                result.AsyncWaitHandle.Dispose();
+            }
 
-		}			
+            return returnValue;
+#else
+            try
+            {
+                return ((Task<StorageContainer>)result).Result;
+            }
+            catch (AggregateException ex)
+            {
+                throw;
+            }
+#endif
+
+        }			
+
 		//
 		// Summary:
 		//     Ends the display of the storage selector user interface. Reference page contains
@@ -441,32 +521,48 @@ namespace Microsoft.Xna.Framework.Storage
 		public static StorageDevice EndShowSelector (IAsyncResult result) 
 		{
 
-			if (!result.IsCompleted) {
-				// Wait for the WaitHandle to become signaled.
-				try {
-					result.AsyncWaitHandle.WaitOne ();
-				} finally {
+#if WINDOWS || MONOMAC
+            if (!result.IsCompleted)
+            {
+                // Wait for the WaitHandle to become signaled.
+                try
+                {
+                    result.AsyncWaitHandle.WaitOne();
+                }
+                finally
+                {
 #if !WINRT
-					result.AsyncWaitHandle.Close ();
+                    result.AsyncWaitHandle.Close();
 #endif
-				}
-			}
+                }
+            }
 #if WINRT
             var del = showDelegate;
             showDelegate = null;
 #else
-			// Retrieve the delegate.
-			AsyncResult asyncResult = (AsyncResult)result;
+            // Retrieve the delegate.
+            AsyncResult asyncResult = (AsyncResult)result;
 
             var del = asyncResult.AsyncDelegate;
 #endif
 
-			if (del is ShowSelectorAsynchronousShow)
-				return (del as ShowSelectorAsynchronousShow).EndInvoke (result);
-			else if (del is ShowSelectorAsynchronousShowNoPlayer)
-				return (del as ShowSelectorAsynchronousShowNoPlayer).EndInvoke (result);
-			else
-				throw new ArgumentException ("result");
+            if (del is ShowSelectorAsynchronousShow)
+                return (del as ShowSelectorAsynchronousShow).EndInvoke(result);
+            else if (del is ShowSelectorAsynchronousShowNoPlayer)
+                return (del as ShowSelectorAsynchronousShowNoPlayer).EndInvoke(result);
+            else
+                throw new ArgumentException("result");
+#else
+            try
+            {
+                return ((Task<StorageDevice>)result).Result;
+            }
+            catch (AggregateException ex)
+            {
+                throw;
+            }
+#endif
+
 		}
 		
 		internal static string StorageRoot

--- a/MonoGame.Framework/Storage/StorageDevice.cs
+++ b/MonoGame.Framework/Storage/StorageDevice.cs
@@ -239,9 +239,9 @@ namespace Microsoft.Xna.Framework.Storage
 		}
 		
 		private IAsyncResult OpenContainer (string displayName, AsyncCallback callback, object state)
-		{
+        {
 
-#if WINDOWS || MONOMAC
+#if !WINDOWS_PHONE81 && !ANDROID && !IOS && !NETFX_CORE && !WINDOWS_PHONE
             try
             {
                 OpenContainerAsynchronous AsynchronousOpen = new OpenContainerAsynchronous(Open);
@@ -342,7 +342,7 @@ namespace Microsoft.Xna.Framework.Storage
 		//     A user-created object used to uniquely identify the request, or null.
 		public static IAsyncResult BeginShowSelector (int sizeInBytes, int directoryCount, AsyncCallback callback, object state)
 		{
-#if WINDOWS || MONOMAC
+#if !WINDOWS_PHONE81 && !ANDROID && !IOS && !NETFX_CORE && !WINDOWS_PHONE
             var del = new ShowSelectorAsynchronousShowNoPlayer (Show);
 
 #if WINRT
@@ -398,7 +398,7 @@ namespace Microsoft.Xna.Framework.Storage
 		//     A user-created object used to uniquely identify the request, or null.
 		public static IAsyncResult BeginShowSelector (PlayerIndex player, int sizeInBytes, int directoryCount, AsyncCallback callback, object state)
 		{
-#if WINDOWS || MONOMAC
+#if !WINDOWS_PHONE81 && !ANDROID && !IOS && !NETFX_CORE && !WINDOWS_PHONE
             var del = new ShowSelectorAsynchronousShow (Show);
 #if WINRT
             showDelegate = del;
@@ -458,7 +458,7 @@ namespace Microsoft.Xna.Framework.Storage
         public StorageContainer EndOpenContainer (IAsyncResult result)
 		{
 
-#if WINDOWS || MONOMAC
+#if !WINDOWS_PHONE81 && !ANDROID && !IOS && !NETFX_CORE && !WINDOWS_PHONE
             StorageContainer returnValue = null;
             try
             {
@@ -521,7 +521,7 @@ namespace Microsoft.Xna.Framework.Storage
 		public static StorageDevice EndShowSelector (IAsyncResult result) 
 		{
 
-#if WINDOWS || MONOMAC
+#if !WINDOWS_PHONE81 && !ANDROID && !IOS && !NETFX_CORE && !WINDOWS_PHONE
             if (!result.IsCompleted)
             {
                 // Wait for the WaitHandle to become signaled.


### PR DESCRIPTION
…tion.

See issue https://github.com/mono/MonoGame/issues/3988

Has been tested on WindowsDX, WidnowsGL, Windows8, WP8.0, WP8.1, Android, iOS and Mac.