### PR TITLE
Fix for VideoPlayer.WMS volume controller initialisation

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.WMS.cs
@@ -139,38 +139,6 @@ namespace Microsoft.Xna.Framework.Media
 
         #endregion
 
-        internal static IntPtr GetVolumeObj(MediaSession session)
-        {
-            // Get the volume interface - shared between MediaPlayer and VideoPlayer
-            const int retries = 10;
-            const int sleepTimeFactor = 50;
-
-            var volumeObj = (IntPtr)0;
-
-            //See https://github.com/mono/MonoGame/issues/2620
-            //MediaFactory.GetService throws a SharpDX exception for unknown reasons. it appears retrying will solve the problem but there
-            //is no specific number of times, nor pause that works. So we will retry N times with an increasing Sleep between each one
-            //before finally throwing the error we saw in the first place.
-            for (int i = 0; i < retries; i++)
-            {
-                try
-                {
-                    MediaFactory.GetService(session, MediaServiceKeys.StreamVolume, AudioStreamVolumeGuid, out volumeObj);
-                    break;
-                }
-                catch (SharpDXException)
-                {
-                    if (i == retries - 1)
-                    {
-                        throw;
-                    }
-                    Debug.WriteLine("MediaFactory.GetService failed({0}) sleeping for {1} ms", i + 1, i * sleepTimeFactor);
-                    Thread.Sleep(i * sleepTimeFactor); //Sleep for longer and longer times
-                }
-            }
-            return volumeObj;
-        }
-
         private static void PlatformPause()
         {
             _session.Pause();

--- a/MonoGame.Framework/Media/VideoPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/VideoPlayer.WMS.cs
@@ -22,6 +22,13 @@ namespace Microsoft.Xna.Framework.Media
 
         private class Callback : IAsyncCallback
         {
+            private VideoPlayer _player;
+
+            public Callback(VideoPlayer player)
+            {
+                _player = player;
+            }
+
             public void Dispose()
             {
             }
@@ -32,6 +39,9 @@ namespace Microsoft.Xna.Framework.Media
                 var ev = _session.EndGetEvent(asyncResultRef);
 
                 // Trigger an "on Video Ended" event here if needed
+
+                if (ev.TypeInfo == MediaEventTypes.SessionTopologyStatus && ev.Get(EventAttributeKeys.TopologyStatus) == TopologyStatus.Ready)
+                    _player.OnTopologyReady();
 
                 _session.BeginGetEvent(this, null);
             }
@@ -100,25 +110,24 @@ namespace Microsoft.Xna.Framework.Media
             if (State != MediaState.Stopped)
             {
                 _session.Stop();
+                _session.ClearTopologies();
+                _session.Close();
                 _volumeController.Dispose();
                 _clock.Dispose();
             }
 
-            // Set the new song.
-            _session.SetTopology(0, _currentVideo.Topology);
-
-            _volumeController = CppObject.FromPointer<AudioStreamVolume>(MediaPlayer.GetVolumeObj(_session));
-            SetChannelVolumes();
-
-            // Get the clock.
-            _clock = _session.Clock.QueryInterface<PresentationClock>();
-
             //create the callback if it hasn't been created yet
             if (_callback == null)
             {
-                _callback = new Callback();
+                _callback = new Callback(this);
                 _session.BeginGetEvent(_callback, null);
             }
+
+            // Set the new song.
+            _session.SetTopology(SessionSetTopologyFlags.Immediate, _currentVideo.Topology);
+
+            // Get the clock.
+            _clock = _session.Clock.QueryInterface<PresentationClock>();
 
             // Start playing.
             var varStart = new Variant();
@@ -143,11 +152,16 @@ namespace Microsoft.Xna.Framework.Media
 
         private void SetChannelVolumes()
         {
-            if (_volumeController != null)
+            if (_volumeController != null && !_volumeController.IsDisposed)
             {
-                float volume = !_isMuted ? _volume : 0.0f;
+                float volume = _volume;
+                if (IsMuted)
+                    volume = 0.0f;
+
                 for (int i = 0; i < _volumeController.ChannelCount; i++)
+                {
                     _volumeController.SetChannelVolume(i, volume);
+                }
             }
         }
 
@@ -179,6 +193,19 @@ namespace Microsoft.Xna.Framework.Media
 
         private void PlatformDispose(bool disposing)
         {
+        }
+
+        private void OnTopologyReady()
+        {
+            if (_session.IsDisposed)
+                return;
+
+            // Get the volume interface.
+            IntPtr volumeObjectPtr;
+            MediaFactory.GetService(_session, MediaServiceKeys.StreamVolume, AudioStreamVolumeGuid, out volumeObjectPtr);
+            _volumeController = CppObject.FromPointer<AudioStreamVolume>(volumeObjectPtr);
+
+            SetChannelVolumes();
         }
     }
 }


### PR DESCRIPTION
This is a follow up to #4044

It does an async initialisation of the AudioStreamVolume and cleans up unused methods.