### PR TITLE
Windows 8/10 input panel fixes

### DIFF
--- a/MonoGame.Framework/Input/KeyboardInput.WinRT.cs
+++ b/MonoGame.Framework/Input/KeyboardInput.WinRT.cs
@@ -346,6 +346,8 @@ namespace Microsoft.Xna.Framework.Input
 
         private void OnLayoutRootTapped(object sender, TappedRoutedEventArgs e)
         {
+            _buttons[0].Focus(FocusState.Programmatic); // Hide input panel
+
             if (e.OriginalSource == sender &&
                 IsLightDismissEnabled)
             {

--- a/MonoGame.Framework/Themes/generic.xaml
+++ b/MonoGame.Framework/Themes/generic.xaml
@@ -76,6 +76,9 @@
                     <Setter
                         Property="MinHeight"
                         Value="52" />
+                    <Setter
+                        Property="Background"
+                        Value="White" />
                 </Style>
             </Setter.Value>
         </Setter>
@@ -107,34 +110,6 @@
                     <Setter
                         Property="FontSize"
                         Value="40" />
-                    <Setter Property="Template">
-                        <Setter.Value>
-                            <ControlTemplate TargetType="Button">
-                                <Border Height="{TemplateBinding Height}" Width="{TemplateBinding Width}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" x:Name="ButtonHighlight" BorderThickness="0" BorderBrush="Black">
-                                    <Grid>
-                                        <Rectangle x:Name="innerRectangle" HorizontalAlignment="Stretch" 
-                                           VerticalAlignment="Stretch" Fill="{TemplateBinding Background}" />
-                                        <ContentPresenter x:Name="Text" Content="{TemplateBinding Content}" VerticalAlignment="Center" HorizontalAlignment="Center"/>
-                                        <VisualStateManager.VisualStateGroups>
-                                            <VisualStateGroup x:Name="CommonStates">
-                                                <VisualState x:Name="Normal">
-                                                    <Storyboard>
-                                                        <ColorAnimation From="Transparent" To="Black" Storyboard.TargetName="Text" Storyboard.TargetProperty="(Button.Foreground).(SolidColorBrush.Color)" BeginTime="0" Duration="1"></ColorAnimation>
-                                                        <ColorAnimation From="Transparent" To="White" Storyboard.TargetName="Text" Storyboard.TargetProperty="(Button.Background).(SolidColorBrush.Color)" BeginTime="0" Duration="1"></ColorAnimation>
-                                                    </Storyboard>
-                                                </VisualState>
-                                                <VisualState x:Name="PointerOver">
-                                                    <Storyboard>
-                                                        <ColorAnimation From="Transparent" To="#888888" Storyboard.TargetName="ButtonHighlight" Storyboard.TargetProperty="(Button.Background).(SolidColorBrush.Color)"  Duration="0:0:1"></ColorAnimation>
-                                                    </Storyboard>
-                                                </VisualState>
-                                            </VisualStateGroup>
-                                        </VisualStateManager.VisualStateGroups>
-                                    </Grid>
-                                </Border>
-                            </ControlTemplate>
-                        </Setter.Value>
-                    </Setter>
                 </Style>
             </Setter.Value>
         </Setter>


### PR DESCRIPTION
Hide input panel when tapping outside textbox (Microsoft QA requirement)
Fixed input panel background color when not focused (was black, which made it hard to see)
Cleaned up input panel button style (padding was messed up, lot of code for nothing)