### PR TITLE
Fix for back button state being ignored if no gamepad connected on UWP

### DIFF
--- a/MonoGame.Framework/Input/GamePad.UWP.cs
+++ b/MonoGame.Framework/Input/GamePad.UWP.cs
@@ -58,8 +58,8 @@ namespace Microsoft.Xna.Framework.Input
 
         private static GamePadState PlatformGetState(int index, GamePadDeadZone deadZoneMode)
         {
-            if (index >= WGI.Gamepad.Gamepads.Count && index == 0)
-                return GetDefaultState();
+            if (index >= WGI.Gamepad.Gamepads.Count)
+                return (index == 0 ? GetDefaultState() : GamePadState.Default);
 
             var state = WGI.Gamepad.Gamepads[index].GetCurrentReading();
 

--- a/MonoGame.Framework/Input/GamePad.UWP.cs
+++ b/MonoGame.Framework/Input/GamePad.UWP.cs
@@ -49,10 +49,17 @@ namespace Microsoft.Xna.Framework.Input
             };
         }
 
+        private static GamePadState GetDefaultState()
+        {
+            var state = new GamePadState();
+            state.Buttons = new GamePadButtons(Back ? Buttons.Back : 0);
+            return state;
+        }
+
         private static GamePadState PlatformGetState(int index, GamePadDeadZone deadZoneMode)
         {
             if (index >= WGI.Gamepad.Gamepads.Count)
-                return GamePadState.Default;
+                return GetDefaultState();
 
             var state = WGI.Gamepad.Gamepads[index].GetCurrentReading();
 

--- a/MonoGame.Framework/Input/GamePad.UWP.cs
+++ b/MonoGame.Framework/Input/GamePad.UWP.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Xna.Framework.Input
 
         private static GamePadState PlatformGetState(int index, GamePadDeadZone deadZoneMode)
         {
-            if (index >= WGI.Gamepad.Gamepads.Count)
+            if (index >= WGI.Gamepad.Gamepads.Count && index == 0)
                 return GetDefaultState();
 
             var state = WGI.Gamepad.Gamepads[index].GetCurrentReading();


### PR DESCRIPTION
This PR fixes the issue raised by #4077 regarding back button states when no gamepad is connected with an UWP.