### PR TITLE
[pipeline] El Capitan did some weird stuff with the $PATH and /usr/bin

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets
@@ -24,9 +24,15 @@
       <ParentOutputDir Condition=" '$(ParentOutputDir)' == '' " >$(ProjectDir)$(ContentRootDirectory)\bin\$(MonoGamePlatform)</ParentOutputDir>
       <ParentIntermediateDir Condition=" '$(ParentIntermediateDir)' == '' " >$(ProjectDir)$(ContentRootDirectory)\obj\$(MonoGamePlatform)</ParentIntermediateDir>
 
+      <!-- El Capitan Support -->
+      <MonoExe Condition=" '$(OS)' != 'Windows_NT' And Exists ('/Library/Frameworks/Mono.framework/Versions/Current/bin/mono') ">/Library/Frameworks/Mono.framework/Versions/Current/bin/mono</MonoExe>
+      <MonoExe Condition=" '$(OS)' != 'Windows_NT' And Exists ('/usr/local/bin/mono') ">/usr/local/bin/mono</MonoExe>
+      <MonoExe Condition=" '$(OS)' != 'Windows_NT' And Exists ('/usr/bin/mono') ">/usr/bin/mono</MonoExe>
+      <MonoExe Condition=" '$(OS)' != 'Windows_NT' And '$(MonoExe)' == '' ">mono</MonoExe>
+
       <MonoGameContentBuilderExe Condition="'$(MonoGameContentBuilderExe)' == ''">$(MSBuildThisFileDirectory)Tools\MGCB.exe</MonoGameContentBuilderExe>
       <MonoGameContentBuilderCmd>&quot;$(MonoGameContentBuilderExe)&quot;</MonoGameContentBuilderCmd>
-      <MonoGameContentBuilderCmd Condition=" '$(OS)' != 'Windows_NT' ">mono $(MonoGameContentBuilderCmd)</MonoGameContentBuilderCmd>
+      <MonoGameContentBuilderCmd Condition=" '$(OS)' != 'Windows_NT' ">$(MonoExe) $(MonoGameContentBuilderCmd)</MonoGameContentBuilderCmd>
 
       <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'MacOSX' Or '$(MonoGamePlatform)' == 'iOS'">Resources\</PlatformResourcePrefix>
       <PlatformResourcePrefix Condition="'$(MonoGamePlatform)' == 'Android'">Assets\</PlatformResourcePrefix>

--- a/Tools/Pipeline/Gtk/MainWindow.cs
+++ b/Tools/Pipeline/Gtk/MainWindow.cs
@@ -466,6 +466,27 @@ namespace MonoGame.Tools.Pipeline
             projectview1.RefreshItem(projectview1.GetBaseIter(), item.OriginalPath, item.Exists, _controller.GetFullPath(item.OriginalPath));
         }
 
+
+#if MONOMAC || LINUX
+        string FindSystemMono ()
+        {
+            // El Capitan Support. /usr/bin is now read only and /usr/local/bin is NOT included
+            // in $PATH for apps... only the shell. So we need to manaully find the full path to 
+            // the right location.
+            string[] pathsToCheck = new string[] {
+                "/usr/bin",
+                "/usr/local/bin",
+                "/Library/Frameworks/Mono.framework/Versions/Current/bin",
+            };
+            foreach (var path in pathsToCheck) {
+                if (System.IO.File.Exists (System.IO.Path.Combine (path, "mono")))
+                    return System.IO.Path.Combine (path, "mono");
+            }
+            OutputAppend("Cound not find mono. Please install the latest version from http://www.mono-project.com");
+            return "mono";
+        }
+#endif
+
         public Process CreateProcess(string exe, string commands)
         {
             var _buildProcess = new Process();
@@ -474,7 +495,7 @@ namespace MonoGame.Tools.Pipeline
             _buildProcess.StartInfo.Arguments = commands;
 #endif
 #if MONOMAC || LINUX
-            _buildProcess.StartInfo.FileName = "mono";
+            _buildProcess.StartInfo.FileName = FindSystemMono ();
             if (_controller.LaunchDebugger) {
                 var port = Environment.GetEnvironmentVariable("MONO_DEBUGGER_PORT");
                 port = !string.IsNullOrEmpty (port) ? port : "55555";


### PR DESCRIPTION
Because of these changes mono can no longer be created in /usr/bin
as its read only. So the mono project have moved that exe to
/usr/local/bin.. which makes sense..

But /usr/local/bin is ONLY included in the path for the terminal/shell
and NOT for Applicaitons. So we end up in a situation where calls
to mono don't work. So the fix is to search for the locations in
the Pipeline tool AND the Build .targets.