### PR TITLE
Fix For XAudio Voice Leak

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -185,18 +185,23 @@ namespace Microsoft.Xna.Framework.Audio
 
             if (voice != null)
             {
-                // We can reuse this existing voice if the sample rate and
-                // channel count are the same which will reduce garbage generation
-                // and overhead of allocating another native resource.
-
-                var details = voice.VoiceDetails;
-
-                if (details.InputSampleRate != _format.SampleRate ||
-                    details.InputChannelCount != _format.Channels)
+                // TODO: This really shouldn't be here.  Instead we should fix the 
+                // SoundEffectInstancePool to internally to look for a compatible
+                // instance or return a new instance without a voice.
+                //
+                // For now we do the same test that the pool should be doing here.
+             
+                if (!ReferenceEquals(inst._format, _format))
                 {
-                    voice.DestroyVoice();
-                    voice.Dispose();
-                    voice = null;
+                    if (inst._format.Encoding != _format.Encoding ||
+                        inst._format.Channels != _format.Channels ||
+                        inst._format.SampleRate != _format.SampleRate ||
+                        inst._format.BitsPerSample != _format.BitsPerSample)
+                    {
+                        voice.DestroyVoice();
+                        voice.Dispose();
+                        voice = null;
+                    }
                 }
             }
 
@@ -204,6 +209,7 @@ namespace Microsoft.Xna.Framework.Audio
                 voice = new SourceVoice(Device, _format, VoiceFlags.None, XAudio2.MaximumFrequencyRatio);
 
             inst._voice = voice;
+            inst._format = _format;
         }
 
         #endregion

--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -179,10 +179,16 @@ namespace Microsoft.Xna.Framework.Audio
 
         private void PlatformSetupInstance(SoundEffectInstance inst)
         {
+            // If the instance came from the pool then it could
+            // already have a valid voice assigned.
             var voice = inst._voice;
 
             if (voice != null)
             {
+                // We can reuse this existing voice if the sample rate and
+                // channel count are the same which will reduce garbage generation
+                // and overhead of allocating another native resource.
+
                 var details = voice.VoiceDetails;
 
                 if (details.InputSampleRate != _format.SampleRate ||

--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -179,8 +179,22 @@ namespace Microsoft.Xna.Framework.Audio
 
         private void PlatformSetupInstance(SoundEffectInstance inst)
         {
-            SourceVoice voice = null;
-            if (Device != null)
+            var voice = inst._voice;
+
+            if (voice != null)
+            {
+                var details = voice.VoiceDetails;
+
+                if (details.InputSampleRate != _format.SampleRate ||
+                    details.InputChannelCount != _format.Channels)
+                {
+                    voice.DestroyVoice();
+                    voice.Dispose();
+                    voice = null;
+                }
+            }
+
+            if (voice == null && Device != null)
                 voice = new SourceVoice(Device, _format, VoiceFlags.None, XAudio2.MaximumFrequencyRatio);
 
             inst._voice = voice;

--- a/MonoGame.Framework/Audio/SoundEffectInstance.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.XAudio.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Xna.Framework.Audio
     public partial class SoundEffectInstance : IDisposable
     {
         internal SourceVoice _voice;
+        internal WaveFormat _format;
 
         private static float[] _panMatrix;
 


### PR DESCRIPTION
This is a leak fix with a simple optimization for reuse of voices in XAudio.  It affected any game that relies on `SoundEffect.Play()` or XAct.  It seems like the OpenAL implementation suffers from a similar leak, but that is left to another PR.

Also there is missing optimization here that I added a `TODO` comment for.  We should be finding a `SoundEffectInstance` from the pool that is the format we need else return a new instance.  That is left for another PR.

It would be good for a few people to test this with their games before we merge this.

Thanks to @mrhelmut for the test project that exposed this issue.

Fixes #4146.