### PR TITLE
Fix NVorbis "instance not running" on game end

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -168,13 +168,6 @@ namespace Microsoft.Xna.Framework
             //Net.NetworkSession.Exit();
             Interlocked.Increment(ref isExiting);
 
-            // sound controller must be disposed here
-            // so that it doesn't stop the game from disposing
-            if (soundControllerInstance != null)
-            {
-                soundControllerInstance.Dispose();
-                soundControllerInstance = null;
-            }
             OpenTK.DisplayDevice.Default.RestoreResolution();
         }
 


### PR DESCRIPTION
So, long story short, in #3837 I added a dispose method which was needed because exit errors were stopping OpenALSoundController from disposing and making the game run forever, but now that #4153 got merged that's no longer the case.