### PR TITLE
GraphicsMetrics update

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -1171,8 +1171,14 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new InvalidOperationException("A pixel shader must be set!");
 
             if (_vertexShaderDirty)
+            {
                 _d3dContext.VertexShader.Set(_vertexShader.VertexShader);
 
+                unchecked
+                {
+                    _graphicsMetrics._vertexShaderCount++;
+                }
+            }
             if (_vertexShaderDirty || _vertexBufferDirty)
             {
                 _d3dContext.InputAssembler.InputLayout = GetInputLayout(_vertexShader, _vertexBuffer.VertexDeclaration);
@@ -1183,6 +1189,11 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 _d3dContext.PixelShader.Set(_pixelShader.PixelShader);
                 _pixelShaderDirty = false;
+
+                unchecked
+                {
+                    _graphicsMetrics._pixelShaderCount++;
+                }
             }
 
             _vertexConstantBuffers.SetConstantBuffers(this);

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -834,6 +834,23 @@ namespace Microsoft.Xna.Framework.Graphics
             if (_vertexShaderDirty || _pixelShaderDirty)
             {
                 ActivateShaderProgram();
+
+                if (_vertexShaderDirty)
+                {
+                    unchecked
+                    {
+                        _graphicsMetrics._vertexShaderCount++;
+                    }
+                }
+
+                if (_pixelShaderDirty)
+                {
+                    unchecked
+                    {
+                        _graphicsMetrics._pixelShaderCount++;
+                    }
+                }
+
                 _vertexShaderDirty = _pixelShaderDirty = false;
             }
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -423,16 +423,31 @@ namespace Microsoft.Xna.Framework.Graphics
             options |= ClearOptions.DepthBuffer;
             options |= ClearOptions.Stencil;
             PlatformClear(options, color.ToVector4(), _viewport.MaxDepth, 0);
+
+            unchecked
+            {
+                _graphicsMetrics._clearCount++;
+            }
         }
 
         public void Clear(ClearOptions options, Color color, float depth, int stencil)
         {
             PlatformClear(options, color.ToVector4(), depth, stencil);
+
+            unchecked
+            {
+                _graphicsMetrics._clearCount++;
+            }
         }
 
 		public void Clear(ClearOptions options, Vector4 color, float depth, int stencil)
 		{
             PlatformClear(options, color, depth, stencil);
+
+            unchecked
+            {
+                _graphicsMetrics._clearCount++;
+            }
         }
 
         public void Dispose()
@@ -658,7 +673,9 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 renderTargetCount = renderTargets.Length;
                 if (renderTargetCount == 0)
+                {
                     renderTargets = null;
+                }
             }
 
             // Try to early out if the current and new bindings are equal.
@@ -680,6 +697,21 @@ namespace Microsoft.Xna.Framework.Graphics
             }
 
             ApplyRenderTargets(renderTargets);
+
+            if (renderTargetCount == 0)
+            {
+                unchecked
+                {
+                    _graphicsMetrics._targetCount++;
+                }
+            }
+            else
+            {
+                unchecked
+                {
+                    _graphicsMetrics._targetCount += (ulong)renderTargetCount;
+                }
+            }
         }
 
         internal void ApplyRenderTargets(RenderTargetBinding[] renderTargets)
@@ -833,13 +865,13 @@ namespace Microsoft.Xna.Framework.Graphics
             if (primitiveCount <= 0)
                 throw new ArgumentOutOfRangeException("primitiveCount");
 
+            PlatformDrawIndexedPrimitives(primitiveType, baseVertex, startIndex, primitiveCount);
+
             unchecked
             {
                 _graphicsMetrics._drawCount++;
                 _graphicsMetrics._primitiveCount += (ulong)primitiveCount;
             }
-
-            PlatformDrawIndexedPrimitives(primitiveType, baseVertex, startIndex, primitiveCount);
         }
 
         public void DrawUserPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int primitiveCount) where T : struct, IVertexType
@@ -868,14 +900,14 @@ namespace Microsoft.Xna.Framework.Graphics
 
             if (vertexDeclaration == null)
                 throw new ArgumentNullException("vertexDeclaration");
-            
+
+            PlatformDrawUserPrimitives<T>(primitiveType, vertexData, vertexOffset, vertexDeclaration, vertexCount);
+
             unchecked
             {
                 _graphicsMetrics._drawCount++;
                 _graphicsMetrics._primitiveCount += (ulong) primitiveCount;
             }
-
-            PlatformDrawUserPrimitives<T>(primitiveType, vertexData, vertexOffset, vertexDeclaration, vertexCount);
         }
 
         public void DrawPrimitives(PrimitiveType primitiveType, int vertexStart, int primitiveCount)
@@ -891,14 +923,13 @@ namespace Microsoft.Xna.Framework.Graphics
 
             var vertexCount = GetElementCountArray(primitiveType, primitiveCount);
 
-            
+            PlatformDrawPrimitives(primitiveType, vertexStart, vertexCount);
+
             unchecked
             {
                 _graphicsMetrics._drawCount++;
                 _graphicsMetrics._primitiveCount += (ulong) primitiveCount;
             }
-
-            PlatformDrawPrimitives(primitiveType, vertexStart, vertexCount);
         }
 
         public void DrawUserIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int numVertices, short[] indexData, int indexOffset, int primitiveCount) where T : struct, IVertexType
@@ -938,14 +969,13 @@ namespace Microsoft.Xna.Framework.Graphics
             if (vertexDeclaration == null)
                 throw new ArgumentNullException("vertexDeclaration");
 
-            
+            PlatformDrawUserIndexedPrimitives<T>(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, vertexDeclaration);
+
             unchecked
             {
                 _graphicsMetrics._drawCount++;
                 _graphicsMetrics._primitiveCount += (ulong) primitiveCount;
             }
-
-            PlatformDrawUserIndexedPrimitives<T>(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, vertexDeclaration);
         }
 
         public void DrawUserIndexedPrimitives<T>(PrimitiveType primitiveType, T[] vertexData, int vertexOffset, int numVertices, int[] indexData, int indexOffset, int primitiveCount) where T : struct, IVertexType
@@ -985,14 +1015,13 @@ namespace Microsoft.Xna.Framework.Graphics
             if (vertexDeclaration == null)
                 throw new ArgumentNullException("vertexDeclaration");
 
+            PlatformDrawUserIndexedPrimitives<T>(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, vertexDeclaration);
             
             unchecked
             {
                 _graphicsMetrics._drawCount++;
                 _graphicsMetrics._primitiveCount += (ulong) primitiveCount;
             }
-
-            PlatformDrawUserIndexedPrimitives<T>(primitiveType, vertexData, vertexOffset, numVertices, indexData, indexOffset, primitiveCount, vertexDeclaration);
         }
 
         private static int GetElementCountArray(PrimitiveType primitiveType, int primitiveCount)

--- a/MonoGame.Framework/Graphics/GraphicsMetrics.cs
+++ b/MonoGame.Framework/Graphics/GraphicsMetrics.cs
@@ -9,24 +9,54 @@ namespace Microsoft.Xna.Framework.Graphics
     /// </summary>
     public struct GraphicsMetrics
     {
-        internal ulong _spriteCount;
+        internal ulong _clearCount;
         internal ulong _drawCount;
+        internal ulong _pixelShaderCount;
         internal ulong _primitiveCount;
+        internal ulong _spriteCount;
+        internal ulong _targetCount;
+        internal ulong _textureCount;
+        internal ulong _vertexShaderCount;
 
         /// <summary>
-        /// The count of sprites and text characters rendered via <see cref="SpriteBatch"/>.
+        /// Number of times Clear was called.
         /// </summary>
-        public ulong SpriteCount { get { return _spriteCount; } }
+        public ulong ClearCount { get { return _clearCount; } }
 
         /// <summary>
-        /// The count of draw calls.
+        /// Number of times Draw was called.
         /// </summary>
         public ulong DrawCount { get { return _drawCount; } }
 
         /// <summary>
-        /// The count of rendered primitives.
+        /// Number of times the pixel shader was changed on the GPU.
+        /// </summary>
+        public ulong PixelShaderCount { get { return _pixelShaderCount; } }
+
+        /// <summary>
+        /// Number of rendered primitives.
         /// </summary>
         public ulong PrimitiveCount { get { return _primitiveCount; } }
+
+        /// <summary>
+        /// Number of sprites and text characters rendered via <see cref="SpriteBatch"/>.
+        /// </summary>
+        public ulong SpriteCount { get { return _spriteCount; } }
+
+        /// <summary>
+        /// Number of times a target was changed on the GPU.
+        /// </summary>
+        public ulong TargetCount {get { return _targetCount; } }
+
+        /// <summary>
+        /// Number of times a texture was changed on the GPU.
+        /// </summary>
+        public ulong TextureCount { get { return _textureCount; } }
+
+        /// <summary>
+        /// Number of times the vertex shader was changed on the GPU.
+        /// </summary>
+        public ulong VertexShaderCount { get { return _vertexShaderCount; } }
 
         /// <summary>
         /// Returns the difference between two sets of metrics.
@@ -38,9 +68,14 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             return new GraphicsMetrics()
             {
-                _spriteCount = value1._spriteCount - value2._spriteCount,
+                _clearCount = value1._clearCount - value2._clearCount,
                 _drawCount = value1._drawCount - value2._drawCount,
-                _primitiveCount = value1._primitiveCount - value2._primitiveCount
+                _pixelShaderCount = value1._pixelShaderCount - value2._pixelShaderCount,
+                _primitiveCount = value1._primitiveCount - value2._primitiveCount,
+                _spriteCount = value1._spriteCount - value2._spriteCount,
+                _targetCount = value1._targetCount - value2._targetCount,
+                _textureCount = value1._textureCount - value2._textureCount,
+                _vertexShaderCount = value1._vertexShaderCount - value2._vertexShaderCount
             };
         }
 
@@ -54,9 +89,14 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             return new GraphicsMetrics()
             {
-                _spriteCount = value1._spriteCount + value2._spriteCount,
+                _clearCount =  value1._clearCount + value2._clearCount,
                 _drawCount = value1._drawCount + value2._drawCount,
-                _primitiveCount = value1._primitiveCount + value2._primitiveCount
+                _pixelShaderCount = value1._pixelShaderCount + value2._pixelShaderCount,
+                _primitiveCount = value1._primitiveCount + value2._primitiveCount,
+                _spriteCount = value1._spriteCount + value2._spriteCount,
+                _targetCount = value1._targetCount + value2._targetCount,
+                _textureCount = value1._textureCount + value2._textureCount,
+                _vertexShaderCount = value1._vertexShaderCount + value2._vertexShaderCount
             };
         }
     }

--- a/MonoGame.Framework/Graphics/TextureCollection.DirectX.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.DirectX.cs
@@ -80,8 +80,13 @@ namespace Microsoft.Xna.Framework.Graphics
                 if (_textures[i] == null || _textures[i].IsDisposed)
                     shaderStage.SetShaderResource(i, null);
                 else
+                {
                     shaderStage.SetShaderResource(i, _textures[i].GetShaderResourceView());
-
+                    unchecked
+                    {
+                        _graphicsDevice._graphicsMetrics._textureCount++;
+                    }
+                }
                 _dirty &= ~mask;
                 if (_dirty == 0)
                     break;

--- a/MonoGame.Framework/Graphics/TextureCollection.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.OpenGL.cs
@@ -58,6 +58,11 @@ namespace Microsoft.Xna.Framework.Graphics
                     _targets[i] = tex.glTarget;
                     GL.BindTexture(tex.glTarget, tex.glTexture);
                     GraphicsExtensions.CheckGLError();
+
+                    unchecked
+                    {
+                        _graphicsDevice._graphicsMetrics._textureCount++;
+                    }
                 }
 
                 _dirty &= ~mask;


### PR DESCRIPTION
This is update for GraphicsMetrics which resolves https://github.com/mono/MonoGame/issues/4111

I also makes all metrics values appends after actual calls(for example DrawCount will appends after PlatformDrawPrimitives and not before) - which is more nice in my opinion, and changed docs a bit.