### PR TITLE
Added a null check on Window disposal

### DIFF
--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -146,7 +146,8 @@ namespace MonoGame.Framework
         
         public override void Exit()
         {
-            _window.Dispose();
+            if (_window != null)
+                _window.Dispose();
             _window = null;
             Window = null;
         }


### PR DESCRIPTION
We are getting a few crash reports related to ```WinFormsGamePlatform.Exit()``` throwing NullException's. I haven't identified why it is called multiple times (most probably gamers button mashing the exit button), but this little null check shouldn't harm. :)