### PR TITLE
DynamicVertexBuffer.SetData(..., SetDataOptions)

### DIFF
--- a/MonoGame.Framework/Graphics/Vertices/DynamicVertexBuffer.cs
+++ b/MonoGame.Framework/Graphics/Vertices/DynamicVertexBuffer.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
@@ -32,7 +33,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public void SetData<T>(T[] data, int startIndex, int elementCount, SetDataOptions options) where T : struct
         {
-            base.SetDataInternal<T>(0, data, startIndex, elementCount, VertexDeclaration.VertexStride, options);
+            var elementSizeInBytes = Marshal.SizeOf(typeof(T));
+            base.SetDataInternal<T>(0, data, startIndex, elementCount, elementSizeInBytes, options);
         }
     }
 }

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.DirectX.cs
@@ -133,8 +133,16 @@ namespace Microsoft.Xna.Framework.Graphics
                 lock (d3dContext)
                 {
                     var dataBox = d3dContext.MapSubresource(_buffer, 0, mode, SharpDX.Direct3D11.MapFlags.None);
-                    SharpDX.Utilities.Write(IntPtr.Add(dataBox.DataPointer, offsetInBytes), data, startIndex,
-                                            elementCount);
+                    if (vertexStride == elementSizeInBytes)
+					{
+                        SharpDX.Utilities.Write(dataBox.DataPointer + offsetInBytes, data, startIndex, elementCount);
+                    }
+                    else
+                    {
+                        for (int i = 0; i < elementCount; i++)
+                            SharpDX.Utilities.Write(dataBox.DataPointer + offsetInBytes + i * vertexStride, data, startIndex + i, 1);
+                    }
+
                     d3dContext.UnmapSubresource(_buffer, 0);
                 }
             }

--- a/Test/Framework/Visual/VertexBufferTest.cs
+++ b/Test/Framework/Visual/VertexBufferTest.cs
@@ -116,6 +116,12 @@ namespace MonoGame.Tests.Visual
                 var savedDataBytes = ArrayUtil.ConvertFrom(savedData);
                 vertexBuffer.SetData(savedDataBytes);
 
+                if (dynamic)
+                {
+                    var dynamicVertexBuffer = vertexBuffer as DynamicVertexBuffer;
+                    dynamicVertexBuffer.SetData(savedDataBytes, 0, savedDataBytes.Length, SetDataOptions.None);
+                }
+
                 var readData = new VertexPositionTexture[4];
                 vertexBuffer.GetData(readData, 0, 4);
                 Assert.AreEqual(savedData, readData);


### PR DESCRIPTION
The DynamicVertexBuffer specific SetData throws
"InvalidOperationException : The vertex stride is larger than the vertex
buffer" when initialized from a byte array