### PR TITLE
Support for playing a song from a given start position.

### DIFF
--- a/MonoGame.Framework/Media/MediaPlayer.Default.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.Default.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Xna.Framework.Media
             _queue.ActiveSong.Pause();
         }
 
-        private static void PlatformPlaySong(Song song)
+        private static void PlatformPlaySong(Song song, TimeSpan? startPosition)
         {
             if (_queue.ActiveSong == null)
                 return;
@@ -126,7 +126,7 @@ namespace Microsoft.Xna.Framework.Media
             song.SetEventHandler(OnSongFinishedPlaying);
 
             song.Volume = _isMuted ? 0.0f : _volume;
-            song.Play();
+            song.Play(startPosition);
         }
 
         private static void PlatformResume()

--- a/MonoGame.Framework/Media/MediaPlayer.WMS.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.WMS.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Xna.Framework.Media
                 return;
             }
 
-            StartSession(startPosition.HasValue ? PositionVariantFor(startPosition.Value) : PositionBeginning);
+            StartSession(PositionVariantFor(startPosition));
         }
 
         private static void PlayNewSong(Song song, TimeSpan? startPosition)
@@ -217,6 +217,7 @@ namespace Microsoft.Xna.Framework.Media
 
             _currentSong = song;
 
+            //We need to start playing from 0, then seek the stream when the topology is ready, otherwise the song doesn't play.
             if (startPosition.HasValue)
                 _desiredPosition = PositionVariantFor(startPosition.Value);
             _session.SetTopology(SessionSetTopologyFlags.Immediate, song.Topology);
@@ -277,14 +278,16 @@ namespace Microsoft.Xna.Framework.Media
                 if (_nextSong != _currentSong)
                     StartNewSong(_nextSong, _nextSongStartPosition);
                 else
-                    StartSession(_nextSongStartPosition.HasValue ? PositionVariantFor(_nextSongStartPosition.Value) : PositionBeginning);
+                    StartSession(PositionVariantFor(_nextSongStartPosition));
                 _nextSong = null;
             }
         }
 
-        private static Variant PositionVariantFor(TimeSpan position)
+        private static Variant PositionVariantFor(TimeSpan? position)
         {
-            return new Variant { Value = (long)(10000000L * (position.TotalSeconds)) };
+            if (position.HasValue)
+                return new Variant { Value = position.Value.Ticks };
+            return PositionBeginning;
         }
     }
 }

--- a/MonoGame.Framework/Media/MediaPlayer.WP.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.WP.cs
@@ -214,8 +214,11 @@ namespace Microsoft.Xna.Framework.Media
             }
         }
 
-        private static void PlatformPlaySong(Song song)
+        private static void PlatformPlaySong(Song song, TimeSpan? startPosition)
         {
+            if (startPosition.HasValue)
+                throw new Exception("startPosition not implemented on WindowsPhone"); //Should be able to implement for MediaElement, but not possible with MsMediaPlayer (XNA)
+
             if (song.InternalSong != null)
             {
                 playingInternal = true;

--- a/MonoGame.Framework/Media/MediaPlayer.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.cs
@@ -112,25 +112,34 @@ namespace Microsoft.Xna.Framework.Media
 
             State = MediaState.Paused;
         }
-		
-		/// <summary>
-		/// Play clears the current playback queue, and then queues up the specified song for playback. 
-		/// Playback starts immediately at the beginning of the song.
-		/// </summary>
+
+        /// <summary>
+        /// Play clears the current playback queue, and then queues up the specified song for playback. 
+        /// Playback starts immediately at the beginning of the song.
+        /// </summary>
         public static void Play(Song song)
+        {
+            Play(song, null);
+        }
+
+        /// <summary>
+        /// Play clears the current playback queue, and then queues up the specified song for playback. 
+        /// Playback starts immediately at the given position of the song.
+        /// </summary>
+        public static void Play(Song song, TimeSpan? startPosition)
         {
             var previousSong = _queue.Count > 0 ? _queue[0] : null;
             _queue.Clear();
             _numSongsInQueuePlayed = 0;
             _queue.Add(song);
-			_queue.ActiveSongIndex = 0;
+            _queue.ActiveSongIndex = 0;
             
-            PlaySong(song);
+            PlaySong(song, startPosition);
 
             if (previousSong != song && ActiveSongChanged != null)
                 ActiveSongChanged.Invoke(null, EventArgs.Empty);
         }
-		
+
 		public static void Play(SongCollection collection, int index = 0)
 		{
             _queue.Clear();
@@ -141,12 +150,12 @@ namespace Microsoft.Xna.Framework.Media
 			
 			_queue.ActiveSongIndex = index;
 			
-			PlaySong(_queue.ActiveSong);
+			PlaySong(_queue.ActiveSong, null);
 		}
 
-        private static void PlaySong(Song song)
+        private static void PlaySong(Song song, TimeSpan? startPosition)
         {
-            PlatformPlaySong(song);
+            PlatformPlaySong(song, startPosition);
             State = MediaState.Playing;
         }
 
@@ -231,7 +240,7 @@ namespace Microsoft.Xna.Framework.Media
 			var nextSong = _queue.GetNextSong(direction, IsShuffled);
 
             if (nextSong != null)
-                PlaySong(nextSong);
+                PlaySong(nextSong, null);
 
             if (ActiveSongChanged != null)
             {

--- a/MonoGame.Framework/Media/Song.Android.cs
+++ b/MonoGame.Framework/Media/Song.Android.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Xna.Framework.Media
             // Appears to be a noOp on Android
         }
 
-        internal void Play()
+        internal void Play(TimeSpan? startPosition)
         {
             // Prepare the player
             _androidPlayer.Reset();
@@ -94,6 +94,8 @@ namespace Microsoft.Xna.Framework.Media
             _androidPlayer.Looping = MediaPlayer.IsRepeating;
             _playingSong = this;
 
+            if (startPosition.HasValue)
+                Position = startPosition.Value;
             _androidPlayer.Start();
             _playCount++;
         }

--- a/MonoGame.Framework/Media/Song.Default.cs
+++ b/MonoGame.Framework/Media/Song.Default.cs
@@ -53,8 +53,10 @@ namespace Microsoft.Xna.Framework.Media
 			DonePlaying += handler;
 		}
 
-		internal void Play()
+		internal void Play(TimeSpan? startPosition)
 		{	
+			if (startPosition.HasValue)
+				throw new Exception("startPosition not implemented on this Platform"); //Should be possible to implement in OpenAL
 			if ( _sound == null )
 				return;
 

--- a/MonoGame.Framework/Media/Song.IOS.cs
+++ b/MonoGame.Framework/Media/Song.IOS.cs
@@ -85,8 +85,8 @@ namespace Microsoft.Xna.Framework.Media
 			DonePlaying += handler;
 		}
 
-		internal void Play()
-		{	
+        internal void Play(TimeSpan? startPosition)
+        {
             if (_player == null)
             {
                 // MediaLibrary items are lazy loaded
@@ -96,15 +96,18 @@ namespace Microsoft.Xna.Framework.Media
                     return;
             }
 
-            PlatformPlay();
+            PlatformPlay(startPosition);
 
             _playCount++;
         }
 
-        private void PlatformPlay()
+        private void PlatformPlay(TimeSpan? startPosition)
         {
-            // Seek to start to ensure playback at the start.
-            _player.Seek(CMTime.Zero);
+            
+            if (startPosition.HasValue)
+                _player.Seek(CMTime.FromSeconds(startPosition.Value.TotalSeconds, 1));
+            else
+                _player.Seek(CMTime.Zero); // Seek to start to ensure playback at the start.
             
             _player.Play();
         }

--- a/MonoGame.Framework/Media/Song.NVorbis.cs
+++ b/MonoGame.Framework/Media/Song.NVorbis.cs
@@ -34,9 +34,12 @@ namespace Microsoft.Xna.Framework.Media
             stream.Dispose();
         }
 
-        internal void Play()
+        internal void Play(TimeSpan? startPosition)
         {
             stream.Play();
+            if (startPosition != null)
+                stream.SeekToPosition((TimeSpan)startPosition);
+
             _playCount++;
         }
 

--- a/MonoGame.Framework/Utilities/OggStream.cs
+++ b/MonoGame.Framework/Utilities/OggStream.cs
@@ -173,6 +173,12 @@ namespace MonoGame.Utilities
             return AL.GetSourceState(alSourceId);
         }
 
+        public void SeekToPosition(TimeSpan pos)
+        {
+            Reader.DecodedTime = pos;
+            AL.SourceStop(alSourceId);
+        }
+
         public TimeSpan GetPosition()
         {
             if (Reader == null)


### PR DESCRIPTION
Implemented and tested on Android, iOS, WMS (Windows).

The WMS version was the trickiest, if you specify the start position immediately when you try ```_session.Start``` it doesn't work, you need to wait until the Topology is ready before you can play from anywhere that isn't the beginning. But you need to call ```_session.Start``` before it will prepare the topology. (At least in my testing)

@MichaelDePiazzi - Since you did a big bunch of WMS work in #4090 would you please be able to check over the WMS changes? Thanks!

I have a feeling I'll need to implement this for WP, WME, NVorbis(?) platforms too. Will look at that later in the week.