### PR TITLE
IOS: reduce freezes on song looping

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.cs
@@ -215,8 +215,10 @@ namespace Microsoft.Xna.Framework.Media
 		
 		private static void NextSong(int direction)
 		{
-            Stop();
-
+            if (!IsRepeating || _queue.Count > 1)
+            {
+                Stop();
+            }
             if (IsRepeating && _queue.ActiveSongIndex >= _queue.Count - 1)
             {
                 _queue.ActiveSongIndex = 0;


### PR DESCRIPTION
Do not call stop() when only one song is in a queue and IsRepeating is true (to avoid noticeable freezes on iOS).