### PR TITLE
Adds MathHelper.LerpPrecise

### DIFF
--- a/MonoGame.Framework/MathHelper.cs
+++ b/MonoGame.Framework/MathHelper.cs
@@ -159,19 +159,46 @@ namespace Microsoft.Xna.Framework
         /// Linearly interpolates between two values.
         /// </summary>
         /// <param name="value1">Source value.</param>
-        /// <param name="value2">Source value.</param>
+        /// <param name="value2">Destination value.</param>
         /// <param name="amount">Value between 0 and 1 indicating the weight of value2.</param>
         /// <returns>Interpolated value.</returns> 
         /// <remarks>This method performs the linear interpolation based on the following formula.
         /// <c>value1 + (value2 - value1) * amount</c>
         /// Passing amount a value of 0 will cause value1 to be returned, a value of 1 will cause value2 to be returned.
+        /// <seealso cref="MathHelper.LerpPrecise"/> For a less efficient version with more precision around edge cases.
         /// </remarks>
         public static float Lerp(float value1, float value2, float amount)
         {
             return value1 + (value2 - value1) * amount;
         }
 
-	/// <summary>
+
+        /// <summary>
+        /// Linearly interpolates between two values.
+        /// This method is a less efficient, more precise version of <see cref="MathHelper.Lerp"/>.
+        /// See remarks for more info.
+        /// </summary>
+        /// <param name="value1">Source value.</param>
+        /// <param name="value2">Destination value.</param>
+        /// <param name="amount">Value between 0 and 1 indicating the weight of value2.</param>
+        /// <returns>Interpolated value.</returns>
+        /// <remarks>This method performs the linear interpolation based on the following formula.
+        /// <c> ((1 - amount) * value1) + (value2 * amount) </c>
+        /// Passing amount a value of 0 will cause value1 to be returned, a value of 1 will cause value2 to be returned.
+        /// This method does not have the floating point precision issue that <see cref="MathHelper.Lerp"/> has.
+        /// i.e. If there is a big gap between value1 and value2 in magnitude (e.g. value1=10000000000000000, value2=1),
+        /// right at the edge of the interpolation range (amount=1), <see cref="MathHelper.Lerp"/> will return 0 (whereas it should return 1).
+        /// This also holds for value1=10^17, value2=10; value1=10^18,value2=10^2... so on.
+        /// For an in depth explanation of the issue, see below references:
+        /// Relevant Wikipedia Article: https://en.wikipedia.org/wiki/Linear_interpolation#Programming_language_support
+        /// Relevant StackOverflow Answer: http://stackoverflow.com/questions/4353525/floating-point-linear-interpolation#answer-23716956
+        /// </remarks>
+        public static object LerpPrecise(float value1, float value2, float amount)
+        {
+            return ((1 - amount) * value1) + (value2 * amount);
+        }
+
+        /// <summary>
         /// Returns the greater of two values.
         /// </summary>
         /// <param name="value1">Source value.</param>

--- a/Test/Framework/MathHelperTest.cs
+++ b/Test/Framework/MathHelperTest.cs
@@ -39,12 +39,25 @@ namespace MonoGame.Tests.Framework
         }
 
         [Test]
-        public void DistanceLerp()
+        public void LerpTest()
         {
             Assert.AreEqual(MathHelper.Lerp(0f, 5f, .5f), 2.5f, "Lerp test failed on [0,5,.5]");
-            Assert.AreEqual(MathHelper.Lerp(-5f, 5f, 0.5f), 0f, "Distance test failed on [-5,5,0.5]");
-            Assert.AreEqual(MathHelper.Lerp(0f, 0f, 0.5f), 0f, "Distance test failed on [0,0,0.5]");
-            Assert.AreEqual(MathHelper.Lerp(-5f, -1f, 0.5f), -3f, "Distance test failed on [-5,-1, 0.5]");
+            Assert.AreEqual(MathHelper.Lerp(-5f, 5f, 0.5f), 0f, "Lerp test failed on [-5,5,0.5]");
+            Assert.AreEqual(MathHelper.Lerp(0f, 0f, 0.5f), 0f, "Lerp test failed on [0,0,0.5]");
+            Assert.AreEqual(MathHelper.Lerp(-5f, -1f, 0.5f), -3f, "Lerp test failed on [-5,-1, 0.5]");
+            // The following test checks for XNA compatibility. 
+            // Even though the calculation itself should return "1", the XNA implementaion returns 0 (presumably due to a efficiency/precision tradeoff).
+            Assert.AreEqual(MathHelper.Lerp(10000000000000000f, 1f, 1f), 0f, "Lerp test failed on [10000000000000000,1,1]");
+        }
+
+        [Test]
+        public void LerpPreciseTest()
+        {
+            Assert.AreEqual(MathHelper.LerpPrecise(0f, 5f, .5f), 2.5f, "LerpPrecise test failed on [0,5,.5]");
+            Assert.AreEqual(MathHelper.LerpPrecise(-5f, 5f, 0.5f), 0f, "LerpPrecise test failed on [-5,5,0.5]");
+            Assert.AreEqual(MathHelper.LerpPrecise(0f, 0f, 0.5f), 0f, "LerpPrecise test failed on [0,0,0.5]");
+            Assert.AreEqual(MathHelper.LerpPrecise(-5f, -1f, 0.5f), -3f, "LerpPrecise test failed on [-5,-1, 0.5]");
+            Assert.AreEqual(MathHelper.LerpPrecise(10000000000000000f, 1f, 1f), 1, "LerpPrecise test failed on [10000000000000000,1,1]");
         }
 
         [Test]


### PR DESCRIPTION
Following discussion on #4204, this PR implements the proposed MathHelper.LerpPrecise.

I've also fixed a few apparent typos in the tests, added an XNA compat. test for current Lerp behaviour and added the relevant tests for LerpPrecise.
