### PR TITLE
TouchPanelCapabilities fix for Windows 10

### DIFF
--- a/MonoGame.Framework/Input/Touch/TouchPanelCapabilities.cs
+++ b/MonoGame.Framework/Input/Touch/TouchPanelCapabilities.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Xna.Framework.Input.Touch
                 // XNA does not expose a pressure value, so let's assume it doesn't support it.
                 hasPressure = false;
 
-#if WINDOWS_STOREAPP
+#if WINDOWS_STOREAPP || WINDOWS_UAP
                 // Is a touch device present?
                 // Iterate through all pointer devices and find the maximum number of concurrent touches possible
                 maximumTouchCount = 0;


### PR DESCRIPTION
TouchPanel.IsConnected was always false prior to this