### PR TITLE
Better OpenTK Window handling

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -171,12 +171,6 @@ namespace Microsoft.Xna.Framework
             OpenTK.DisplayDevice.Default.RestoreResolution();
         }
 
-        public override void BeforeInitialize()
-        {
-            _view.Window.Visible = true;
-            base.BeforeInitialize();
-        }
-
         public override bool BeforeUpdate(GameTime gameTime)
         {
             IsActive = _view.Window.Focused;

--- a/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
@@ -248,7 +248,15 @@ namespace Microsoft.Xna.Framework
         {
             lock (window)
             {
-                UpdateBorder();
+                if (CurrentPlatform.OS == OS.Linux)
+                {
+                    if (updateborder == 1)
+                        UpdateBorder();
+
+                    if(updateborder > 0)
+                        updateborder--;
+                }
+
                 Window.ProcessEvents();
                 UpdateWindowState();
                 HandleInput();
@@ -257,20 +265,14 @@ namespace Microsoft.Xna.Framework
 
         private void UpdateBorder()
         {
-            if (updateborder == 1)
-            {
-                WindowBorder desired;
-                if (_isBorderless)
-                    desired = WindowBorder.Hidden;
-                else
-                    desired = _isResizable ? WindowBorder.Resizable : WindowBorder.Fixed;
-            
-                if (desired != window.WindowBorder && window.WindowState != WindowState.Fullscreen)
-                    window.WindowBorder = desired;
-            }
-
-            if(updateborder > 0)
-                updateborder--;
+            WindowBorder desired;
+            if (_isBorderless)
+                desired = WindowBorder.Hidden;
+            else
+                desired = _isResizable ? WindowBorder.Resizable : WindowBorder.Fixed;
+        
+            if (desired != window.WindowBorder && window.WindowState != WindowState.Fullscreen)
+                window.WindowBorder = desired;
         }
 
         private void UpdateWindowState()
@@ -279,7 +281,9 @@ namespace Microsoft.Xna.Framework
 
             if (updateClientBounds)
             {
-                window.WindowBorder = WindowBorder.Resizable;
+                if (CurrentPlatform.OS == OS.Linux)
+                    window.WindowBorder = WindowBorder.Resizable;
+                
                 updateClientBounds = false;
                 window.ClientRectangle = new System.Drawing.Rectangle(targetBounds.X,
                                      targetBounds.Y, targetBounds.Width, targetBounds.Height);
@@ -296,11 +300,17 @@ namespace Microsoft.Xna.Framework
 
                 // we need to create a small delay between resizing the window
                 // and changing the border to avoid OpenTK Linux bug
-                updateborder = 2;
+                if (CurrentPlatform.OS == OS.Linux)
+                    updateborder = 2;
+                else
+                    UpdateBorder();
 
                 var context = GraphicsContext.CurrentContext;
                 if (context != null)
                     context.Update(window.WindowInfo);
+
+                if (!Window.Visible)
+                    Window.Visible = true;
             }
         }
 

--- a/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
@@ -102,7 +102,14 @@ namespace Microsoft.Xna.Framework
 
         public override string ScreenDeviceName { get { return window.Title; } }
 
-        public override Rectangle ClientBounds { get { return clientBounds; } }
+        public override Rectangle ClientBounds 
+        { 
+            get 
+            {
+                var pos = window.PointToScreen(new System.Drawing.Point(0));
+                return new Rectangle(pos.X, pos.Y, clientBounds.Width, clientBounds.Height);
+            }
+        }
 
         // TODO: this is buggy on linux - report to opentk team
         public override bool AllowUserResizing

--- a/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
@@ -297,8 +297,8 @@ namespace Microsoft.Xna.Framework
                 // to do this, we simply compare the old size to the target size
                 int centerOffsetX = -(targetBounds.Width - window.ClientRectangle.Width) / 2;
                 int centerOffsetY = -(targetBounds.Height - window.ClientRectangle.Height) / 2;
-                window.X += centerOffsetX;
-                window.Y += centerOffsetY;
+                window.X = Math.Max(0, centerOffsetX + window.X);
+                window.Y = Math.Max(0, centerOffsetY + window.Y);
 
                 window.ClientRectangle = new System.Drawing.Rectangle(targetBounds.X,
                                      targetBounds.Y, targetBounds.Width, targetBounds.Height);


### PR DESCRIPTION
This PR does the following things:
 - makes border delay code Linux only, since that bug only affects Linux, on Windows it would create a flicker when window size would change and the border was fixed
 - moves the window set visibility code to the first time that clientbounds gets updated, this way the window will become visible with the correct size instead of becoming visible and then changing size. Fixes #4215
 - Fixes #4344 for DesktopGL side
 - Added Window centering after resize