### PR TITLE
Reset ScreenReceiver.ScreenLocked in OnDestroy()

### DIFF
--- a/MonoGame.Framework/Android/AndroidGameActivity.cs
+++ b/MonoGame.Framework/Android/AndroidGameActivity.cs
@@ -90,6 +90,7 @@ namespace Microsoft.Xna.Framework
 		protected override void OnDestroy ()
 		{
             UnregisterReceiver(screenReceiver);
+            ScreenReceiver.ScreenLocked = false;
             _orientationListener = null;
             if (Game != null)
                 Game.Dispose();


### PR DESCRIPTION
PROBLEM:
When launching an AndroidGameActivity from a notification the static field ScreenReceiver.ScreenLocked stays on true.
The problem is that then the game won't be initalized because of this check in AndroidGameWindow.OnUpdateFrame:

                if (!GameView.IsResuming && _game.Platform.IsActive && !ScreenReceiver.ScreenLocked)
                {
                    _game.Tick();
                } 

SOLUTION:
Reset ScreenReceiver.ScreenLocked in OnDestroy()