### PR TITLE
Fix: Asset was built multiple times with same settings.

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
@@ -48,6 +48,12 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         // with different parameters.)
         private readonly Dictionary<string, List<PipelineBuildEvent>> _pipelineBuildEvents;
 
+        // Store default values for content processor parameters. (Necessary to compare processor
+        // parameters. See PipelineBuildEvent.AreParametersEqual.)
+        //   Key = name of content processor
+        //   Value = processor parameters
+        private readonly Dictionary<string, OpaqueDataDictionary> _processorDefaultValues;
+
         public string ProjectDirectory { get; private set; }
         public string OutputDirectory { get; private set; }
         public string IntermediateDirectory { get; private set; }
@@ -88,6 +94,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         public PipelineManager(string projectDir, string outputDir, string intermediateDir)
         {
             _pipelineBuildEvents = new Dictionary<string, List<PipelineBuildEvent>>();
+            _processorDefaultValues = new Dictionary<string, OpaqueDataDictionary>();
             RethrowExceptions = true;
 
             Assemblies = new List<string>();
@@ -377,6 +384,47 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             return processor;
         }
 
+        /// <summary>
+        /// Gets the default values for the content processor parameters.
+        /// </summary>
+        /// <param name="processorName">The name of the content processor.</param>
+        /// <returns>
+        /// A dictionary containing the default value for each parameter. Returns
+        /// <see langword="null"/> if the content processor has not been created yet.
+        /// </returns>
+        public OpaqueDataDictionary GetProcessorDefaultValues(string processorName)
+        {
+            // null is not allowed as key in dictionary.
+            if (processorName == null)
+                processorName = string.Empty;
+
+            OpaqueDataDictionary defaultValues;
+            if (!_processorDefaultValues.TryGetValue(processorName, out defaultValues))
+            {
+                // Create the content processor instance and read the default values.
+                defaultValues = new OpaqueDataDictionary();
+                var processorType = GetProcessorType(processorName);
+                if (processorType != null)
+                {
+                    try
+                    {
+                        var processor = (IContentProcessor)Activator.CreateInstance(processorType);
+                        var properties = processorType.GetProperties(BindingFlags.FlattenHierarchy | BindingFlags.Public | BindingFlags.Instance);
+                        foreach (var property in properties)
+                            defaultValues.Add(property.Name, property.GetValue(processor, null));
+                    }
+                    catch
+                    {
+                        // Ignore exception. Will be handled in ProcessContent.
+                    }
+                }
+
+                _processorDefaultValues.Add(processorName, defaultValues);
+            }
+
+            return defaultValues;
+        }
+
         public DateTime GetProcessorAssemblyTimestamp(string name)
         {
             if (_processors == null)
@@ -458,6 +506,26 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             return PipelineBuildEvent.Load(eventFilepath);
         }
 
+        public void RegisterContent(string sourceFilepath, string outputFilepath = null, string importerName = null, string processorName = null, OpaqueDataDictionary processorParameters = null)
+        {
+            sourceFilepath = PathHelper.Normalize(sourceFilepath);
+            ResolveOutputFilepath(sourceFilepath, ref outputFilepath);
+
+            ResolveImporterAndProcessor(sourceFilepath, ref importerName, ref processorName);
+
+            var contentEvent = new PipelineBuildEvent
+            {
+                SourceFile = sourceFilepath,
+                DestFile = outputFilepath,
+                Importer = importerName,
+                Processor = processorName,
+                Parameters = ValidateProcessorParameters(processorName, processorParameters),
+            };
+
+            // Register pipeline build event. (Required to correctly resolve external dependencies.)
+            TrackPipelineBuildEvent(contentEvent);
+        }
+
         public PipelineBuildEvent BuildContent(string sourceFilepath, string outputFilepath = null, string importerName = null, string processorName = null, OpaqueDataDictionary processorParameters = null)
         {
             sourceFilepath = PathHelper.Normalize(sourceFilepath);
@@ -492,7 +560,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             Logger.PushFile(pipelineEvent.SourceFile);
 
             // Keep track of all build events. (Required to resolve automatic names "AssetName_n".)
-            bool fileAlreadyProcessed = TrackPipelineBuildEvent(pipelineEvent);
+            TrackPipelineBuildEvent(pipelineEvent);
 
             var rebuild = pipelineEvent.NeedsRebuild(this, cachedEvent);
             if (!rebuild)
@@ -545,9 +613,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             }
             else
             {
-                // Print message, but only if the file has not been logged before.
-                if (!fileAlreadyProcessed)
-                    Logger.LogMessage("Skipping {0}", pipelineEvent.SourceFile);
+                Logger.LogMessage("Skipping {0}", pipelineEvent.SourceFile);
             }
 
             Logger.PopFile();
@@ -714,11 +780,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         /// Stores the pipeline build event (in memory) if no matching event is found.
         /// </summary>
         /// <param name="pipelineEvent">The pipeline build event.</param>
-        /// <returns>
-        /// <see langword="true"/> if the source file was already processed before; otherwise,
-        /// <see langword="false"/>.
-        /// </returns>
-        private bool TrackPipelineBuildEvent(PipelineBuildEvent pipelineEvent)
+        private void TrackPipelineBuildEvent(PipelineBuildEvent pipelineEvent)
         {
             List<PipelineBuildEvent> pipelineBuildEvents;
             bool eventsFound = _pipelineBuildEvents.TryGetValue(pipelineEvent.SourceFile, out pipelineBuildEvents);
@@ -728,10 +790,8 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 _pipelineBuildEvents.Add(pipelineEvent.SourceFile, pipelineBuildEvents);
             }
 
-            if (FindMatchingEvent(pipelineBuildEvents, pipelineEvent.Importer, pipelineEvent.Processor, pipelineEvent.Parameters) == null)
+            if (FindMatchingEvent(pipelineBuildEvents, pipelineEvent.DestFile, pipelineEvent.Importer, pipelineEvent.Processor, pipelineEvent.Parameters) == null)
                 pipelineBuildEvents.Add(pipelineEvent);
-
-            return eventsFound;
         }
 
         /// <summary>
@@ -757,7 +817,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 // --> Compare pipeline build events.
                 ResolveImporterAndProcessor(sourceFileName, ref importerName, ref processorName);
 
-                var matchingEvent = FindMatchingEvent(pipelineBuildEvents, importerName, processorName, processorParameters);
+                var matchingEvent = FindMatchingEvent(pipelineBuildEvents, null, importerName, processorName, processorParameters);
                 if (matchingEvent != null)
                 {
                     // Matching pipeline build event found.
@@ -783,21 +843,26 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         /// Determines whether the specified list contains a matching pipeline build event.
         /// </summary>
         /// <param name="pipelineBuildEvents">The list of pipeline build events.</param>
+        /// <param name="destFile">Absolute path to the output file. Can be <see langword="null"/>.</param>
         /// <param name="importerName">The name of the content importer. Can be <see langword="null"/>.</param>
         /// <param name="processorName">The name of the content processor. Can be <see langword="null"/>.</param>
         /// <param name="processorParameters">The processor parameters. Can be <see langword="null"/>.</param>
         /// <returns>
         /// The matching pipeline build event, or <see langword="null"/>.
         /// </returns>
-        private static PipelineBuildEvent FindMatchingEvent(List<PipelineBuildEvent> pipelineBuildEvents, string importerName, string processorName, OpaqueDataDictionary processorParameters)
+        private PipelineBuildEvent FindMatchingEvent(List<PipelineBuildEvent> pipelineBuildEvents, string destFile, string importerName, string processorName, OpaqueDataDictionary processorParameters)
         {
             foreach (var existingBuildEvent in pipelineBuildEvents)
             {
-                if (existingBuildEvent.Importer == importerName
-                    && existingBuildEvent.Processor == processorName
-                    && PipelineBuildEvent.AreParametersEqual(existingBuildEvent.Parameters, processorParameters))
+                if ((destFile == null || existingBuildEvent.DestFile.Equals(destFile))
+                    && existingBuildEvent.Importer == importerName
+                    && existingBuildEvent.Processor == processorName)
                 {
-                    return existingBuildEvent;
+                    var defaultValues = GetProcessorDefaultValues(processorName);
+                    if (PipelineBuildEvent.AreParametersEqual(existingBuildEvent.Parameters, processorParameters, defaultValues))
+                    {
+                        return existingBuildEvent;
+                    }
                 }
             }
 

--- a/Tools/MGCB/BuildContent.cs
+++ b/Tools/MGCB/BuildContent.cs
@@ -284,6 +284,20 @@ namespace MGCB
             errorCount = 0;
             successCount = 0;
 
+            // Before building the content, register all files to be built. (Necessary to
+            // correctly resolve external references.)
+            foreach (var c in _content)
+            {
+                try
+                {
+                    _manager.RegisterContent(c.SourceFile, null, c.Importer, c.Processor, c.ProcessorParams);
+                }
+                catch
+                {
+                    // Ignore exception. Exception will be handled below.
+                }
+            }
+
             foreach (var c in _content)
             {
                 try


### PR DESCRIPTION
This PR solves two problems:

- _Problem 1: "An asset is built multiple times, even though the processor parameters are identical."_
When PipelineBuildEvents are compared, the method PipelineBuildEvents.AreParametersEqual assumes that the same parameters are stored in both dictionaries. This is not true in practice.
Example: One PipelineBuildEvent stores the parameter ("ColorKeyEnabled", true). The second PipelineBuildEvent does not have a matching entry. The two PipelineBuildEvents might still be equivalent. We need to compare the parameter with the default value of the content processor.
	
- _Problem 2: "The order of the assets in the content project should not matter, but it does matter."_
Example: ModelA, ModelB, TextureC are included in the content project. Both models reference TextureC.
Currently when the order in the content project is ModelA, ModelB, TextureC, the TextureC is output as "Texture_0.xnb" and "Texture.xnb". If the order is TextureC, ModelA, ModelB, the output is only "Texture.xnb", which is in in my opinion the correct result.
To solve the problem, all asset that need to be registered as PipelineBuildEvents before building any assets. Then it is possible to correctly resolve external references.