### PR TITLE
Reverting audio changes (#4010) due to bug on Windows 7 (#4045)

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -73,6 +73,15 @@ namespace Microsoft.Xna.Framework.Audio
             {
                 if (Device == null)
                 {
+#if !WINRT && DEBUG
+                    try
+                    {
+                        //Fails if the XAudio2 SDK is not installed
+                        Device = new XAudio2(XAudio2Flags.DebugEngine, ProcessorSpecifier.DefaultProcessor);
+                        Device.StartEngine();
+                    }
+                    catch
+#endif
                     {
                         Device = new XAudio2(XAudio2Flags.None, ProcessorSpecifier.DefaultProcessor);
                         Device.StartEngine();
@@ -80,7 +89,11 @@ namespace Microsoft.Xna.Framework.Audio
                 }
 
                 // Just use the default device.
+#if WINRT
                 string deviceId = null;
+#else
+                const int deviceId = 0;
+#endif
 
                 if (MasterVoice == null)
                 {
@@ -89,7 +102,12 @@ namespace Microsoft.Xna.Framework.Audio
                 }
 
                 // The autodetected value of MasterVoice.ChannelMask corresponds to the speaker layout.
+#if WINRT
                 Speakers = (Speakers)MasterVoice.ChannelMask;
+#else
+                var deviceDetails = Device.GetDeviceDetails(deviceId);
+                Speakers = deviceDetails.OutputFormat.ChannelMask;
+#endif
             }
             catch
             {


### PR DESCRIPTION
There seems to be a problem when using DX11.1 and 11.2 on Windows 7:
http://sharpdx.org/forum/5-api-usage/3334-xaudio2-unable-to-load-dll-xaudio2-8-dll

This commit reverts the requirement for the newer version of DX, and just uses DX11.
This should now work on both Windows 7 and Windows 8.

The dependencies uses my revision, but before it is pulled, I'll change it.

See issue: https://github.com/mono/MonoGame/issues/4045