### PR TITLE
License and comment cleanup for AssemblyHelper

### DIFF
--- a/MonoGame.Framework/Utilities/AssemblyHelper.cs
+++ b/MonoGame.Framework/Utilities/AssemblyHelper.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
 using System.Reflection;
 
 namespace MonoGame.Utilities
@@ -14,7 +18,7 @@ namespace MonoGame.Utilities
             var assembly = Assembly.GetEntryAssembly();
             if (assembly != null)
             {
-                //Use the Title attribute of the Assembly if possible.
+                // Use the Title attribute of the Assembly if possible.
                 var assemblyTitleAtt = ((AssemblyTitleAttribute)Attribute.GetCustomAttribute(assembly, typeof(AssemblyTitleAttribute)));
                 if (assemblyTitleAtt != null)
                     windowTitle = assemblyTitleAtt.Title;


### PR DESCRIPTION
This adds the MonoGame project license to AssemblyHelper.cs. Also added a space to one of the comments for consistency, because why not.