### PR TITLE
expose SRT Channels

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/AnimationChannel.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/AnimationChannel.cs
@@ -15,6 +15,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
     {
         List<AnimationKeyframe> keyframes;
 
+        public Dictionary<TimeSpan, Vector3> Translation;
+        public Dictionary<TimeSpan, Vector3> Scale;
+        public Dictionary<TimeSpan, Quaternion> Rotation;
+
         /// <summary>
         /// Gets the number of keyframes in the collection.
         /// </summary>
@@ -54,6 +58,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         public AnimationChannel()
         {
             keyframes = new List<AnimationKeyframe>();
+            Translation = new Dictionary<TimeSpan, Vector3>();
+            Scale = new Dictionary<TimeSpan,Vector3>();
+            Rotation = new Dictionary<TimeSpan,Quaternion>();
         }
 
         /// <summary>

--- a/MonoGame.Framework.Content.Pipeline/OpenAssetImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/OpenAssetImporter.cs
@@ -805,6 +805,26 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                     }
                 }
 
+                var translateTime = (TimeSpan.TicksPerSecond / aiAnimation.TicksPerSecond);
+                foreach (var key in scaleKeys)
+                {
+                    long ticks = (long)(key.Time * translateTime);
+                    TimeSpan time = TimeSpan.FromTicks(ticks);
+                    channel.Scale[time] = ToXna(key.Value);
+                }
+                foreach (var key in rotationKeys)
+                {
+                    long ticks = (long)(key.Time * translateTime);
+                    TimeSpan time = TimeSpan.FromTicks(ticks);
+                    channel.Rotation[time] = ToXna(key.Value);
+                }
+                foreach (var key in translationKeys)
+                {
+                    long ticks = (long)(key.Time * translateTime);
+                    TimeSpan time = TimeSpan.FromTicks(ticks);
+                    channel.Translation[time] = ToXna(key.Value);
+                }
+                
                 // Get all unique keyframe times. (Assuming that no two key frames
                 // have the same time, which is usually a safe assumption.)
                 var times = scaleKeys.Select(k => k.Time)


### PR DESCRIPTION
Expose Scale/Rotate/Translate channels to content Processors.

```
//ex: access Scale keyframes from content Processor
foreach (var keyframeContent in animationChannel.Scale)
{
        var time = keyframeContent.Key;
        var scale = keyframeContent.Value;
}
```