### PR TITLE
Added BlendFactor to GraphicsDevice

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private bool _isDisposed;
 
+        private Color _blendFactor;
         private BlendState _blendState;
         private BlendState _actualBlendState;
         private bool _blendStateDirty;
@@ -324,6 +325,33 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
+        /// <summary>
+        /// Blend factor for alpha blending.
+        /// </summary>
+        public Color BlendFactor
+        {
+            get { return _blendFactor; }
+            set
+            {
+                if(_blendFactor == value)
+                    return;
+
+                _blendFactor = value;
+
+                var newBlendState = _blendState.Clone();
+
+                newBlendState.BlendFactor = value;
+
+                newBlendState.BindToGraphicsDevice(this);
+
+                _blendState = newBlendState;
+
+                _actualBlendState = newBlendState;
+
+                _blendStateDirty = true;
+            }
+        }
+
         public BlendState BlendState
         {
 			get { return _blendState; }
@@ -349,6 +377,9 @@ namespace Microsoft.Xna.Framework.Graphics
                     newBlendState = _blendStateNonPremultiplied;
                 else if (ReferenceEquals(_blendState, BlendState.Opaque))
                     newBlendState = _blendStateOpaque;
+
+                // Setup blend factor.
+                _blendFactor = _blendState.BlendFactor;
 
                 // Blend state is now bound to a device... no one should
                 // be changing the state of the blend state object now!

--- a/MonoGame.Framework/Graphics/States/BlendState.cs
+++ b/MonoGame.Framework/Graphics/States/BlendState.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-	public partial class BlendState : GraphicsResource
+	public partial class BlendState : GraphicsResource, ICloneable
 	{
         private readonly TargetBlendState[] _targetBlendState;
 
@@ -230,10 +230,23 @@ namespace Microsoft.Xna.Framework.Graphics
             Opaque = new BlendState("BlendState.Opaque", Blend.One, Blend.Zero);
 		}
 
-	    internal BlendState Clone()
-	    {
+        /// <summary>
+        /// Creates a new instance of <see cref="BlendState"/> which contains exact values from the current instance.
+        /// </summary>
+        /// <returns>A shallow copy of this state.</returns>
+        public BlendState Clone()
+        {
 	        return new BlendState(this);
-	    }
-	}
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="BlendState"/> which contains exact values from the current instance.
+        /// </summary>
+        /// <returns>A shallow copy of this state.</returns>
+        object ICloneable.Clone()
+        {
+            return new BlendState(this);
+        }
+    }
 }
 

--- a/MonoGame.Framework/Graphics/States/BlendState.cs
+++ b/MonoGame.Framework/Graphics/States/BlendState.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-	public partial class BlendState : GraphicsResource, ICloneable
+	public partial class BlendState : GraphicsResource
 	{
         private readonly TargetBlendState[] _targetBlendState;
 
@@ -237,15 +237,6 @@ namespace Microsoft.Xna.Framework.Graphics
         public BlendState Clone()
         {
 	        return new BlendState(this);
-        }
-
-        /// <summary>
-        /// Creates a new instance of <see cref="BlendState"/> which contains exact values from the current instance.
-        /// </summary>
-        /// <returns>A shallow copy of this state.</returns>
-        object ICloneable.Clone()
-        {
-            return new BlendState(this);
         }
     }
 }


### PR DESCRIPTION
Changes:

-BlendFactor added to GraphicsDevice and acts as an easy way to access to GraphicsDevice.BlendState.BlendFactor.

-Clone method in BlendState is now public and this provides way to clone popular things like BlendState.AlphaBlend for easy prototyping

Demo screenshot
![image](https://cloud.githubusercontent.com/assets/3036176/9926694/795f4e74-5d20-11e5-9e04-b592c723124b.png)
