### PR TITLE
Windows 10 input fixes

### DIFF
--- a/MonoGame.Framework/Input/KeyboardInput.WinRT.cs
+++ b/MonoGame.Framework/Input/KeyboardInput.WinRT.cs
@@ -311,6 +311,7 @@ namespace Microsoft.Xna.Framework.Input
             if (_inputTextBox != null && _inputPasswordBox != null)
             {
                 _inputTextBox.Text = InputText;
+                _inputTextBox.IsTextPredictionEnabled = false;
                 _inputTextBox.TextChanged += OnInputTextBoxTextChanged;
                 _inputTextBox.KeyUp += OnInputTextBoxKeyUp;
 

--- a/MonoGame.Framework/Input/MessageBox.WinRT.cs
+++ b/MonoGame.Framework/Input/MessageBox.WinRT.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Xna.Framework.Input
                         dialogResult = dialog.ShowAsync();
                         var result = await dialogResult;
                         if (!tcs.Task.IsCompleted)
-                            tcs.SetResult((int)result.Id);
+                            tcs.SetResult(result == null ? null : (int?)result.Id);
                     }
                     catch (TaskCanceledException)
                     {

--- a/MonoGame.Framework/Themes/generic.xaml
+++ b/MonoGame.Framework/Themes/generic.xaml
@@ -12,7 +12,7 @@
             Value="#80000000" />
         <Setter
             Property="Padding"
-            Value="25" />
+            Value="15" />
         <Setter
             Property="TitleStyle">
             <Setter.Value>
@@ -23,7 +23,7 @@
                         Value="Segoe UI" />
                     <Setter
                         Property="FontSize"
-                        Value="50" />
+                        Value="24" />
                     <Setter
                         Property="Margin"
                         Value="3,0" />
@@ -43,10 +43,10 @@
                         Value="Segoe UI Semilight" />
                     <Setter
                         Property="FontSize"
-                        Value="30" />
+                        Value="16" />
                     <Setter
                         Property="Margin"
-                        Value="3,25,3,5" />
+                        Value="3,10,3,5" />
                     <Setter
                         Property="TextWrapping"
                         Value="Wrap" />
@@ -63,7 +63,7 @@
                     TargetType="TextBox">
                     <Setter
                         Property="Margin"
-                        Value="0,15,15,15" />
+                        Value="0,10,10,10" />
                     <Setter
                         Property="TextWrapping"
                         Value="Wrap" />
@@ -72,10 +72,10 @@
                         Value="Black" />
                     <Setter 
 						Property="FontSize"
-						Value="30" />
+						Value="16" />
                     <Setter
                         Property="MinHeight"
-                        Value="52" />
+                        Value="30" />
                     <Setter
                         Property="Background"
                         Value="White" />
@@ -106,10 +106,10 @@
                         Value="#FFFFFF" />
                     <Setter
                         Property="Margin"
-                        Value="25,25,25,25" />
+                        Value="5" />
                     <Setter
                         Property="FontSize"
-                        Value="40" />
+                        Value="16" />
                 </Style>
             </Setter.Value>
         </Setter>

--- a/MonoGame.Framework/WindowsUAP/UAPGamePlatform.cs
+++ b/MonoGame.Framework/WindowsUAP/UAPGamePlatform.cs
@@ -117,7 +117,12 @@ namespace Microsoft.Xna.Framework
 
         private static void BackRequested(object sender, BackRequestedEventArgs e)
         {
-            GamePad.Back = true;
+            // We need to manually hide the keyboard input UI when the back button is pressed
+            if (KeyboardInput.IsVisible)
+                KeyboardInput.Cancel(null);
+            else
+                GamePad.Back = true;
+
             e.Handled = true;
         }
 


### PR DESCRIPTION
* Fixed MessageBox back button handling on Windows 10 Mobile (was throwing null reference exception
* Added KeyboardInput back button handling on Windows 10 Mobile (back button did not hide it)
* Reduced the size of KeyboardInput to fit on the screen of phones (had to disable text prediction)

Before:
![wp_ss_20150812_0001](https://cloud.githubusercontent.com/assets/431167/9236651/5ec93516-4146-11e5-9959-a05f7553c680.png)

After:
![wp_ss_20150812_0004](https://cloud.githubusercontent.com/assets/431167/9236652/5ecc1772-4146-11e5-9a51-b468d6b84e99.png)
