### PR TITLE
Fix re-launching on Android from a notification

### DIFF
--- a/MonoGame.Framework/Android/AndroidGameActivity.cs
+++ b/MonoGame.Framework/Android/AndroidGameActivity.cs
@@ -90,6 +90,7 @@ namespace Microsoft.Xna.Framework
 		protected override void OnDestroy ()
 		{
             UnregisterReceiver(screenReceiver);
+            ScreenReceiver.ScreenLocked = false;
             _orientationListener = null;
             if (Game != null)
                 Game.Dispose();


### PR DESCRIPTION
When we are launched from a notification ScreenLocked would still be true so things wouldn't work. Reset it early instead.

See #4097 for details. This is just a whitespace correct commit. (Actual change by @hig-ag)