### PR TITLE
Removed call to GetExecutingAssembly in ContentTypeReaderManager

### DIFF
--- a/MonoGame.Framework/Content/ContentTypeReaderManager.cs
+++ b/MonoGame.Framework/Content/ContentTypeReaderManager.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Xna.Framework.Content
 #if WINRT
             _assemblyName = typeof(ContentTypeReaderManager).GetTypeInfo().Assembly.FullName;
 #else
-            _assemblyName = Assembly.GetExecutingAssembly().FullName;
+            _assemblyName = typeof(ContentTypeReaderManager).Assembly.FullName;
 #endif
         }
 


### PR DESCRIPTION
Removed call to GetExecutingAssembly in favour to use the Assembly property of Type.

Fixes #4047