### PR TITLE
Fix for XAudio crashing if any instance is playing while parent is disposed

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -353,6 +353,7 @@ namespace Microsoft.Xna.Framework.Audio
         {
             if (!_isDisposed)
             {
+                SoundEffectInstancePool.StopPooledInstances(this);
                 PlatformDispose(disposing);
                 _isDisposed = true;
             }

--- a/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
@@ -154,6 +154,28 @@ namespace Microsoft.Xna.Framework.Audio
             }
         }
 
+        /// <summary>
+        /// Iterates the list of playing instances, stop them and return them to the pool if they are instances of the given SoundEffect.
+        /// </summary>
+        /// <param name="effect">The SoundEffect</param>
+        internal static void StopPooledInstances(SoundEffect effect)
+        {
+            SoundEffectInstance inst = null;
+
+            for (var x = 0; x < _playingInstances.Count; x++)
+            {
+                inst = _playingInstances[x];
+                if (inst.State != SoundState.Stopped && inst._effect == effect)
+                {
+                    inst.Stop();
+                    Add(inst);
+                    continue;
+                }
+
+                x++;
+            }
+        }
+
         internal static void UpdateMasterVolume()
         {
             foreach (var inst in _playingInstances)

--- a/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
@@ -140,15 +140,6 @@ namespace Microsoft.Xna.Framework.Audio
                     Add(inst);
                     continue;
                 }
-                else if (inst._effect.IsDisposed)
-                {
-                    Add(inst);
-                    // Instances created through SoundEffect.CreateInstance need to be disposed when
-                    // their owner SoundEffect is disposed.
-                    if (!inst._isPooled)
-                        inst.Dispose();
-                    continue;
-                }
 
                 x++;
             }
@@ -167,7 +158,7 @@ namespace Microsoft.Xna.Framework.Audio
                 inst = _playingInstances[x];
                 if (inst.State != SoundState.Stopped && inst._effect == effect)
                 {
-                    inst.Stop();
+                    inst.Stop(true); // stop immediatly
                     Add(inst);
                     continue;
                 }

--- a/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Xna.Framework.Audio
         {
             SoundEffectInstance inst = null;
 
-            for (var x = 0; x < _playingInstances.Count; x++)
+            for (var x = 0; x < _playingInstances.Count;)
             {
                 inst = _playingInstances[x];
                 if (inst.State != SoundState.Stopped && inst._effect == effect)


### PR DESCRIPTION
This is a fix proposal for #4093

If a ```SoundEffect``` is disposed while a ```SoundEffectInstance``` of that effect is playing, it results in an XAudio crash (and possibly other audio implementations).

This fix stops all playing instances upon an effect disposal (and return them to the pool).

It doesn't concern ```SoundEffectInstance``` created through ```SoundEffect.CreateInstance()```, assuming that these instances life-cycle management are up to the developer. (How does XNA behave regarding these? I don't remember having this kind of issue back then.)

If this fix gets merged, ```SoundEffectInstancePool.Update()``` could be a bit cleaned, since the check of disposed effects would no more be useful.