### PR TITLE
Trim DXGI device when suspending on UWP as required by app cert kit

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -1401,5 +1401,12 @@ namespace Microsoft.Xna.Framework.Graphics
             return graphicsProfile;
         }
 
+#if WINDOWS_STOREAPP || WINDOWS_UAP
+        internal void Trim()
+        {
+            using (var dxgiDevice3 = _d3dDevice.QueryInterface<SharpDX.DXGI.Device3>())
+                dxgiDevice3.Trim();
+        }
+#endif
     }
 }

--- a/MonoGame.Framework/WindowsUAP/UAPGamePlatform.cs
+++ b/MonoGame.Framework/WindowsUAP/UAPGamePlatform.cs
@@ -11,7 +11,9 @@ using System.Diagnostics;
 //using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input.Touch;
+using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
+using Windows.ApplicationModel.Core;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml;
@@ -97,7 +99,15 @@ namespace Microsoft.Xna.Framework
 
             SystemNavigationManager.GetForCurrentView().BackRequested += BackRequested;
 
+            CoreApplication.Suspending += this.CoreApplication_Suspending;
+
             Game.PreviousExecutionState = PreviousExecutionState;
+        }
+
+        private void CoreApplication_Suspending(object sender, SuspendingEventArgs e)
+        {
+            if (this.Game.GraphicsDevice != null)
+                this.Game.GraphicsDevice.Trim();
         }
 
         public override GameRunBehavior DefaultRunBehavior


### PR DESCRIPTION
This was not added during transition the to W8.1 (#2204). I don't know if these things are in the right place, but they make it possible to pass the app cert kit.

It would be also great to add similar code to the Windows 8 version as officially it is also required there.