### PR TITLE
Fixed threading issue in OggStream

### DIFF
--- a/MonoGame.Framework/Utilities/OggStream.cs
+++ b/MonoGame.Framework/Utilities/OggStream.cs
@@ -341,6 +341,9 @@ namespace MonoGame.Utilities
 
         public OggStreamer(int bufferSize = DefaultBufferSize, float updateRate = DefaultUpdateRate)
         {
+            UpdateRate = updateRate;
+            BufferSize = bufferSize;
+
             lock (singletonMutex)
             {
                 if (instance != null)
@@ -350,9 +353,6 @@ namespace MonoGame.Utilities
                 underlyingThread = new Thread(EnsureBuffersFilled) { Priority = ThreadPriority.Lowest };
                 underlyingThread.Start();
             }
-
-            UpdateRate = updateRate;
-            BufferSize = bufferSize;
 
             readSampleBuffer = new float[bufferSize];
             castBuffer = new short[bufferSize];
@@ -413,7 +413,7 @@ namespace MonoGame.Utilities
         {
             while (!cancelled)
             {
-                Thread.Sleep((int) (1000 / UpdateRate));
+                Thread.Sleep((int) (1000 / ((UpdateRate <= 0) ? 1 : UpdateRate)));
                 if (cancelled) break;
 
                 threadLocalStreams.Clear();


### PR DESCRIPTION
Fixes threading issue in OggStream, update rate was getting set after the thread... also added an extra check just in case.