### PR TITLE
Fix for songs occasionally stopping shortly after starting (Windows DirectX)

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.WMS.cs
@@ -3,12 +3,9 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using SharpDX;
 using SharpDX.MediaFoundation;
 using SharpDX.Win32;
 using System.Runtime.InteropServices;
-using System.Threading;
-using System.Diagnostics;
 
 namespace Microsoft.Xna.Framework.Media
 {

--- a/MonoGame.Framework/Media/MediaPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.WMS.cs
@@ -165,13 +165,6 @@ namespace Microsoft.Xna.Framework.Media
 
             // Set the new song.
             _session.SetTopology(SessionSetTopologyFlags.Immediate, song.Topology);
-
-            // Get the clock.
-            _clock = _session.Clock.QueryInterface<PresentationClock>();
-
-            // Start playing.
-            var varStart = new Variant();
-            _session.Start(null, varStart);
         }
 
         private static void OnTopologyReady()
@@ -185,6 +178,13 @@ namespace Microsoft.Xna.Framework.Media
             _volumeController = CppObject.FromPointer<AudioStreamVolume>(volumeObjectPtr);
 
             SetChannelVolumes();
+
+            // Get the clock.
+            _clock = _session.Clock.QueryInterface<PresentationClock>();
+
+            // Start playing.
+            var varStart = new Variant();
+            _session.Start(null, varStart);
         }
 
         private static void PlatformResume()

--- a/MonoGame.Framework/Media/MediaPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.WMS.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Xna.Framework.Media
             // Get the volume interface.
             IntPtr volumeObjectPtr;
             MediaFactory.GetService(_session, MediaServiceKeys.StreamVolume, AudioStreamVolumeGuid, out volumeObjectPtr);
-            _volumeController = CppObject.FromPointer<AudioStreamVolume>(volumeObjectPtr);
+            _volumeController = new AudioStreamVolume(volumeObjectPtr);
 
             SetChannelVolumes();
 

--- a/MonoGame.Framework/Media/MediaPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.WMS.cs
@@ -118,17 +118,12 @@ namespace Microsoft.Xna.Framework.Media
 
         private static void SetChannelVolumes()
         {
-            if (_volumeController != null && !_volumeController.IsDisposed)
-            {
-                float volume = _volume;
-                if (IsMuted)
-                    volume = 0.0f;
+            if ((_volumeController == null) || _volumeController.IsDisposed)
+                return;
 
-                for (int i = 0; i < _volumeController.ChannelCount; i++)
-                {
-                    _volumeController.SetChannelVolume(i, volume);
-                }
-            }
+            var volume = IsMuted ? 0f : _volume;
+            for (int i = 0; i < _volumeController.ChannelCount; i++)
+                _volumeController.SetChannelVolume(i, volume);
         }
 
         private static void PlatformSetVolume(float volume)

--- a/MonoGame.Framework/Media/VideoPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/VideoPlayer.WMS.cs
@@ -1,7 +1,4 @@
-﻿using System.Diagnostics;
-using System.Threading;
-using Microsoft.Xna.Framework.Graphics;
-using SharpDX;
+﻿using Microsoft.Xna.Framework.Graphics;
 using SharpDX.MediaFoundation;
 using SharpDX.Win32;
 using System;

--- a/MonoGame.Framework/Media/VideoPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/VideoPlayer.WMS.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Xna.Framework.Media
             // Get the volume interface.
             IntPtr volumeObjectPtr;
             MediaFactory.GetService(_session, MediaServiceKeys.StreamVolume, AudioStreamVolumeGuid, out volumeObjectPtr);
-            _volumeController = CppObject.FromPointer<AudioStreamVolume>(volumeObjectPtr);
+            _volumeController = new AudioStreamVolume(volumeObjectPtr);
 
             SetChannelVolumes();
 

--- a/MonoGame.Framework/Media/VideoPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/VideoPlayer.WMS.cs
@@ -145,17 +145,12 @@ namespace Microsoft.Xna.Framework.Media
 
         private void SetChannelVolumes()
         {
-            if (_volumeController != null && !_volumeController.IsDisposed)
-            {
-                float volume = _volume;
-                if (IsMuted)
-                    volume = 0.0f;
+            if ((_volumeController == null) || _volumeController.IsDisposed)
+                return;
 
-                for (int i = 0; i < _volumeController.ChannelCount; i++)
-                {
-                    _volumeController.SetChannelVolume(i, volume);
-                }
-            }
+            var volume = IsMuted ? 0f : _volume;
+            for (int i = 0; i < _volumeController.ChannelCount; i++)
+                _volumeController.SetChannelVolume(i, volume);
         }
 
         private void PlatformSetVolume()

--- a/MonoGame.Framework/Media/VideoPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/VideoPlayer.WMS.cs
@@ -125,13 +125,6 @@ namespace Microsoft.Xna.Framework.Media
 
             // Set the new song.
             _session.SetTopology(SessionSetTopologyFlags.Immediate, _currentVideo.Topology);
-
-            // Get the clock.
-            _clock = _session.Clock.QueryInterface<PresentationClock>();
-
-            // Start playing.
-            var varStart = new Variant();
-            _session.Start(null, varStart);
         }
 
         private void PlatformResume()
@@ -206,6 +199,13 @@ namespace Microsoft.Xna.Framework.Media
             _volumeController = CppObject.FromPointer<AudioStreamVolume>(volumeObjectPtr);
 
             SetChannelVolumes();
+
+            // Get the clock.
+            _clock = _session.Clock.QueryInterface<PresentationClock>();
+
+            // Start playing.
+            var varStart = new Variant();
+            _session.Start(null, varStart);
         }
     }
 }


### PR DESCRIPTION
I noticed in the Windows DirectX build that occasionally when playing a song, it would stop very shortly after starting.

It turns out that the previous fix I did (PR #4044) was almost there, but not quite. Apparently you are also not meant to start the session until the topology is ready.

So I've fixed this up and it seems to work reliably now. I also applied the same fix to VideoPlayer.WMS this time.

While I was working on this area of code, I took the liberty of doing some minor refactoring to make it simpler and more readable. I hope this is ok.