### PR TITLE
Allow using all of the available SoundEffectInstancePool Instances

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffectInstance.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.cs
@@ -145,10 +145,10 @@ namespace Microsoft.Xna.Framework.Audio
             // if we're resuming from a paused state.
             if (State != SoundState.Paused)
             {
-                SoundEffectInstancePool.Remove(this);
-
                 if (!SoundEffectInstancePool.SoundsAvailable)
                     throw new InstancePlayLimitException();
+
+                SoundEffectInstancePool.Remove(this);
             }
             
             // For non-XAct sounds we need to be sure the latest


### PR DESCRIPTION
We need to check there are any remaining before using ourself, not after, otherwise we count ourself against the limit.

ATM we throw the InstancePlayLimitException when calling SoundEffect.Play to play the maximum amount of instances.

Broken since e8d2069da115e7be2d11374c399a945bb28d252e