### PR TITLE
Fixed clipping issue when using circular dead zone

### DIFF
--- a/MonoGame.Framework/Input/GamePadThumbSticks.cs
+++ b/MonoGame.Framework/Input/GamePadThumbSticks.cs
@@ -162,10 +162,8 @@ namespace Microsoft.Xna.Framework.Input
                         right.Y = 0f;
                     break;
                 case GamePadDeadZone.Circular:
-                    if (left.LengthSquared() < leftThumbDeadZone * leftThumbDeadZone)
-                        left = Vector2.Zero;
-                    if (right.LengthSquared() < rightThumbDeadZone * rightThumbDeadZone)
-                        right = Vector2.Zero;
+                    left = ExcludeCircularDeadZone(left, leftThumbDeadZone);
+                    right = ExcludeCircularDeadZone(right, rightThumbDeadZone);
                     break;
             }
 
@@ -195,23 +193,15 @@ namespace Microsoft.Xna.Framework.Input
                 right.X = right.X / (1.0f - rightThumbDeadZone);
                 right.Y = right.Y / (1.0f - rightThumbDeadZone);
             }
-            else if (dz == GamePadDeadZone.Circular)
-            {
-                if (left.LengthSquared() >= leftThumbDeadZone * leftThumbDeadZone)
-                {
-                    Vector2 norm = left;
-                    norm.Normalize();
-                    left = left - norm * leftThumbDeadZone; // excluding deadzone
-                    left = left / leftThumbDeadZone; // re-range output
-                }
-                if (right.LengthSquared() >= rightThumbDeadZone * rightThumbDeadZone)
-                {
-                    Vector2 norm = right;
-                    norm.Normalize();
-                    right = right - norm * rightThumbDeadZone;
-                    right = right / rightThumbDeadZone;
-                }
-            }
+        }
+
+        private Vector2 ExcludeCircularDeadZone(Vector2 value, float deadZone)
+        {
+            var originalLength = value.Length();
+            if (originalLength <= deadZone)
+                return Vector2.Zero;
+            var newLength = (originalLength - deadZone) / (1f - deadZone);
+            return value * (newLength / originalLength);
         }
 
         /// <summary>

--- a/MonoGame.Framework/Input/GamePadThumbSticks.cs
+++ b/MonoGame.Framework/Input/GamePadThumbSticks.cs
@@ -152,47 +152,30 @@ namespace Microsoft.Xna.Framework.Input
                 case GamePadDeadZone.None:
                     break;
                 case GamePadDeadZone.IndependentAxes:
-                    if (Math.Abs(left.X) < leftThumbDeadZone)
-                        left.X = 0f;
-                    if (Math.Abs(left.Y) < leftThumbDeadZone)
-                        left.Y = 0f;
-                    if (Math.Abs(right.X) < rightThumbDeadZone)
-                        right.X = 0f;
-                    if (Math.Abs(right.Y) < rightThumbDeadZone)
-                        right.Y = 0f;
+                    left = ExcludeIndependentAxesDeadZone(left, leftThumbDeadZone);
+                    right = ExcludeIndependentAxesDeadZone(right, rightThumbDeadZone);
                     break;
                 case GamePadDeadZone.Circular:
                     left = ExcludeCircularDeadZone(left, leftThumbDeadZone);
                     right = ExcludeCircularDeadZone(right, rightThumbDeadZone);
                     break;
             }
+        }
 
-            // excluding deadZone from the final output range
-            if (dz == GamePadDeadZone.IndependentAxes)
-            {
-                if (left.X < -leftThumbDeadZone)
-                     left.X = left.X + leftThumbDeadZone;
-                else if (left.X > leftThumbDeadZone)
-                    left.X = left.X - leftThumbDeadZone;
-                if (left.Y < -leftThumbDeadZone)
-                    left.Y = left.Y + leftThumbDeadZone;
-                else if (left.Y > leftThumbDeadZone)
-                    left.Y = left.Y - leftThumbDeadZone;
+        private Vector2 ExcludeIndependentAxesDeadZone(Vector2 value, float deadZone)
+        {
+            return new Vector2(ExcludeAxisDeadZone(value.X, deadZone), ExcludeAxisDeadZone(value.Y, deadZone));
+        }
 
-                if (right.X < -rightThumbDeadZone)
-                    right.X = right.X + rightThumbDeadZone;
-                else if (right.X > rightThumbDeadZone)
-                    right.X = right.X - rightThumbDeadZone;
-                if (right.Y < -rightThumbDeadZone)
-                    right.Y = right.Y + rightThumbDeadZone;
-                else if (right.Y > rightThumbDeadZone)
-                    right.Y = right.Y - rightThumbDeadZone;
-
-                left.X = left.X / (1.0f - leftThumbDeadZone);
-                left.Y = left.Y / (1.0f - leftThumbDeadZone);
-                right.X = right.X / (1.0f - rightThumbDeadZone);
-                right.Y = right.Y / (1.0f - rightThumbDeadZone);
-            }
+        private float ExcludeAxisDeadZone(float value, float deadZone)
+        {
+            if (value < -deadZone)
+                value += deadZone;
+            else if (value > deadZone)
+                value -= deadZone;
+            else
+                return 0f;
+            return value / (1f - deadZone);
         }
 
         private Vector2 ExcludeCircularDeadZone(Vector2 value, float deadZone)


### PR DESCRIPTION
This fixes the circular dead zone clipping issue described in issue #4170.

I'll also submit a separate PR to remove the superfluous `GamePadThumbSticks.Gate` property once this has been merged.