### PR TITLE
Save and restore the pipeline window position and size

### DIFF
--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -317,6 +317,8 @@ namespace MonoGame.Tools.Pipeline
             History.Default.StartupProject = null;
             History.Default.Save();
 
+            WindowConfiguration.Default.Save ();
+
             Selection.Clear(this);
             UpdateTree();
         }

--- a/Tools/Pipeline/Common/WindowConfiguration.cs
+++ b/Tools/Pipeline/Common/WindowConfiguration.cs
@@ -1,0 +1,85 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.IO.IsolatedStorage;
+using System.Text;
+
+namespace MonoGame.Tools.Pipeline
+{
+    public class WindowConfiguration
+    {
+        [Serializable]
+        public class WindowConfigurationSettings
+        {
+            public int X = 0;
+            public int Y = 0;
+            public int Width = 751;
+            public int Height = 557;
+            public int SeparatorPosition = 179;
+
+            public override string ToString ()
+            {
+                return string.Format ("[WindowConfigurationSettings] x:{0}, y:{1}, width:{2}, height:{3}, sepeator:{4}", X, Y, Width, Height, SeparatorPosition);
+            }
+        }
+
+
+        private const string WindowConfigurationPath = "WindowConfiguration.txt";
+
+        private IsolatedStorageFile _isoStore;
+
+        public static WindowConfiguration Default { get; private set; }
+        public WindowConfigurationSettings _settings;
+
+
+        static WindowConfiguration()
+        {
+            Default = new WindowConfiguration();
+        }
+        
+        public WindowConfiguration()
+        {
+            _settings = new WindowConfigurationSettings();
+            _isoStore = IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Assembly, null, null);            
+        }
+
+        public WindowConfigurationSettings Settings
+        {
+            get
+            {
+                return _settings;
+            }
+        }        
+
+
+        public void Save()
+        {
+            var mode = FileMode.CreateNew;
+			if (_isoStore.FileExists (WindowConfigurationPath)) 
+				mode = FileMode.Truncate;
+
+            using (var isoStream = new IsolatedStorageFileStream(WindowConfigurationPath, mode, _isoStore))
+            {
+                var binaryFormatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+                binaryFormatter.Serialize(isoStream, Settings);
+            }
+        }
+
+        public void Load()
+		{
+            if (_isoStore.FileExists(WindowConfigurationPath))
+            {
+                using (var isoStream = new IsolatedStorageFileStream(WindowConfigurationPath, FileMode.Open, _isoStore))
+                {
+                    var binaryFormatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+                    _settings = (WindowConfigurationSettings)binaryFormatter.Deserialize(isoStream);
+                }
+            }
+        }
+    }
+}

--- a/Tools/Pipeline/Gtk/MainWindow.GUI.cs
+++ b/Tools/Pipeline/Gtk/MainWindow.GUI.cs
@@ -289,6 +289,7 @@ namespace MonoGame.Tools.Pipeline
 			this.SaveAction.Activated += new global::System.EventHandler (this.OnSaveActionActivated);
 			this.SaveAsAction.Activated += new global::System.EventHandler (this.OnSaveAsActionActivated);
 			this.ExitAction.Activated += new global::System.EventHandler (this.OnExitActionActivated);
+            this.SizeAllocated += new global::Gtk.SizeAllocatedHandler (this.OnSizeAllocateActivated);
 			this.UndoAction.Activated += new global::System.EventHandler (this.OnUndoActionActivated);
 			this.RedoAction.Activated += new global::System.EventHandler (this.OnRedoActionActivated);
 			RenameAction.Activated += this.OnRenameActionActivated;


### PR DESCRIPTION
Minor changes to save out the window position, size and separator position and restore them when reopening the pipeline tool