### PR TITLE
Better Window Title and Icon Handling for DesktopGL

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -1040,6 +1040,9 @@
     <Compile Include="Input\KeyboardUtil.OpenTK.cs">
       <Platforms>Angle,Linux,WindowsGL</Platforms>
     </Compile>
+	 <EmbeddedResource Include="../Installers/monogame.ico">
+      <Platforms>Angle,Linux,WindowsGL</Platforms>
+    </EmbeddedResource>
 
 
     <!-- iOS Platform -->

--- a/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
@@ -334,17 +334,15 @@ namespace Microsoft.Xna.Framework
 
             window.KeyPress += OnKeyPress;
 
-            //make sure that the game is not running on linux
-            //on Linux people may want to use mkbundle to
-            //create native Linux binaries
-            if (CurrentPlatform.OS != OS.Linux)
-            {
-                // Set the window icon.
-                var assembly = Assembly.GetEntryAssembly();
-                if (assembly != null)
-                    window.Icon = Icon.ExtractAssociatedIcon(assembly.Location);
-                Title = MonoGame.Utilities.AssemblyHelper.GetDefaultWindowTitle();
-            }
+            var assembly = Assembly.GetEntryAssembly();
+            var t = Type.GetType ("Mono.Runtime");
+
+            Title = assembly != null ? AssemblyHelper.GetDefaultWindowTitle() : "MonoGame Application";
+
+            if (t == null && assembly != null)
+                window.Icon = Icon.ExtractAssociatedIcon(assembly.Location);
+            else
+                window.Icon = new Icon(Assembly.GetExecutingAssembly().GetManifestResourceStream("Microsoft.Xna.Framework.monogame.ico"));
 
             updateClientBounds = false;
             clientBounds = new Rectangle(window.ClientRectangle.X, window.ClientRectangle.Y,


### PR DESCRIPTION
Notes:
 - in some older version of mkbundle/mono, Assembly.GetEntryAssembly() would throw an error when called from application from inside mkbundle, it has been fixed since then
 - on Mono platforms "Icon.ExtractAssociatedIcon" does nothing(always loads Mono icon) so I included the MonoGame icon so it would load that as default instead of the Mono icon
   - will adding few extra KB to dll size be an issue?