### PR TITLE
Fix for WP81 template: GamePage is not calling InitializeComponent

### DIFF
--- a/ProjectTemplates/VisualStudio2013/WindowsPhone8.1/GamePage.xaml.cs
+++ b/ProjectTemplates/VisualStudio2013/WindowsPhone8.1/GamePage.xaml.cs
@@ -23,13 +23,11 @@ namespace $safeprojectname$
     public sealed partial class GamePage : SwapChainBackgroundPanel
     {
         readonly Game1 _game;
-        public GamePage()
-        {
-            this.InitializeComponent();
-        }
 
         public GamePage(string launchArguments)
         {
+            this.InitializeComponent();
+
             _game = XamlGame<Game1>.Create(launchArguments, Window.Current.CoreWindow, this);
         }
     }


### PR DESCRIPTION
When InitializeComponent() is not called, the template can still be used to create a running game but InputDialog.ResizeLayoutRoot() will throw a NullReferenceException (because the Grid in the GamePage cannot be found).

The other templates do not have this problem.