### PR TITLE
Don't use alcMacOSXMixerOutputRate on iOS as it is not included in iOS9.

### DIFF
--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Xna.Framework.Audio
         /// <returns>True if the sound controller was setup, and false if not.</returns>
         private bool OpenSoundController()
         {
-#if MONOMAC || IOS
+#if MONOMAC
 			alcMacOSXMixerOutputRate(PREFERRED_MIX_RATE);
 #endif
 


### PR DESCRIPTION
Fixes #4076

Not sure if we should merge this yet as iOS9 hasn't hit gold master and the symbol could potentially come back.