### PR TITLE
Remove PSMoble From Docs

### DIFF
--- a/Documentation/config.xml
+++ b/Documentation/config.xml
@@ -116,9 +116,4 @@
   </group>
   -->
 
-  <!-- PSMobile -->
-  <group api="psm|PlayStation Mobile">    
-    <source>..\MonoGame.Framework\bin\PSMobile\AnyCPU\Release\MonoGame.Framework.dll</source>
-  </group>
-
 </config>


### PR DESCRIPTION
Remove depreciated PSMoble from doc generation which was missed in https://github.com/mono/MonoGame/pull/4016.