### PR TITLE
Matrix.Invert(Matrix matrix) fix

### DIFF
--- a/MonoGame.Framework/Matrix.cs
+++ b/MonoGame.Framework/Matrix.cs
@@ -1691,8 +1691,9 @@ namespace Microsoft.Xna.Framework
         /// <returns>The inverted matrix.</returns>
         public static Matrix Invert(Matrix matrix)
         {
-            Invert(ref matrix, out matrix);
-            return matrix;
+            Matrix result;
+            Invert(ref matrix, out result);
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
I had a weird bug with Xamarin.iOS while Debug build was running fine, but Release build had a corrupted view matrix.