### PR TITLE
Fix for songs sometimes not playing (Windows DirectX)

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.WMS.cs
@@ -152,17 +152,12 @@ namespace Microsoft.Xna.Framework.Media
 
         private static void SetChannelVolumes()
         {
-            if (_volumeController != null)
-            {
-                float volume = _volume;
-                if (IsMuted)
-                    volume = 0.0f;
+            if (_volumeController == null)
+                return;
 
-                for (int i = 0; i < _volumeController.ChannelCount; i++)
-                {
-                    _volumeController.SetChannelVolume(i, volume);
-                }
-            }
+            float volume = _isMuted ? 0f : _volume;
+            for (int i = 0; i < _volumeController.ChannelCount; i++)
+                _volumeController.SetChannelVolume(i, volume);
         }
 
         private static void PlatformSetVolume(float volume)

--- a/MonoGame.Framework/Media/MediaPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.WMS.cs
@@ -7,8 +7,6 @@ using SharpDX;
 using SharpDX.MediaFoundation;
 using SharpDX.Win32;
 using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Xna.Framework.Media
 {
@@ -28,7 +26,6 @@ namespace Microsoft.Xna.Framework.Media
         private static readonly Variant PositionCurrent = new Variant();
         private static readonly Variant PositionBeginning = new Variant { ElementType = VariantElementType.Long, Value = 0L };
 
-        private static TaskScheduler _uiTaskScheduler;
         private static Callback _callback;
 
         private class Callback : IAsyncCallback
@@ -71,8 +68,6 @@ namespace Microsoft.Xna.Framework.Media
 
             MediaManagerState.CheckStartup();
             MediaFactory.CreateMediaSession(null, out _session);
-
-            _uiTaskScheduler = TaskScheduler.FromCurrentSynchronizationContext();
 
             _callback = new Callback();
             _session.BeginGetEvent(_callback, null);

--- a/MonoGame.Framework/Media/Song.WMS.cs
+++ b/MonoGame.Framework/Media/Song.WMS.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Xna.Framework.Media
 {
     public sealed partial class Song : IEquatable<Song>, IDisposable
     {
-        private SharpDX.MediaFoundation.MediaSource _mediaSource;
         private Topology _topology;
 
         internal Topology Topology { get { return _topology; } }
@@ -25,17 +24,18 @@ namespace Microsoft.Xna.Framework.Media
 
             MediaFactory.CreateTopology(out _topology);
 
+            SharpDX.MediaFoundation.MediaSource mediaSource;
             {
                 SourceResolver resolver = new SourceResolver();
 
                 ComObject source = resolver.CreateObjectFromURL(FilePath, SourceResolverFlags.MediaSource);
-                _mediaSource = source.QueryInterface<SharpDX.MediaFoundation.MediaSource>();
+                mediaSource = source.QueryInterface<SharpDX.MediaFoundation.MediaSource>();
                 resolver.Dispose();
                 source.Dispose();
             }
 
             PresentationDescriptor presDesc;
-            _mediaSource.CreatePresentationDescriptor(out presDesc);
+            mediaSource.CreatePresentationDescriptor(out presDesc);
 
             for (var i = 0; i < presDesc.StreamDescriptorCount; i++)
             {
@@ -48,7 +48,7 @@ namespace Microsoft.Xna.Framework.Media
                     TopologyNode sourceNode;
                     MediaFactory.CreateTopologyNode(TopologyType.SourceStreamNode, out sourceNode);
 
-                    sourceNode.Set(TopologyNodeAttributeKeys.Source, _mediaSource);
+                    sourceNode.Set(TopologyNodeAttributeKeys.Source, mediaSource);
                     sourceNode.Set(TopologyNodeAttributeKeys.PresentationDescriptor, presDesc);
                     sourceNode.Set(TopologyNodeAttributeKeys.StreamDescriptor, desc);
 
@@ -78,6 +78,7 @@ namespace Microsoft.Xna.Framework.Media
             }
 
             presDesc.Dispose();
+            mediaSource.Dispose();
         }
 
         private void PlatformDispose(bool disposing)
@@ -86,12 +87,6 @@ namespace Microsoft.Xna.Framework.Media
             {
                 _topology.Dispose();
                 _topology = null;
-            }
-            if (_mediaSource != null)
-            {
-                _mediaSource.Shutdown();
-                _mediaSource.Dispose();
-                _mediaSource = null;
             }
         }
         


### PR DESCRIPTION
I've had some issues with the Windows DirectX build where songs sometimes didn't play as follows:

* On my Win7 desktop, the problem only happened occasionally and was difficult to reproduce. When it did happen, the song would start playing but then stop very shortly after.
* On my Win10 laptop, the problem was much easier to reproduce. Basically I'd play a song, stop it, play another song, stop it, and then play the first song again (which would then not start playing at all).

I believe issues #1954 and #3884 are related (and likely will be resolved by this PR and/or my previous PR #4044).

This was quite a pain to resolve (I spent the past 2 days working on it)... Eventually it mostly came down to cross threading issues, not waiting for asynchronous methods to complete when required, and unnecessary/incorrect use of some MediaSession functions.

Anyway, it should hopefully be a lot cleaner and more robust now. I have not been able to reproduce the issues I was having, so I believe they're resolved now.

VideoPlayer.WMS will most likely need similar fixes (since it uses the same APIs), but I don't have anything that uses it and can't afford the time to investigate further. If there are similar issues though, hopefully someone else can just look at what I've done here to resolve them.