### PR TITLE
Fixed sample length for SoundEffect.FromStream (Windows DirectX)

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -125,10 +125,11 @@ namespace Microsoft.Xna.Framework.Audio
         {
             var soundStream = new SoundStream(s);
             var dataStream = soundStream.ToDataStream();
+            var sampleLength = (int)(dataStream.Length / ((soundStream.Format.Channels * soundStream.Format.BitsPerSample) / 8));
             CreateBuffers(  soundStream.Format,
                             dataStream,
                             0,
-                            (int)dataStream.Length);
+                            sampleLength);
         }
 
         private void CreateBuffers(WaveFormat format, DataStream dataStream, int loopStart, int loopLength)


### PR DESCRIPTION
SoundEffect.FromStream is currently using the wrong sample length (in the Windows DirectX build). It's currently using the length in bytes, when it needs to use the length in samples. The effect of this is that sound effects loaded with FromStream play for too long (and usually end up playing bits of other sound effects).

There was some code correcting for this at some point, but this was removed in PR #3638 because XNB sound effect lengths are already specified in samples.

So this PR calculates the correct length in samples only when using SoundEffect.FromStream. It won't affect loading of XNB sound effects.