### PR TITLE
Removed GamePadThumbSticks.Gate property

### DIFF
--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -92,6 +92,7 @@
 	<Compile Include="Framework\CurveTest.cs" />
 	<Compile Include="Framework\EnumConformingTest.cs" />
     <Compile Include="Framework\GamePadStateTest.cs" />
+    <Compile Include="Framework\GamePadThumbSticksTest.cs" />
     <Compile Include="Framework\GameTest.cs" />	
     <Compile Include="Framework\GameTest+Methods.cs" />
     <Compile Include="Framework\GameTest+Properties.cs" />

--- a/MonoGame.Framework/Input/GamePadThumbSticks.cs
+++ b/MonoGame.Framework/Input/GamePadThumbSticks.cs
@@ -45,14 +45,6 @@ namespace Microsoft.Xna.Framework.Input
 {
     public struct GamePadThumbSticks
     {
-        public enum GateType
-        {
-            None,
-            Round,
-            Square
-        };
-        public static GateType Gate = GateType.Round;
-
         Vector2 left;
         Vector2 right;
 
@@ -62,27 +54,6 @@ namespace Microsoft.Xna.Framework.Input
             {
                 return left;
             }
-        	internal set
-            {
-        		switch (Gate)
-                {
-        		case GateType.None:
-        			left = value;
-        			break;
-        		case GateType.Round:
-        			if (value.LengthSquared () > 1f)
-        				left = Vector2.Normalize (value);
-        			else
-        				left = value;
-        			break;
-                    case GateType.Square:
-                        left = new Vector2(MathHelper.Clamp(value.X, -1f, 1f), MathHelper.Clamp(value.Y, -1f, 1f));
-                        break;
-                    default:
-                        left = Vector2.Zero;
-                        break;
-                }
-            }
         }
         public Vector2 Right
         {
@@ -90,33 +61,13 @@ namespace Microsoft.Xna.Framework.Input
             {
                 return right;
             }
-        	internal set
-            {
-        		switch (Gate)
-                {
-        		case GateType.None:
-        			right = value;
-        			break;
-        		case GateType.Round:
-        			if (value.LengthSquared () > 1f)
-        				right = Vector2.Normalize (value);
-        			else
-        				right = value;
-        			break;
-                    case GateType.Square:
-                        right = new Vector2(MathHelper.Clamp(value.X, -1f, 1f), MathHelper.Clamp(value.Y, -1f, 1f));
-                        break;
-                    default:
-                        right = Vector2.Zero;
-                        break;
-                }
-            }
         }
 
 		public GamePadThumbSticks(Vector2 leftPosition, Vector2 rightPosition):this()
 		{
-			Left = leftPosition;
-			Right = rightPosition;
+			left = leftPosition;
+			right = rightPosition;
+            ApplySquareClamp();
 		}
 
         internal GamePadThumbSticks(Vector2 leftPosition, Vector2 rightPosition, GamePadDeadZone deadZoneMode):this()
@@ -125,8 +76,24 @@ namespace Microsoft.Xna.Framework.Input
             left = leftPosition;
             right = rightPosition;
             ApplyDeadZone(deadZoneMode);
-            Left = left;
-            Right = right;
+            if (deadZoneMode == GamePadDeadZone.Circular)
+                ApplyCircularClamp();
+            else
+                ApplySquareClamp();
+        }
+
+        private void ApplySquareClamp()
+        {
+            left = new Vector2(MathHelper.Clamp(left.X, -1f, 1f), MathHelper.Clamp(left.Y, -1f, 1f));
+            right = new Vector2(MathHelper.Clamp(right.X, -1f, 1f), MathHelper.Clamp(right.Y, -1f, 1f));
+        }
+
+        private void ApplyCircularClamp()
+        {
+            if (left.LengthSquared() > 1f)
+                left.Normalize();
+            if (right.LengthSquared() > 1f)
+                right.Normalize();
         }
 
         private void ApplyDeadZone(GamePadDeadZone dz)

--- a/Test/Framework/GamePadThumbSticksTest.cs
+++ b/Test/Framework/GamePadThumbSticksTest.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using NUnit.Framework;
+
+namespace MonoGame.Tests.Framework
+{
+    [TestFixture]
+    class GamePadThumbSticksTest
+    {
+        [TestCaseSource("PublicConstructorClampsValuesTestCases")]
+        public void PublicConstructorClampsValues(Vector2 left, Vector2 right, Vector2 expectedLeft, Vector2 expectedRight)
+        {
+            var gamePadThumbSticks = new GamePadThumbSticks(left, right);
+            Assert.That(gamePadThumbSticks.Left, Is.EqualTo(expectedLeft).Using(Vector2Comparer.Epsilon));
+            Assert.That(gamePadThumbSticks.Right, Is.EqualTo(expectedRight).Using(Vector2Comparer.Epsilon));
+        }
+
+        private static IEnumerable<TestCaseData> PublicConstructorClampsValuesTestCases
+        {
+            get
+            {
+                yield return new TestCaseData(
+                    Vector2.Zero, Vector2.Zero,
+                    Vector2.Zero, Vector2.Zero);
+
+                yield return new TestCaseData(
+                    Vector2.One, Vector2.One,
+                    Vector2.One, Vector2.One);
+
+                yield return new TestCaseData(
+                    -Vector2.One, -Vector2.One,
+                    -Vector2.One, -Vector2.One);
+
+                yield return new TestCaseData(
+                    new Vector2(-2.7f, 5.6f), new Vector2(3.5f, -4.8f),
+                    new Vector2(-1f, 1f), new Vector2(1f, -1f));
+
+                yield return new TestCaseData(
+                    new Vector2(34f, 65f), new Vector2(-33f, -17f),
+                    new Vector2(1f, 1f), new Vector2(-1f, -1f));
+            }
+        }
+    }
+}

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Framework\CurveTest.cs" />
     <Compile Include="Framework\EnumConformingTest.cs" />
     <Compile Include="Framework\GamePadStateTest.cs" />
+    <Compile Include="Framework\GamePadThumbSticksTest.cs" />
     <Compile Include="Framework\MatrixTest.cs" />
     <Compile Include="Framework\PackedVectorTest.cs" />
     <Compile Include="Framework\PlaneTest.cs" />


### PR DESCRIPTION
Closes #4170

This PR removes the superfluous `GamePadThumbSticks.Gate` property as discussed in issue #4170. This property did not exist in XNA, and it's default setting (i.e. round gate type) only matched XNA behaviour when using a circular dead zone.

I've now changed clamping of thumbstick values to be in line with XNA. From my tests and observations, XNA applies circular clamping when using a circular dead zone (i.e. clamps the vector length to 1). In all other cases (including the public constructor), it applies square clamping (i.e. clamps the vector within bounds [-1,-1]..[1,1]).

I've also added some unit tests for the public constructor to test that values are being clamped as expected (which fail with the previous MonoGame code due to the incorrect default clamping).