### PR TITLE
Dispose XAudio source voices before disposing the XAudio master voice.

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -226,6 +226,8 @@ namespace Microsoft.Xna.Framework.Audio
 
         internal static void PlatformShutdown()
         {
+            SoundEffectInstancePool.Shutdown();
+
             if (MasterVoice != null)
             {
                 MasterVoice.DestroyVoice();

--- a/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
@@ -181,5 +181,24 @@ namespace Microsoft.Xna.Framework.Audio
                 inst.Volume = inst.Volume;
             }
         }
+
+        internal static void Shutdown()
+        {
+            // We need to dispose all SoundEffectInstances before shutdown,
+            // so as to destroy all SourceVoice instances,
+            // before we can destroy our XAudio MasterVoice instance.
+            // Otherwise XAudio shutdown fails, causing intermittent crashes.
+            foreach (var inst in _playingInstances)
+            {
+                inst.Dispose();
+            }
+            _playingInstances.Clear();
+
+            foreach (var inst in _pooledInstances)
+            {
+                inst.Dispose();
+            }
+            _pooledInstances.Clear();
+        }
     }
 }


### PR DESCRIPTION
When tracking down some intermittent crashes on shutdown which seemed to be related to XAudio, I found that with a debug build of MonoGame and the Windows SDK installed I would see an "XAUDIO2: ERROR: The voice still has 1 senders" error output by my program on shutdown.

Looking into it further I found:

1) Reports of crashes if the mastering voice isn't destroyed properly before the device is destroyed.
2) https://msdn.microsoft.com/en-us/library/windows/desktop/hh405048(v=vs.85).aspx documenting that source voices must be destroyed before the mastering voice can be.

This PR causes sound effect instances to be disposed (which disposes their source voice) on PlatformShutdown of SoundEffect, before the MasteringVoice is disposed, and stops the XAudio error from being output on shutdown. I believe this also fixes an intermittent crash problem on shutdown but it's harder to tell.

I think so long as you didn't shut down while playing audio, you'd only have seen this problem if you were using pooled SoundEffectInstances, but otherwise it should have shown up consistently.