### PR TITLE
Fix for DesktopGL Exit errors

### DIFF
--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -308,11 +308,14 @@ namespace Microsoft.Xna.Framework.Audio
                 {
                     if (_bSoundAvailable)
                     {
-                        CleanUpOpenAL();
 #if DESKTOPGL
                         if(_oggstreamer != null)
                             _oggstreamer.Dispose();
 #endif
+                        for (int i = 0; i < allSourcesArray.Length; i++)
+                            AL.DeleteSource(allSourcesArray[i]);
+                        
+                        CleanUpOpenAL();
                     }
                 }
                 _isDisposed = true;

--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -88,13 +88,13 @@ namespace Microsoft.Xna.Framework
 		private OpenALSoundController soundControllerInstance = null;
         // stored the current screen state, so we can check if it has changed.
         private bool isCurrentlyFullScreen = false;
-        private Toolkit toolkit;
         private int isExiting; // int, so we can use Interlocked.Increment
+
+        int windowDelay = 2;
         
 		public OpenTKGamePlatform(Game game)
             : base(game)
         {
-            toolkit = Toolkit.Init();
             _view = new OpenTKGameWindow(game);
             this.Window = _view;
 
@@ -137,12 +137,23 @@ namespace Microsoft.Xna.Framework
                 // Note 2: Game.Exit() can be called asynchronously from
                 // _view.ProcessEvents() (cases #2 and #3 above), so the
                 // isExiting check must be placed *after* _view.ProcessEvents()
-                if (isExiting > 0)
+                // Note 3: We need to continue processing view events until  
+                // everything gets disposed of, otherwise it will close the window
+                // and make the window handle invalid
+                if (isExiting == 0)
+                    Game.Tick();
+                else if (windowDelay == 2)
                 {
+                    windowDelay--;
+                    Game.ExitEverything();
+                }
+                else if (windowDelay > 0)
+                    windowDelay--;
+                else
+                {
+                    _view.Dispose();
                     break;
                 }
-
-                Game.Tick();
             }
         }
 
@@ -286,27 +297,6 @@ namespace Microsoft.Xna.Framework
             var device = Game.GraphicsDevice;
             if (device != null)
                 device.Present();
-        }
-		
-        protected override void Dispose(bool disposing)
-        {
-            if (!IsDisposed)
-            {
-                if (toolkit != null)
-                {
-                    toolkit.Dispose();
-                    toolkit = null;
-                }
-
-                if (_view != null)
-                {
-                    _view.Dispose();
-                    _view = null;
-                }
-            }
-
-			base.Dispose(disposing);
-        }
-			
+        }	
     }
 }

--- a/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
@@ -409,8 +409,9 @@ namespace Microsoft.Xna.Framework
             {
                 if (disposing)
                 {
-                    // Dispose/release managed objects
-                    window.Dispose();
+                    // Disposing of window will cause a crash on Linux
+                    // tho it will get destroied anyway by not beeing updated
+                    window.Close();
                 }
                 // The window handle no longer exists
                 _windowHandle = IntPtr.Zero;

--- a/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
@@ -186,6 +186,10 @@ namespace Microsoft.Xna.Framework
 
         private void OpenTkGameWindow_Closing(object sender, CancelEventArgs e)
         {
+            //block the window from getting destroyed before we dispose of
+            //the resources, than we will destroy it
+            e.Cancel = true;
+
             Game.Exit();
         }
 
@@ -214,35 +218,41 @@ namespace Microsoft.Xna.Framework
             if (Game == null)
                 return;
 
-            var winWidth = window.ClientRectangle.Width;
-            var winHeight = window.ClientRectangle.Height;
-            var winRect = new Rectangle(0, 0, winWidth, winHeight);
+            lock (window)
+            {
+                var winWidth = window.ClientRectangle.Width;
+                var winHeight = window.ClientRectangle.Height;
+                var winRect = new Rectangle(0, 0, winWidth, winHeight);
 
-            // If window size is zero, leave bounds unchanged
-            // OpenTK appears to set the window client size to 1x1 when minimizing
-            if (winWidth <= 1 || winHeight <= 1) 
-                return;
+                // If window size is zero, leave bounds unchanged
+                // OpenTK appears to set the window client size to 1x1 when minimizing
+                if (winWidth <= 1 || winHeight <= 1)
+                    return;
 
-            //If we've already got a pending change, do nothing
-            if (updateClientBounds)
-                return;
+                //If we've already got a pending change, do nothing
+                if (updateClientBounds)
+                    return;
             
-            Game.GraphicsDevice.PresentationParameters.BackBufferWidth = winWidth;
-            Game.GraphicsDevice.PresentationParameters.BackBufferHeight = winHeight;
+                Game.GraphicsDevice.PresentationParameters.BackBufferWidth = winWidth;
+                Game.GraphicsDevice.PresentationParameters.BackBufferHeight = winHeight;
 
-            Game.GraphicsDevice.Viewport = new Viewport(0, 0, winWidth, winHeight);
+                Game.GraphicsDevice.Viewport = new Viewport(0, 0, winWidth, winHeight);
 
-            clientBounds = winRect;
+                clientBounds = winRect;
 
-            OnClientSizeChanged();
+                OnClientSizeChanged();
+            }
         }
 
         internal void ProcessEvents()
         {
-            UpdateBorder();
-            Window.ProcessEvents();
-            UpdateWindowState();
-            HandleInput();
+            lock (window)
+            {
+                UpdateBorder();
+                Window.ProcessEvents();
+                UpdateWindowState();
+                HandleInput();
+            }
         }
 
         private void UpdateBorder()

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -395,14 +395,27 @@ namespace Microsoft.Xna.Framework
                 break;
             case GameRunBehavior.Synchronous:
                 Platform.RunLoop();
+#if !DESKTOPGL
                 EndRun();
 				DoExiting();
+#endif
                 break;
             default:
                 throw new ArgumentException(string.Format(
                     "Handling for the run behavior {0} is not implemented.", runBehavior));
             }
         }
+
+#if DESKTOPGL
+        // This code is used so that the Window could stay alive
+        // while all the resources are getting destroyed
+        internal void ExitEverything()
+        {
+            EndRun();
+            DoExiting();
+            this.Dispose();
+        }
+#endif
 
         private TimeSpan _accumulatedElapsedTime;
         private readonly GameTime _gameTime = new GameTime();


### PR DESCRIPTION
Fixes: #3540

Stuff done:
 - Fixes BadWindow, BadCursor and OpenTK: Failed to make context current errors
   - was occurring because of window getting Disposed before the rest of the things completed like disposing of Textures(which require a valid window handle) and was also because of Run Loop stopping with processing of events for the window which would close the window and also make that handle invalid.
 - Fixes AL Sources Error
   - whoever wrote the code didn't dispose of the sources at the end... nothing major
 - Fixes AL Device Not Closed error
   - was occurring because of the BadWindow and BadCursor errors were stopping dispose from completing
 - Fixed native stacktrace error
   - was occurring because of _toolkit.Dispose()... it's an error within OpenTK, but since _toolkit was an unused variable I just removed it