### PR TITLE
[Win Pipeline] Use window color for menubar if on Windows 10

### DIFF
--- a/Build/GenerateProject.CSharp.xslt
+++ b/Build/GenerateProject.CSharp.xslt
@@ -598,6 +598,15 @@
       </xsl:when>
     </xsl:choose>
     </PropertyGroup>
+	<xsl:choose>
+      <xsl:when test="/Input/Properties/ApplicationManifest">
+        <PropertyGroup>
+            <ApplicationManifest>
+                <xsl:value-of select="/Input/Properties/ApplicationManifest" />
+            </ApplicationManifest>
+        </PropertyGroup>
+      </xsl:when>
+    </xsl:choose>
   </xsl:template>
 
   <xsl:template name="NativeBinary"

--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -21,6 +21,7 @@
     <RootNamespace>MonoGame.Tools.Pipeline</RootNamespace>
     <PlatformSpecificOutputFolder>True</PlatformSpecificOutputFolder>
     <WindowsApplicationIcon>App.ico</WindowsApplicationIcon>
+	<ApplicationManifest>app.manifest</ApplicationManifest>
     <CustomDefinitions>
       <Platform Name="Windows">TRACE;WINDOWS</Platform>
       <Platform Name="MacOS">TRACE;MONOMAC;GTK2</Platform>
@@ -36,6 +37,7 @@
       <Link>Common\CommandLineParser.cs</Link>
     </Compile>
     <None Include="App.config" />
+    <None Include="app.manifest" />
 
     <Compile Include="Common\ActionStack.cs" />
     <Compile Include="Common\AssemblyAttributes.cs" />

--- a/Tools/Pipeline/Windows/MainView.cs
+++ b/Tools/Pipeline/Windows/MainView.cs
@@ -36,6 +36,10 @@ namespace MonoGame.Tools.Pipeline
         {            
             InitializeComponent();
 
+            // Set MenuBar color to Window color if the current OS is Windows 10
+            if (System.Environment.OSVersion.Version.Major == 10)
+                this._mainMenu.BackColor = SystemColors.Window;
+
             // Set the application icon this form.
             Icon = Icon.ExtractAssociatedIcon(Application.ExecutablePath);
 

--- a/Tools/Pipeline/app.manifest
+++ b/Tools/Pipeline/app.manifest
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on and is
+           is designed to work with. Uncomment the appropriate elements and Windows will 
+           automatically selected the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />
+
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
+  <!--
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+  -->
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>


### PR DESCRIPTION
Just thought it looked a bit ugly, had to change it...

For the question why didn't I use "System.Environment.OSVersion" to check if the OS is Windows 10, that's easy to answer, that would give me a result of Windows 8:

> Applications not manifested for Windows 8.1 or Windows 10 will return the Windows 8 OS version value (6.2). 

https://msdn.microsoft.com/en-ca/library/windows/desktop/ms724832(v=vs.85).aspx