### PR TITLE
Vector3 performance improvements

### DIFF
--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -353,9 +353,13 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">The cross product of two vectors as an output parameter.</param>
         public static void Cross(ref Vector3 vector1, ref Vector3 vector2, out Vector3 result)
         {
-            result.X = vector1.Y * vector2.Z - vector2.Y * vector1.Z;
-            result.Y = -(vector1.X * vector2.Z - vector2.X * vector1.Z);
-            result.Z = vector1.X * vector2.Y - vector2.X * vector1.Y;
+            float x = vector1.Y*vector2.Z - vector2.Y*vector1.Z;
+            float y = -(vector1.X*vector2.Z - vector2.X*vector1.Z);
+            float z = vector1.X*vector2.Y - vector2.X*vector1.Y;
+
+            result.X = x;
+            result.Y = y;
+            result.Z = z;
         }
 
         /// <summary>

--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -353,9 +353,9 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">The cross product of two vectors as an output parameter.</param>
         public static void Cross(ref Vector3 vector1, ref Vector3 vector2, out Vector3 result)
         {
-            float x = vector1.Y*vector2.Z - vector2.Y*vector1.Z;
-            float y = -(vector1.X*vector2.Z - vector2.X*vector1.Z);
-            float z = vector1.X*vector2.Y - vector2.X*vector1.Y;
+            var x = vector1.Y*vector2.Z - vector2.Y*vector1.Z;
+            var y = -(vector1.X*vector2.Z - vector2.X*vector1.Z);
+            var z = vector1.X*vector2.Y - vector2.X*vector1.Y;
 
             result.X = x;
             result.Y = y;
@@ -1119,9 +1119,9 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Transformed normal as an output parameter.</param>
         public static void TransformNormal(ref Vector3 normal, ref Matrix matrix, out Vector3 result)
         {
-            var x = (normal.X*matrix.M11) + (normal.Y*matrix.M21) + (normal.Z*matrix.M31);
-            var y = (normal.X*matrix.M12) + (normal.Y*matrix.M22) + (normal.Z*matrix.M32);
-            var z = (normal.X*matrix.M13) + (normal.Y*matrix.M23) + (normal.Z*matrix.M33);
+            var x = (normal.X * matrix.M11) + (normal.Y * matrix.M21) + (normal.Z * matrix.M31);
+            var y = (normal.X * matrix.M12) + (normal.Y * matrix.M22) + (normal.Z * matrix.M32);
+            var z = (normal.X * matrix.M13) + (normal.Y * matrix.M23) + (normal.Z * matrix.M33);
             result.X = x;
             result.Y = y;
             result.Z = z;

--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -787,7 +787,13 @@ namespace Microsoft.Xna.Framework
         /// <returns>Reflected vector.</returns>
         public static Vector3 Reflect(Vector3 vector, Vector3 normal)
         {
+            // I is the original array
+            // N is the normal of the incident plane
+            // R = I - (2 * N * ( DotProduct[ I,N] ))
+
             Vector3 reflectedVector;
+            
+            // inline the dotProduct here instead of calling method
 
             var dotProduct = ((vector.X * normal.X) + (vector.Y * normal.Y)) + (vector.Z * normal.Z);
             reflectedVector.X = vector.X - (2.0f * normal.X) * dotProduct;
@@ -805,6 +811,12 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Reflected vector as an output parameter.</param>
         public static void Reflect(ref Vector3 vector, ref Vector3 normal, out Vector3 result)
         {
+            // I is the original array
+            // N is the normal of the incident plane
+            // R = I - (2 * N * ( DotProduct[ I,N] ))
+
+            // inline the dotProduct here instead of calling method
+
             var dotProduct = ((vector.X * normal.X) + (vector.Y * normal.Y)) + (vector.Z * normal.Z);
             result.X = vector.X - (2.0f * normal.X) * dotProduct;
             result.Y = vector.Y - (2.0f * normal.Y) * dotProduct;
@@ -902,9 +914,12 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Transformed <see cref="Vector3"/> as an output parameter.</param>
         public static void Transform(ref Vector3 position, ref Matrix matrix, out Vector3 result)
         {
-            result.X = (position.X * matrix.M11) + (position.Y * matrix.M21) + (position.Z * matrix.M31) + matrix.M41;
-            result.Y = (position.X * matrix.M12) + (position.Y * matrix.M22) + (position.Z * matrix.M32) + matrix.M42;
-            result.Z = (position.X * matrix.M13) + (position.Y * matrix.M23) + (position.Z * matrix.M33) + matrix.M43;
+            var x = (position.X*matrix.M11) + (position.Y*matrix.M21) + (position.Z*matrix.M31) + matrix.M41;
+            var y = (position.X*matrix.M12) + (position.Y*matrix.M22) + (position.Z*matrix.M32) + matrix.M42;
+            var z = (position.X*matrix.M13) + (position.Y*matrix.M23) + (position.Z*matrix.M33) + matrix.M43;
+            result.X = x;
+            result.Y = y;
+            result.Z = z;
         }
 
         /// <summary>
@@ -1104,9 +1119,12 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Transformed normal as an output parameter.</param>
         public static void TransformNormal(ref Vector3 normal, ref Matrix matrix, out Vector3 result)
         {
-            result.X = (normal.X * matrix.M11) + (normal.Y * matrix.M21) + (normal.Z * matrix.M31);
-            result.Y = (normal.X * matrix.M12) + (normal.Y * matrix.M22) + (normal.Z * matrix.M32);
-            result.Z = (normal.X * matrix.M13) + (normal.Y * matrix.M23) + (normal.Z * matrix.M33);
+            var x = (normal.X*matrix.M11) + (normal.Y*matrix.M21) + (normal.Z*matrix.M31);
+            var y = (normal.X*matrix.M12) + (normal.Y*matrix.M22) + (normal.Z*matrix.M32);
+            var z = (normal.X*matrix.M13) + (normal.Y*matrix.M23) + (normal.Z*matrix.M33);
+            result.X = x;
+            result.Y = y;
+            result.Z = z;
         }
 
         /// <summary>

--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -353,9 +353,9 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">The cross product of two vectors as an output parameter.</param>
         public static void Cross(ref Vector3 vector1, ref Vector3 vector2, out Vector3 result)
         {
-            var x = vector1.Y*vector2.Z - vector2.Y*vector1.Z;
-            var y = -(vector1.X*vector2.Z - vector2.X*vector1.Z);
-            var z = vector1.X*vector2.Y - vector2.X*vector1.Y;
+            var x = vector1.Y * vector2.Z - vector2.Y * vector1.Z;
+            var y = -(vector1.X * vector2.Z - vector2.X * vector1.Z);
+            var z = vector1.X * vector2.Y - vector2.X * vector1.Y;
 
             result.X = x;
             result.Y = y;
@@ -748,7 +748,11 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         public void Normalize()
         {
-            var factor = 1f / Distance(this, zero);
+            var ds = (X - 0) * (X - 0) +
+                     (Y - 0) * (Y - 0) +
+                     (Z - 0) * (Z - 0);
+            
+            var factor = 1f / (float)Math.Sqrt(ds);
 
             X *= factor;
             Y *= factor;
@@ -762,7 +766,11 @@ namespace Microsoft.Xna.Framework
         /// <returns>Unit vector.</returns>
         public static Vector3 Normalize(Vector3 value)
         {
-            var factor = 1f / Distance(value, zero);
+            var ds = (value.X - 0) * (value.X - 0) +
+                     (value.Y - 0) * (value.Y - 0) +
+                     (value.Z - 0) * (value.Z - 0);
+
+            var factor = 1f / (float)Math.Sqrt(ds);
             return new Vector3(value.X * factor, value.Y * factor, value.Z * factor);
         }
 
@@ -773,7 +781,11 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Unit vector as an output parameter.</param>
         public static void Normalize(ref Vector3 value, out Vector3 result)
         {
-            var factor = 1f / Distance(value, zero);
+            var ds = (value.X - 0) * (value.X - 0) +
+                     (value.Y - 0) * (value.Y - 0) +
+                     (value.Z - 0) * (value.Z - 0);
+
+            var factor = 1f / (float)Math.Sqrt(ds);
             result.X = value.X * factor;
             result.Y = value.Y * factor;
             result.Z = value.Z * factor;

--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Text;
 using System.Runtime.Serialization;
 
 namespace Microsoft.Xna.Framework
@@ -339,8 +338,11 @@ namespace Microsoft.Xna.Framework
         /// <returns>The cross product of two vectors.</returns>
         public static Vector3 Cross(Vector3 vector1, Vector3 vector2)
         {
-            Cross(ref vector1, ref vector2, out vector1);
-            return vector1;
+            Vector3 result;
+            result.X = vector1.Y * vector2.Z - vector2.Y * vector1.Z;
+            result.Y = -(vector1.X * vector2.Z - vector2.X * vector1.Z);
+            result.Z = vector1.X * vector2.Y - vector2.X * vector1.Y;
+            return result;
         }
 
         /// <summary>
@@ -351,12 +353,9 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">The cross product of two vectors as an output parameter.</param>
         public static void Cross(ref Vector3 vector1, ref Vector3 vector2, out Vector3 result)
         {
-            var x = vector1.Y * vector2.Z - vector2.Y * vector1.Z;
-            var y = -(vector1.X * vector2.Z - vector2.X * vector1.Z);
-            var z = vector1.X * vector2.Y - vector2.X * vector1.Y;
-            result.X = x;
-            result.Y = y;
-            result.Z = z;
+            result.X = vector1.Y * vector2.Z - vector2.Y * vector1.Z;
+            result.Y = -(vector1.X * vector2.Z - vector2.X * vector1.Z);
+            result.Z = vector1.X * vector2.Y - vector2.X * vector1.Y;
         }
 
         /// <summary>
@@ -367,9 +366,11 @@ namespace Microsoft.Xna.Framework
         /// <returns>The distance between two vectors.</returns>
         public static float Distance(Vector3 value1, Vector3 value2)
         {
-            float result;
-            DistanceSquared(ref value1, ref value2, out result);
-            return (float)Math.Sqrt(result);
+            var ds = (value1.X - value2.X) * (value1.X - value2.X) +
+                     (value1.Y - value2.Y) * (value1.Y - value2.Y) +
+                     (value1.Z - value2.Z) * (value1.Z - value2.Z);
+
+            return (float)Math.Sqrt(ds);
         }
 
         /// <summary>
@@ -380,8 +381,11 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">The distance between two vectors as an output parameter.</param>
         public static void Distance(ref Vector3 value1, ref Vector3 value2, out float result)
         {
-            DistanceSquared(ref value1, ref value2, out result);
-            result = (float)Math.Sqrt(result);
+            var ds = (value1.X - value2.X) * (value1.X - value2.X) +
+                     (value1.Y - value2.Y) * (value1.Y - value2.Y) +
+                     (value1.Z - value2.Z) * (value1.Z - value2.Z);
+            
+            result = (float)Math.Sqrt(ds);
         }
 
         /// <summary>
@@ -522,7 +526,7 @@ namespace Microsoft.Xna.Framework
         /// <returns>Hash code of this <see cref="Vector3"/>.</returns>
         public override int GetHashCode()
         {
-            return (int)(this.X + this.Y + this.Z);
+            return X.GetHashCode() + Y.GetHashCode() + Z.GetHashCode();
         }
 
         /// <summary>
@@ -720,8 +724,7 @@ namespace Microsoft.Xna.Framework
         /// <returns>The result of the vector inversion.</returns>
         public static Vector3 Negate(Vector3 value)
         {
-            value = new Vector3(-value.X, -value.Y, -value.Z);
-            return value;
+            return new Vector3(-value.X, -value.Y, -value.Z);
         }
 
         /// <summary>
@@ -741,7 +744,11 @@ namespace Microsoft.Xna.Framework
         /// </summary>
         public void Normalize()
         {
-            Normalize(ref this, out this);
+            var factor = 1f / Distance(this, zero);
+
+            X *= factor;
+            Y *= factor;
+            Z *= factor;
         }
 
         /// <summary>
@@ -751,8 +758,7 @@ namespace Microsoft.Xna.Framework
         /// <returns>Unit vector.</returns>
         public static Vector3 Normalize(Vector3 value)
         {
-            float factor = Distance(value, zero);
-            factor = 1f / factor;
+            var factor = 1f / Distance(value, zero);
             return new Vector3(value.X * factor, value.Y * factor, value.Z * factor);
         }
 
@@ -763,8 +769,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Unit vector as an output parameter.</param>
         public static void Normalize(ref Vector3 value, out Vector3 result)
         {
-            float factor = Distance(value, zero);
-            factor = 1f / factor;
+            var factor = 1f / Distance(value, zero);
             result.X = value.X * factor;
             result.Y = value.Y * factor;
             result.Z = value.Z * factor;
@@ -778,12 +783,9 @@ namespace Microsoft.Xna.Framework
         /// <returns>Reflected vector.</returns>
         public static Vector3 Reflect(Vector3 vector, Vector3 normal)
         {
-            // I is the original array
-            // N is the normal of the incident plane
-            // R = I - (2 * N * ( DotProduct[ I,N] ))
             Vector3 reflectedVector;
-            // inline the dotProduct here instead of calling method
-            float dotProduct = ((vector.X * normal.X) + (vector.Y * normal.Y)) + (vector.Z * normal.Z);
+
+            var dotProduct = ((vector.X * normal.X) + (vector.Y * normal.Y)) + (vector.Z * normal.Z);
             reflectedVector.X = vector.X - (2.0f * normal.X) * dotProduct;
             reflectedVector.Y = vector.Y - (2.0f * normal.Y) * dotProduct;
             reflectedVector.Z = vector.Z - (2.0f * normal.Z) * dotProduct;
@@ -799,12 +801,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Reflected vector as an output parameter.</param>
         public static void Reflect(ref Vector3 vector, ref Vector3 normal, out Vector3 result)
         {
-            // I is the original array
-            // N is the normal of the incident plane
-            // R = I - (2 * N * ( DotProduct[ I,N] ))
-
-            // inline the dotProduct here instead of calling method
-            float dotProduct = ((vector.X * normal.X) + (vector.Y * normal.Y)) + (vector.Z * normal.Z);
+            var dotProduct = ((vector.X * normal.X) + (vector.Y * normal.Y)) + (vector.Z * normal.Z);
             result.X = vector.X - (2.0f * normal.X) * dotProduct;
             result.Y = vector.Y - (2.0f * normal.Y) * dotProduct;
             result.Z = vector.Z - (2.0f * normal.Z) * dotProduct;
@@ -873,15 +870,7 @@ namespace Microsoft.Xna.Framework
         /// <returns>A <see cref="String"/> representation of this <see cref="Vector3"/>.</returns>
         public override string ToString()
         {
-            StringBuilder sb = new StringBuilder(32);
-            sb.Append("{X:");
-            sb.Append(this.X);
-            sb.Append(" Y:");
-            sb.Append(this.Y);
-            sb.Append(" Z:");
-            sb.Append(this.Z);
-            sb.Append("}");
-            return sb.ToString();
+            return "{X:" + X + " Y:" + Y + " Z:" + Z + "}";
         }
 
         #region Transform
@@ -894,8 +883,11 @@ namespace Microsoft.Xna.Framework
         /// <returns>Transformed <see cref="Vector3"/>.</returns>
         public static Vector3 Transform(Vector3 position, Matrix matrix)
         {
-            Transform(ref position, ref matrix, out position);
-            return position;
+            Vector3 result;
+            result.X = (position.X * matrix.M11) + (position.Y * matrix.M21) + (position.Z * matrix.M31) + matrix.M41;
+            result.Y = (position.X * matrix.M12) + (position.Y * matrix.M22) + (position.Z * matrix.M32) + matrix.M42;
+            result.Z = (position.X * matrix.M13) + (position.Y * matrix.M23) + (position.Z * matrix.M33) + matrix.M43;
+            return result;
         }
 
         /// <summary>
@@ -906,12 +898,9 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Transformed <see cref="Vector3"/> as an output parameter.</param>
         public static void Transform(ref Vector3 position, ref Matrix matrix, out Vector3 result)
         {
-            var x = (position.X * matrix.M11) + (position.Y * matrix.M21) + (position.Z * matrix.M31) + matrix.M41;
-            var y = (position.X * matrix.M12) + (position.Y * matrix.M22) + (position.Z * matrix.M32) + matrix.M42;
-            var z = (position.X * matrix.M13) + (position.Y * matrix.M23) + (position.Z * matrix.M33) + matrix.M43;
-            result.X = x;
-            result.Y = y;
-            result.Z = z;
+            result.X = (position.X * matrix.M11) + (position.Y * matrix.M21) + (position.Z * matrix.M31) + matrix.M41;
+            result.Y = (position.X * matrix.M12) + (position.Y * matrix.M22) + (position.Z * matrix.M32) + matrix.M42;
+            result.Z = (position.X * matrix.M13) + (position.Y * matrix.M23) + (position.Z * matrix.M33) + matrix.M43;
         }
 
         /// <summary>
@@ -923,7 +912,15 @@ namespace Microsoft.Xna.Framework
         public static Vector3 Transform(Vector3 value, Quaternion rotation)
         {
             Vector3 result;
-            Transform(ref value, ref rotation, out result);
+
+            var x = 2f * (rotation.Y * value.Z - rotation.Z * value.Y);
+            var y = 2f * (rotation.Z * value.X - rotation.X * value.Z);
+            var z = 2f * (rotation.X * value.Y - rotation.Y * value.X);
+
+            result.X = value.X + x * rotation.W + (rotation.Y * z - rotation.Z * y);
+            result.Y = value.Y + y * rotation.W + (rotation.Z * x - rotation.X * z);
+            result.Z = value.Z + z * rotation.W + (rotation.X * y - rotation.Y * x);
+
             return result;
         }
 
@@ -935,9 +932,9 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Transformed <see cref="Vector3"/> as an output parameter.</param>
         public static void Transform(ref Vector3 value, ref Quaternion rotation, out Vector3 result)
         {
-            float x = 2 * (rotation.Y * value.Z - rotation.Z * value.Y);
-            float y = 2 * (rotation.Z * value.X - rotation.X * value.Z);
-            float z = 2 * (rotation.X * value.Y - rotation.Y * value.X);
+            var x = 2f * (rotation.Y * value.Z - rotation.Z * value.Y);
+            var y = 2f * (rotation.Z * value.X - rotation.X * value.Z);
+            var z = 2f * (rotation.X * value.Y - rotation.Y * value.X);
 
             result.X = value.X + x * rotation.W + (rotation.Y * z - rotation.Z * y);
             result.Y = value.Y + y * rotation.W + (rotation.Z * x - rotation.X * z);
@@ -1088,8 +1085,11 @@ namespace Microsoft.Xna.Framework
         /// <returns>Transformed normal.</returns>
         public static Vector3 TransformNormal(Vector3 normal, Matrix matrix)
         {
-            TransformNormal(ref normal, ref matrix, out normal);
-            return normal;
+            Vector3 result;
+            result.X = (normal.X * matrix.M11) + (normal.Y * matrix.M21) + (normal.Z * matrix.M31);
+            result.Y = (normal.X * matrix.M12) + (normal.Y * matrix.M22) + (normal.Z * matrix.M32);
+            result.Z = (normal.X * matrix.M13) + (normal.Y * matrix.M23) + (normal.Z * matrix.M33);
+            return result;
         }
 
         /// <summary>
@@ -1100,12 +1100,9 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Transformed normal as an output parameter.</param>
         public static void TransformNormal(ref Vector3 normal, ref Matrix matrix, out Vector3 result)
         {
-            var x = (normal.X * matrix.M11) + (normal.Y * matrix.M21) + (normal.Z * matrix.M31);
-            var y = (normal.X * matrix.M12) + (normal.Y * matrix.M22) + (normal.Z * matrix.M32);
-            var z = (normal.X * matrix.M13) + (normal.Y * matrix.M23) + (normal.Z * matrix.M33);
-            result.X = x;
-            result.Y = y;
-            result.Z = z;
+            result.X = (normal.X * matrix.M11) + (normal.Y * matrix.M21) + (normal.Z * matrix.M31);
+            result.Y = (normal.X * matrix.M12) + (normal.Y * matrix.M22) + (normal.Z * matrix.M32);
+            result.Z = (normal.X * matrix.M13) + (normal.Y * matrix.M23) + (normal.Z * matrix.M33);
         }
 
         /// <summary>
@@ -1199,7 +1196,9 @@ namespace Microsoft.Xna.Framework
         /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>	
         public static bool operator !=(Vector3 value1, Vector3 value2)
         {
-            return !(value1 == value2);
+            return value1.X != value2.X
+                || value1.Y != value2.Y
+                || value1.Z != value2.Z;
         }
 
         /// <summary>
@@ -1223,8 +1222,7 @@ namespace Microsoft.Xna.Framework
         /// <returns>Result of the inversion.</returns>
         public static Vector3 operator -(Vector3 value)
         {
-            value = new Vector3(-value.X, -value.Y, -value.Z);
-            return value;
+            return new Vector3(-value.X, -value.Y, -value.Z);
         }
 
         /// <summary>
@@ -1305,7 +1303,7 @@ namespace Microsoft.Xna.Framework
         /// <returns>The result of dividing a vector by a scalar.</returns>
         public static Vector3 operator /(Vector3 value1, float divider)
         {
-            float factor = 1 / divider;
+            var factor = 1f / divider;
             value1.X *= factor;
             value1.Y *= factor;
             value1.Z *= factor;

--- a/MonoGame.Framework/Vector4.cs
+++ b/MonoGame.Framework/Vector4.cs
@@ -479,7 +479,7 @@ namespace Microsoft.Xna.Framework
         /// <returns>Hash code of this <see cref="Vector4"/>.</returns>
         public override int GetHashCode()
         {
-            return (int)(this.W + this.X + this.Y + this.Y);
+            return W.GetHashCode() + X.GetHashCode() + Y.GetHashCode() + Z.GetHashCode();
         }
 
         /// <summary>

--- a/Test/Framework/Vector3Test.cs
+++ b/Test/Framework/Vector3Test.cs
@@ -7,6 +7,16 @@ namespace MonoGame.Tests.Framework
 {
     class Vector3Test
     {
+        private void Compare(Vector3 expected, Vector3 source)
+        {
+            Assert.That(expected, Is.EqualTo(source).Using(Vector3Comparer.Epsilon));
+        }
+
+        private void Compare(float expected, float source)
+        {
+            Assert.That(expected, Is.EqualTo(source).Using(FloatComparer.Epsilon));
+        }
+
         [Test]
         public void TypeConverter()
         {
@@ -27,6 +37,91 @@ namespace MonoGame.Tests.Framework
         }
 
         [Test]
+        public void Properties()
+        {
+            Compare(new Vector3(0, 0, 1), Vector3.Backward);
+            Compare(new Vector3(0, -1, 0), Vector3.Down);
+            Compare(new Vector3(0, 0, -1), Vector3.Forward);
+            Compare(new Vector3(-1, 0, 0), Vector3.Left);
+            Compare(new Vector3(1, 1, 1), Vector3.One);
+            Compare(new Vector3(1, 0, 0), Vector3.Right);
+            Compare(new Vector3(1, 0, 0), Vector3.UnitX);
+            Compare(new Vector3(0, 1, 0), Vector3.UnitY);
+            Compare(new Vector3(0, 0, 1), Vector3.UnitZ);
+            Compare(new Vector3(0, 1, 0), Vector3.Up);
+            Compare(new Vector3(0, 0, 0), Vector3.Zero);
+        }
+
+        [Test]
+        public void Operators()
+        {
+            var v1 = new Vector3(1, 2, 3);
+            var v2 = new Vector3(1, 2, 3);
+            var v3 = new Vector3(-1, -2, -3);
+            var v4 = new Vector3(5, 5, 5);
+
+            var addResult = new Vector3(2, 4, 6);
+            var zero = new Vector3(0, 0, 0);
+            var negResult = new Vector3(-1, -2, -3);
+            var mulResult = new Vector3(1, 4, 9);
+            var mulResult2 = new Vector3(2, 4, 6);
+            var divResult = new Vector3(0.2f, 0.4f, 0.6f);
+
+            Assert.IsTrue(v1 == v2); // comparsion 1
+            Assert.IsTrue(v1 != v3); // comparsion 2
+
+            Compare(addResult, v1 + v2); // add
+            Compare(zero, v1 - v2); // sub
+            Compare(negResult, -v1); // negation
+            Compare(mulResult, v1 * v2); // mul
+            Compare(mulResult2, v1 * 2); // mul scalar
+            Compare(mulResult2, 2 * v1); // scalar mul
+            Compare(divResult, v1 / v4); // div
+            Compare(divResult, v1 / 5.0f); // div scalar
+        }
+
+        [Test]
+        public void Cross()
+        {
+            var v1 = new Vector3(-1, 2, 3);
+            var v2 = new Vector3(4, -10, -11);
+            var v3 = new Vector3(22.55f, 1.5f, -3.14f);
+            var v4 = new Vector3(-2.1f, 1.5f, -0.01f);
+
+            var expected1 = new Vector3(8, 1, 2);
+            var expected2 = new Vector3(4.695f, 6.8195f, 36.975f);
+
+            Vector3 result1;
+            Vector3 result2;
+
+            Compare(expected1, Vector3.Cross(v1, v2));
+            Compare(expected2, Vector3.Cross(v3, v4));
+
+            Vector3.Cross(ref v1, ref v2, out result1);
+            Vector3.Cross(ref v3, ref v4, out result2);
+
+            Compare(expected1, result1);
+            Compare(expected2, result2);
+        }
+
+        [Test]
+        public void Distance()
+        {
+            Vector3 v1 = new Vector3(10.5f, 20, -3.4f);
+            Vector3 v2 = new Vector3(-0.01f, -10, -20);
+
+            var expected = 35.8611221f;
+
+            float result;
+
+            Compare(expected, Vector3.Distance(v1, v2));
+
+            Vector3.Distance(ref v1, ref v2, out result);
+
+            Compare(expected, result);
+        }
+
+        [Test]
         public void DistanceSquared()
         {
             var v1 = new Vector3(0.1f, 100.0f, -5.5f);
@@ -37,15 +132,78 @@ namespace MonoGame.Tests.Framework
         }
 
         [Test]
+        public void Equals()
+        {
+            object vo = new Vector3(1, 2, 3);
+            Vector3 v = new Vector3(1, 2, 3);
+            Assert.IsTrue(new Vector3(1, 2, 3).Equals(vo));
+            Assert.IsTrue(new Vector3(1, 2, 3).Equals(v));
+        }
+
+        [Test]
+        public void Negate()
+        {
+            var expected1 = new Vector3(-1,-2, -3);
+            var expected2 = new Vector3(1, 2, 3);
+
+            var v1 = new Vector3(1, 2, 3);
+            var v2 = new Vector3(-1, -2, -3);
+
+            Vector3 result1;
+            Vector3 result2;
+
+            Compare(expected1, Vector3.Negate(v1));
+            Compare(expected2, Vector3.Negate(v2));
+
+            Vector3.Negate(ref v1, out result1);
+            Vector3.Negate(ref v2, out result2);
+
+            Compare(expected1, result1);
+            Compare(expected2, result2);
+        }
+
+        [Test]
         public void Normalize()
         {
-            Vector3 v1 = new Vector3(-10.5f, 0.2f, 1000.0f);
-            Vector3 v2 = new Vector3(-10.5f, 0.2f, 1000.0f);
-            v1.Normalize();
+            var v1 = new Vector3(-10.5f, 0.2f, 1000.0f);
+            var v2 = new Vector3(-10.5f, 0.2f, 1000.0f);
+
+            Vector3 result;
+
             var expectedResult = new Vector3(-0.0104994215f, 0.000199988979f, 0.999944866f);
-            Assert.That(expectedResult, Is.EqualTo(v1).Using(Vector3Comparer.Epsilon));
-            v2 = Vector3.Normalize(v2);
-            Assert.That(expectedResult, Is.EqualTo(v2).Using(Vector3Comparer.Epsilon));
+
+            v1.Normalize();
+
+            Compare(expectedResult, v1);
+            
+            Compare(expectedResult, Vector3.Normalize(v2));
+
+            Vector3.Normalize(ref v2, out result);
+
+            Compare(expectedResult, result);
+        }
+
+        [Test]
+        public void Reflect()
+        {
+            var expected = new Vector3(-15.5479984f, -20.6239986f, 15.448f);
+
+            var v1 = new Vector3(5.1f, 0.024f, -5.2f);
+            var v2 = new Vector3(1f, 1f, -1f);
+
+            Vector3 result;
+
+            Compare(expected, Vector3.Reflect(v1, v2));
+
+            Vector3.Reflect(ref v1, ref v2, out result);
+
+            Compare(expected, result);
+        }
+
+        [Test]
+        public void ToStringTest()
+        {
+            StringAssert.IsMatch("{X:0 Y:1 Z:2.2}", new Vector3(0, 1, 2.2f).ToString());
         }
 
         [Test]
@@ -65,16 +223,33 @@ namespace MonoGame.Tests.Framework
             Vector3 result1;
             Vector3 result2;
 
-            Assert.That(expectedResult1, Is.EqualTo(Vector3.Transform(v1, m1)).Using(Vector3Comparer.Epsilon));
-            Assert.That(expectedResult2, Is.EqualTo(Vector3.Transform(v2, q1)).Using(Vector3Comparer.Epsilon));
+            Compare(expectedResult1, Vector3.Transform(v1, m1));
+            Compare(expectedResult2, Vector3.Transform(v2, q1));
 
             // OUTPUT OVERLOADS TEST
 
             Vector3.Transform(ref v1, ref m1, out result1);
             Vector3.Transform(ref v2, ref q1, out result2);
 
-            Assert.That(expectedResult1, Is.EqualTo(result1).Using(Vector3Comparer.Epsilon));
-            Assert.That(expectedResult2, Is.EqualTo(result2).Using(Vector3Comparer.Epsilon));
+            Compare(expectedResult1, result1);
+            Compare(expectedResult2, result2);
+        }
+
+        [Test]
+        public void TransformNormal()
+        {
+            var v1 = new Vector3(0.5f, 1.0f, 0.9f);
+            var m1 = new Matrix(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+            
+            var expected = new Vector3(13.5999994f, 16, 18.4f);
+
+            Vector3 result;
+
+            Compare(expected, Vector3.TransformNormal(v1, m1));
+
+            Vector3.TransformNormal(ref v1, ref m1, out result);
+
+            Compare(expected, result);
         }
     }
 }


### PR DESCRIPTION
Batch of performance improvements for Vector3.

inline from "ref" versions
-Cross
-Distance
-Normalize
-Transform
-TransformNormal
-operator !=

simplification(e.g "float" to "var")
-Negate
-Normalize
-Reflect
-ToString - removed StringBuilder
-Transform
-operator /

other:
-GetHashCode - changed to XNA behaviour
-fixed bug in Vector4.GetHashCode

+new Tests for all changed things(tested with XNA)