### PR TITLE
SpriteBatcher item pool

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -355,8 +355,24 @@ namespace Microsoft.Xna.Framework.Graphics
 		{
 			var item = _batcher.CreateBatchItem();
 
-			item.Depth = depth;
 			item.Texture = texture;
+
+            // set SortKey based on SpriteSortMode.
+            switch ( _sortMode )
+            {
+                // Comparison of Texture objects.
+                case SpriteSortMode.Texture:
+                    item.SortKey = texture.SortingKey;
+                    break;
+                // Comparison of Depth
+                case SpriteSortMode.FrontToBack:
+                    item.SortKey = depth;
+                    break;
+                // Comparison of Depth in reverse
+                case SpriteSortMode.BackToFront:
+                    item.SortKey = -depth;
+                    break;
+            }
 
 			if (sourceRectangle.HasValue) {
 				_tempRect = sourceRectangle.Value;
@@ -393,7 +409,8 @@ namespace Microsoft.Xna.Framework.Graphics
 					(float)Math.Cos (rotation), 
 					color, 
 					_texCoordTL, 
-					_texCoordBR);			
+					_texCoordBR,
+                    depth);
 			
 			if (autoFlush)
 			{

--- a/MonoGame.Framework/Graphics/SpriteBatchItem.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatchItem.cs
@@ -2,10 +2,10 @@ using System;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-	internal class SpriteBatchItem
+    internal class SpriteBatchItem : IComparable<SpriteBatchItem>
 	{
 		public Texture2D Texture;
-		public float Depth;
+        public float SortKey;
 
         public VertexPositionColorTexture vertexTL;
 		public VertexPositionColorTexture vertexTR;
@@ -19,70 +19,77 @@ namespace Microsoft.Xna.Framework.Graphics
             vertexBR = new VertexPositionColorTexture();            
 		}
 		
-		public void Set ( float x, float y, float w, float h, Color color, Vector2 texCoordTL, Vector2 texCoordBR )
+		public void Set ( float x, float y, float w, float h, Color color, Vector2 texCoordTL, Vector2 texCoordBR, float depth )
 		{
 			vertexTL.Position.X = x;
             vertexTL.Position.Y = y;
-            vertexTL.Position.Z = Depth;
+            vertexTL.Position.Z = depth;
             vertexTL.Color = color;
             vertexTL.TextureCoordinate.X = texCoordTL.X;
             vertexTL.TextureCoordinate.Y = texCoordTL.Y;            
 
 			vertexTR.Position.X = x+w;
             vertexTR.Position.Y = y;
-            vertexTR.Position.Z = Depth;
+            vertexTR.Position.Z = depth;
             vertexTR.Color = color;
             vertexTR.TextureCoordinate.X = texCoordBR.X;
             vertexTR.TextureCoordinate.Y = texCoordTL.Y;
 
 			vertexBL.Position.X = x;
             vertexBL.Position.Y = y+h;
-            vertexBL.Position.Z = Depth;
+            vertexBL.Position.Z = depth;
             vertexBL.Color = color;
 			vertexBL.TextureCoordinate.X = texCoordTL.X;
             vertexBL.TextureCoordinate.Y = texCoordBR.Y;
 
 			vertexBR.Position.X = x+w;
             vertexBR.Position.Y = y+h;
-            vertexBR.Position.Z = Depth;
+            vertexBR.Position.Z = depth;
             vertexBR.Color = color;
 			vertexBR.TextureCoordinate.X = texCoordBR.X;
             vertexBR.TextureCoordinate.Y = texCoordBR.Y;
 		}
 
-		public void Set ( float x, float y, float dx, float dy, float w, float h, float sin, float cos, Color color, Vector2 texCoordTL, Vector2 texCoordBR )
+		public void Set ( float x, float y, float dx, float dy, float w, float h, float sin, float cos, Color color, Vector2 texCoordTL, Vector2 texCoordBR, float depth )
 		{
             // TODO, Should we be just assigning the Depth Value to Z?
             // According to http://blogs.msdn.com/b/shawnhar/archive/2011/01/12/spritebatch-billboards-in-a-3d-world.aspx
             // We do.
 			vertexTL.Position.X = x+dx*cos-dy*sin;
             vertexTL.Position.Y = y+dx*sin+dy*cos;
-            vertexTL.Position.Z = Depth;
+            vertexTL.Position.Z = depth;
             vertexTL.Color = color;
             vertexTL.TextureCoordinate.X = texCoordTL.X;
             vertexTL.TextureCoordinate.Y = texCoordTL.Y;
 
 			vertexTR.Position.X = x+(dx+w)*cos-dy*sin;
             vertexTR.Position.Y = y+(dx+w)*sin+dy*cos;
-            vertexTR.Position.Z = Depth;
+            vertexTR.Position.Z = depth;
             vertexTR.Color = color;
             vertexTR.TextureCoordinate.X = texCoordBR.X;
             vertexTR.TextureCoordinate.Y = texCoordTL.Y;
 
 			vertexBL.Position.X = x+dx*cos-(dy+h)*sin;
             vertexBL.Position.Y = y+dx*sin+(dy+h)*cos;
-            vertexBL.Position.Z = Depth;
+            vertexBL.Position.Z = depth;
             vertexBL.Color = color;
             vertexBL.TextureCoordinate.X = texCoordTL.X;
             vertexBL.TextureCoordinate.Y = texCoordBR.Y;
 
 			vertexBR.Position.X = x+(dx+w)*cos-(dy+h)*sin;
             vertexBR.Position.Y = y+(dx+w)*sin+(dy+h)*cos;
-            vertexBR.Position.Z = Depth;
+            vertexBR.Position.Z = depth;
             vertexBR.Color = color;
             vertexBR.TextureCoordinate.X = texCoordBR.X;
             vertexBR.TextureCoordinate.Y = texCoordBR.Y;
 		}
-	}
+
+        #region Implement IComparable
+        public int CompareTo(SpriteBatchItem other)
+        {
+            return SortKey.CompareTo(other.SortKey);
+        }
+        #endregion
+    }
 }
 

--- a/MonoGame.Framework/Graphics/SpriteBatcher.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatcher.cs
@@ -82,7 +82,20 @@ namespace Microsoft.Xna.Framework.Graphics
         /// Index pointer to the next available SpriteBatchItem in _freeBatchItemPool.
         /// </summary>
         private int _freeBatchItemBase;
-
+        
+        /// <summary>
+        /// IComparer instance for SpriteSortMode.Texture.
+        /// </summary>
+        private static CompareTexture _compareTexture = new CompareTexture();
+        /// <summary>
+        /// IComparer instance for SpriteSortMode.FrontToBack.
+        /// </summary>
+        private static CompareDepth _compareDepth = new CompareDepth();
+        /// <summary>
+        /// IComparer instance for SpriteSortMode.BackToFront.
+        /// </summary>
+        private static CompareReverseDepth _compareReverseDepth = new CompareReverseDepth();
+        
         /// <summary>
         /// The target graphics device.
         /// </summary>
@@ -167,41 +180,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             _vertexArray = new VertexPositionColorTexture[4 * numBatchItems];
         }
-
-        /// <summary>
-        /// Comparison of the underlying Texture objects for each given SpriteBatchitem.
-        /// </summary>
-        /// <param name="a"></param>
-        /// <param name="b"></param>
-        /// <returns>0 if they are equal, -1 or 1 if not.</returns>
-	    static int CompareTexture ( SpriteBatchItem a, SpriteBatchItem b )
-		{
-            return a.Texture.SortingKey.CompareTo(b.Texture.SortingKey);
-		}
-
-        /// <summary>
-        /// Compares the Depth of a against b returning -1 if a is less than b, 
-        /// 0 if equal, and 1 if a is greater than b. The test uses float.CompareTo(float)
-        /// </summary>
-        /// <param name="a"></param>
-        /// <param name="b"></param>
-        /// <returns>-1 if a is less than b, 0 if equal, and 1 if a is greater than b</returns>
-	    static int CompareDepth ( SpriteBatchItem a, SpriteBatchItem b )
-		{
-			return a.Depth.CompareTo(b.Depth);
-		}
-
-        /// <summary>
-        /// Implements the opposite of CompareDepth, where b is compared against a.
-        /// </summary>
-        /// <param name="a"></param>
-        /// <param name="b"></param>
-        /// <returns>-1 if b is less than a, 0 if equal, and 1 if b is greater than a</returns>
-        static int CompareReverseDepth(SpriteBatchItem a, SpriteBatchItem b)
-		{
-			return b.Depth.CompareTo(a.Depth);
-		}
-		
+                
         /// <summary>
         /// Sorts the batch items and then groups batch drawing into maximal allowed batch sets that do not
         /// overflow the 16 bit array indices for vertices.
@@ -218,13 +197,13 @@ namespace Microsoft.Xna.Framework.Graphics
 			switch ( sortMode )
 			{
 			case SpriteSortMode.Texture :
-				_batchItemList.Sort( CompareTexture );
+				_batchItemList.Sort( _compareTexture );
 				break;
 			case SpriteSortMode.FrontToBack :
-				_batchItemList.Sort ( CompareDepth );
+				_batchItemList.Sort ( _compareDepth );
 				break;
 			case SpriteSortMode.BackToFront :
-				_batchItemList.Sort ( CompareReverseDepth );
+				_batchItemList.Sort ( _compareReverseDepth );
 				break;
 			}
 
@@ -338,6 +317,51 @@ namespace Microsoft.Xna.Framework.Graphics
                     VertexPositionColorTexture.VertexDeclaration);
             }
         }
+
+        #region Sorting
+        private class CompareTexture : IComparer<SpriteBatchItem>
+        {
+            /// <summary>
+            /// Comparison of the underlying Texture objects for each given SpriteBatchitem.
+            /// </summary>
+            /// <param name="a"></param>
+            /// <param name="b"></param>
+            /// <returns>0 if they are equal, -1 or 1 if not.</returns>
+            public int Compare(SpriteBatchItem x, SpriteBatchItem y)
+            {
+                return x.Texture.SortingKey.CompareTo(y.Texture.SortingKey);
+            }
+        }
+
+        private class CompareDepth : IComparer<SpriteBatchItem>
+        {
+            /// <summary>
+            /// Compares the Depth of a against b returning -1 if a is less than b, 
+            /// 0 if equal, and 1 if a is greater than b. The test uses float.CompareTo(float)
+            /// </summary>
+            /// <param name="a"></param>
+            /// <param name="b"></param>
+            /// <returns>-1 if a is less than b, 0 if equal, and 1 if a is greater than b</returns>
+            public int Compare(SpriteBatchItem x, SpriteBatchItem y)
+            {
+                return x.Depth.CompareTo(y.Depth);
+            }
+        }
+
+        private class CompareReverseDepth : IComparer<SpriteBatchItem>
+        {
+            /// <summary>
+            /// Implements the opposite of CompareDepth, where b is compared against a.
+            /// </summary>
+            /// <param name="a"></param>
+            /// <param name="b"></param>
+            /// <returns>-1 if b is less than a, 0 if equal, and 1 if b is greater than a</returns>
+            public int Compare(SpriteBatchItem x, SpriteBatchItem y)
+            {
+                return y.Depth.CompareTo(x.Depth);
+            }
+        }
+        #endregion
 	}
 }
 

--- a/MonoGame.Framework/Graphics/SpriteBatcher.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatcher.cs
@@ -117,14 +117,20 @@ namespace Microsoft.Xna.Framework.Graphics
 		}
 
         /// <summary>
-        /// Create an instance of SpriteBatchItem if there is none available in the free item queue. Otherwise,
-        /// a previously allocated SpriteBatchItem is reused.
+        /// Reuse a previously allocated SpriteBatchItem from the item pool. 
+        /// if there is none available grow the pool and initialize new items.
         /// </summary>
         /// <returns></returns>
         public SpriteBatchItem CreateBatchItem()
         {
             if (_batchItemCount >= _batchItemList.Count)
-                _batchItemList.Add(new SpriteBatchItem());
+            {
+                do
+                {
+                    _batchItemList.Add(new SpriteBatchItem());
+                } while (_batchItemList.Count < _batchItemList.Capacity);
+                    
+            }
             var item = _batchItemList[_batchItemCount++];
             return item;
         }


### PR DESCRIPTION
1) Initialize the pool with new 'SpriteBatchItem' instances in the
constructor. Avoid allocation/GC during gameplay.
2) Remove line '_freeBatchItemQueue.Enqueue(item)' from the inner loop.
Instead of a Queue we pool items in a List<> and keep an index to the
next free item. After the loop we set the index to 0 to return all the
items to the pool.


     | XNA | MG DX | MG GL
--- | ---  | ---- | ---
*Original* Average Draw(ms): | 2,46571 | 1,27025 | 1,51469
*this PR* Average Draw(ms): | N/A | 1,21511 | 1,45861
Diff (%)  | N/A | 95.7% | 96.3% 

using https://github.com/danzel/DrawTextTest