### PR TITLE
Updated the iOS Audio Handling to fix #3652

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.Default.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.Default.cs
@@ -96,13 +96,7 @@ namespace Microsoft.Xna.Framework.Media
         private static bool PlatformGetGameHasControl()
         {
 #if IOS
-            bool isOtherAudioPlaying;
-            AVAudioSession avAudioSession = AVAudioSession.SharedInstance();
-            if (avAudioSession.RespondsToSelector(new ObjCRuntime.Selector("isOtherAudioPlaying")))
-                isOtherAudioPlaying = avAudioSession.OtherAudioPlaying; // iOS 6+
-            else
-                isOtherAudioPlaying = AudioSession.OtherAudioIsPlaying;
-            return !isOtherAudioPlaying;
+            return !AVAudioSession.SharedInstance().OtherAudioPlaying;
 #else
             // TODO: Fix me!
             return true;


### PR DESCRIPTION
We were using some obsolete API's to handle
Audio Interruptions.

Can someone give this a test on a iOS 9 device? 