### PR TITLE
Linux .run installer update

### DIFF
--- a/Installers/Linux/DEBIAN/postinst
+++ b/Installers/Linux/DEBIAN/postinst
@@ -1,5 +1,6 @@
 #!/bin/sh
 xdg-mime install /tmp/mgcb.xml --novendor
+xdg-mime default "Monogame Pipeline.desktop" text/mgcb
 sudo -H -u $SUDO_USER bash -c 'mdtool setup install /tmp/MonoDevelop.MonoGame.mpack'
 
 if [ -L /usr/lib/mono/xbuild/MonoGame/v3.0/Tools ]; then

--- a/Installers/Linux/RUN/postinstall.sh
+++ b/Installers/Linux/RUN/postinstall.sh
@@ -17,13 +17,6 @@ fi
 DIR=$(pwd)
 IDIR="/opt/monogame-pipeline"
 
-read -p "The pipeline will be installed in $IDIR, ok(Y, n): " choice
-case "$choice" in 
-	n|N ) 
-	echo "Type in the directory that will be used for installation:" 
-	read IDIR
-esac
-
 if [ -d "$IDIR" ]
 then
 	rm -rf "$IDIR"
@@ -81,7 +74,7 @@ read -p "Install monodevelop addin(Y, n): " choice2
 case "$choice2" in 
 	n|N ) ;;
 	*)
-	sudo -H -u $SUDO_USER bash -c 'mdtool setup install $DIR/Main/MonoDevelop.MonoGame.mpack'
+	sudo -H -u $SUDO_USER bash -c "mdtool setup install $DIR/Main/MonoDevelop.MonoGame.mpack"
 esac
 
 #MonoGame.xbuild data
@@ -125,19 +118,31 @@ cp $DIR/Main/mgcb /bin/mgcb
 chmod +x /bin/mgcb
 
 #application/mimetype icon
+if [ ! -d /usr/share/icons/gnome/scalable/mimetypes ]
+then
+	mkdir /usr/share/icons/gnome/scalable/mimetypes
+fi
+
 cp $DIR/Main/monogame.svg /usr/share/icons/gnome/scalable/mimetypes/monogame.svg
-sudo gtk-update-icon-cache /usr/share/icons/gnome/ -f
+
+if [ -f /usr/share/icons/default/index.theme ]
+then
+	sudo gtk-update-icon-cache /usr/share/icons/default/ -f
+else
+	sudo gtk-update-icon-cache /usr/share/icons/gnome/ -f
+fi
 
 #application launcher
 if [ -f /usr/share/applications/Monogame\ Pipeline.desktop ]
 then
 	rm /usr/share/applications/Monogame\ Pipeline.desktop
 fi
-echo "[Desktop Entry]\nVersion=1.0\nEncoding=UTF-8\nName=MonoGame Pipeline\nGenericName=MonoGame Pipeline\nComment=Used to create platform specific .xnb files\nExec=monogame-pipeline %F\nTryExec=monogame-pipeline\nIcon=monogame\nStartupNotify=true\nTerminal=false\nType=Application\nMimeType=text/mgcb;\nCategories=Development;" >> /usr/share/applications/Monogame\ Pipeline.desktop
+echo -e "[Desktop Entry]\nVersion=1.0\nEncoding=UTF-8\nName=MonoGame Pipeline\nGenericName=MonoGame Pipeline\nComment=Used to create platform specific .xnb files\nExec=monogame-pipeline %F\nTryExec=monogame-pipeline\nIcon=monogame\nStartupNotify=true\nTerminal=false\nType=Application\nMimeType=text/mgcb;\nCategories=Development;" | sudo tee --append /usr/share/applications/Monogame\ Pipeline.desktop > /dev/null
 
 #mimetype
 echo "Adding mimetype..."
 xdg-mime install $DIR/Main/mgcb.xml --novendor
+xdg-mime default "Monogame Pipeline.desktop" text/mgcb
 
 #uninstall script
 chmod +x $IDIR/uninstall.sh


### PR DESCRIPTION
Stuff done:
 - removed the option to select installation directory(it was broken and linux installers usually don't offer this anyway)
 - fixed installing monodevelop addin
 - fixed /usr/share/icons/gnome/scalable/mimetypes not existing on Fedora
 - fixed updating wrong icon cache
 - fixed not having correct permissions to write to /usr/share/applications
 - set Pipeline Tool as default for .mgcb files on both installers