### PR TITLE
Fix missing reference to FreeImageNET on Windows

### DIFF
--- a/Build/Projects/Framework.Content.Pipeline.References.definition
+++ b/Build/Projects/Framework.Content.Pipeline.References.definition
@@ -67,7 +67,7 @@
       Path="ThirdParty\Dependencies\SharpFont\x64\SharpFont.dll" />
     <Binary
       Name="FreeImageNET"
-      Path="ThirdParty\Dependencies\FreeImage.NET\Windows\FreeImageNET.dll" />
+      Path="ThirdParty\Dependencies\FreeImage.NET\FreeImageNET.dll" />
     <Binary
       Name="PVRTexLibNET"
       Path="ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll" />


### PR DESCRIPTION
Doing a plain checkout of develop, I was unable to compile the content pipeline project. Applying this change fixes that.

It looks like the location of the FreeImage library was moved in https://github.com/Mono-Game/MonoGame.Dependencies/commit/5b324d9eae92925b3d7acb0084879dc44d06727b.