### PR TITLE
Fix for NullReferenceException when trying to switch Song rapidly

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.WMS.cs
@@ -152,7 +152,11 @@ namespace Microsoft.Xna.Framework.Media
                 _session.Stop();
                 _session.ClearTopologies();
                 _session.Close();
-                _volumeController.Dispose();
+                if (_volumeController != null)
+                {
+                    _volumeController.Dispose();
+                    _volumeController = null;
+                }
                 _clock.Dispose();
             }
 
@@ -198,8 +202,11 @@ namespace Microsoft.Xna.Framework.Media
             _session.ClearTopologies();
             _session.Stop();
             _session.Close();
-            _volumeController.Dispose();
-            _volumeController = null;
+            if (_volumeController != null)
+            {
+                _volumeController.Dispose();
+                _volumeController = null;
+            }
             _clock.Dispose();
             _clock = null;
         }

--- a/MonoGame.Framework/Media/VideoPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/VideoPlayer.WMS.cs
@@ -112,7 +112,11 @@ namespace Microsoft.Xna.Framework.Media
                 _session.Stop();
                 _session.ClearTopologies();
                 _session.Close();
-                _volumeController.Dispose();
+                if (_volumeController != null)
+                {
+                    _volumeController.Dispose();
+                    _volumeController = null;
+                }
                 _clock.Dispose();
             }
 
@@ -144,8 +148,11 @@ namespace Microsoft.Xna.Framework.Media
             _session.ClearTopologies();
             _session.Stop();
             _session.Close();
-            _volumeController.Dispose();
-            _volumeController = null;
+            if (_volumeController != null)
+            {
+                _volumeController.Dispose();
+                _volumeController = null;
+            }
             _clock.Dispose();
             _clock = null;
         }


### PR DESCRIPTION
Due to the async volume controller initialization in XAudio, it may happen that switching rapidly songs can trigger a null ref exception here (because the volume has not been init yet): https://github.com/mono/MonoGame/blob/03185dff502df8532600fadbe8044b3d3c978d2d/MonoGame.Framework/Media/MediaPlayer.WMS.cs#L155

This PR adds null checks to MediaPlayer and VideoPlayer to cope with the async init.