### PR TITLE
Fixed #4231 Use DesktopGL if we are on Mac/Linux or if its a MonoGameProject type (DONT MERGE YET)

### DIFF
--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame.addin.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame.addin.xml
@@ -131,9 +131,12 @@
   <Extension path="/MonoDevelop/Ide/DisplayBindings">
     <DisplayBinding id="MonoGamePipeline" insertbefore="DefaultDisplayBinding" class="MonoDevelop.MonoGame.PipelineDisplayBinding" />
   </Extension>
+  <!-- Disabled in favour of MSBuild .targets integration -->
+  <!--
   <Extension path="/MonoDevelop/ProjectModel/ProjectServiceExtensions">
     <Class class="MonoDevelop.MonoGame.MonoGameBuildExtension" />
   </Extension>
+  -->
   <Module>
     <Runtime>
       <Import assembly="MonoDevelop.MonoGame.Android.dll" />

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoGameMSBuildImports.cs
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoGameMSBuildImports.cs
@@ -20,13 +20,16 @@ namespace MonoDevelop.MonoGame
 				project.PropertyGroups.Any (x => x.Properties.Any (p => p.Name == "AndroidApplication" && string.Compare (p.GetValue (), bool.TrueString, true)==0));
 			if (isMonoGame && containsMGCB && isApplication) {
 				var type = item.GetType ().Name;
-				var platform = "Windows";
+				var platform = Environment.OSVersion.Platform == PlatformID.Win32NT ? "Windows" : "DesktopGL";
 				switch (type) {
 				case "XamarinIOSProject":
 					platform = "iOS";
 					break;
 				case "MonoDroidProject":
 					platform = "Android";
+					break;
+				case "MonoGameProject":
+					platform = "DesktopGL";
 					break;
 				}
 				if (!project.PropertyGroups.Any (x => x.Properties.Any (p => p.Name == "MonoGamePlatform"))) {

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameWindowsProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameWindowsProject.xpt.xml
@@ -5,7 +5,7 @@
 		<_Category>C#/MonoGame</_Category>
 		<Icon>monogame-project</Icon>
 		<LanguageName>C#</LanguageName>
-		<_Description>Creates a new C# MonoGame Windows Application. This application will use the DirecTX backend.</_Description>	   
+		<_Description>Creates a new C# MonoGame Windows Application. This application will use the DirectX backend.</_Description>	   
 	</TemplateConfiguration>
 	
 	<Actions>


### PR DESCRIPTION
Also disabled old build extensions code in favour of MSBuild .targets integration
Fixed a typo in the DirectX template