### PR TITLE
Fix multitouch lockup on WP8.1

### DIFF
--- a/MonoGame.Framework/Windows8/MetroGamePlatform.cs
+++ b/MonoGame.Framework/Windows8/MetroGamePlatform.cs
@@ -12,6 +12,8 @@ using System.Diagnostics;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input.Touch;
 using Windows.ApplicationModel.Activation;
+using Windows.Foundation;
+using Windows.System.Threading;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml.Media;
 #if WINDOWS_PHONE81
@@ -115,10 +117,16 @@ namespace Microsoft.Xna.Framework
 
         public override void StartRunLoop()
         {
-            CompositionTarget.Rendering += (o, a) =>
+            ThreadPool.RunAsync(delegate(IAsyncAction action)
             {
-                MetroGameWindow.Instance.Tick();
-            };
+                while (action.Status == AsyncStatus.Started)
+                {
+                    lock (MetroGameWindow.Instance.RunLock)
+                    {
+                        MetroGameWindow.Instance.Tick();
+                    }
+                }
+            }, WorkItemPriority.High, WorkItemOptions.TimeSliced);
         }
         
         public override void Exit()

--- a/MonoGame.Framework/Windows8/MetroGameWindow.cs
+++ b/MonoGame.Framework/Windows8/MetroGameWindow.cs
@@ -40,6 +40,11 @@ namespace Microsoft.Xna.Framework
 
         internal bool IsExiting { get; set; }
 
+        /// <summary>
+        /// Used to stop orientation change events and the run loop from running at the same time
+        /// </summary>
+        internal readonly object RunLock = new object();
+
         #endregion
 
         #region Public Properties
@@ -227,15 +232,18 @@ namespace Microsoft.Xna.Framework
 
         private void DisplayProperties_OrientationChanged(object sender)
         {
-            // Set the new orientation.
-            _orientation = ToOrientation(DisplayProperties.CurrentOrientation);
+            lock (RunLock)
+            {
+                // Set the new orientation.
+                _orientation = ToOrientation(DisplayProperties.CurrentOrientation);
 
-            // Call the user callback.
-            OnOrientationChanged();
+                // Call the user callback.
+                OnOrientationChanged();
 
-            // If we have a valid client bounds then update the graphics device.
-            if (_clientBounds.Width > 0 && _clientBounds.Height > 0)
-                Game.graphicsDeviceManager.ApplyChanges();
+                // If we have a valid client bounds then update the graphics device.
+                if (_clientBounds.Width > 0 && _clientBounds.Height > 0)
+                    Game.graphicsDeviceManager.ApplyChanges();
+            }
         }
 
         protected override void SetTitle(string title)


### PR DESCRIPTION
Use a RunLoop thread rather than listening for ```CompositionTarget.Rendering```.
This seems to fix the lockup during touch on WP8.1.

I needed to add a lock around the orientation event otherwise we could try change orientation while drawing and we'd crash (because the run loop runs at the same time).
I don't think anywhere else needs the same lock, but I may of overlooked something.

I haven't changed the input code, so we still get 60 touches a second for every touch that is occurring. This doesn't seem to cause troubles for me, but may on bigger projects (I'm testing on a lumia 520 though, so it is pretty slow)

This will need testing on other Metro platforms too (Win8 Store app), I'll try have a crack later today, I don't expect any troubles though.

Fixes #3316