### PR TITLE
Add support for tvOS to MonoGame.  

### DIFF
--- a/Build/GenerateProject.CSharp.xslt
+++ b/Build/GenerateProject.CSharp.xslt
@@ -291,7 +291,7 @@
 			  <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
 			  <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
 		  </xsl:when>			
-          <xsl:when test="/Input/Generation/Platform = 'iOS' or /Input/Generation/Platform = 'PSMobile'">
+          <xsl:when test="/Input/Generation/Platform = 'iOS' or /Input/Generation/Platform = 'PSMobile' or /Input/Generation/Platform = 'tvOS'">
           </xsl:when>
           <xsl:when test="/Input/Generation/Platform = 'PCL'">
             <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
@@ -429,6 +429,9 @@
               <xsl:when test="/Input/Generation/Platform = 'iOS'">
                 <xsl:text>PLATFORM_IOS</xsl:text>
               </xsl:when>
+              <xsl:when test="/Input/Generation/Platform = 'tvOS'">
+                <xsl:text>PLATFORM_TVOS</xsl:text>
+              </xsl:when>
               <xsl:when test="/Input/Generation/Platform = 'Linux'">
                 <xsl:text>PLATFORM_LINUX</xsl:text>
               </xsl:when>
@@ -517,7 +520,7 @@
           </xsl:otherwise>
         </xsl:choose>
       </xsl:when>
-      <xsl:when test="/Input/Generation/Platform = 'iOS'">
+      <xsl:when test="/Input/Generation/Platform = 'iOS' or /Input/Generation/Platform = 'tvOS'">
         <xsl:if test="$debug = 'true'">
           <MtouchDebug>True</MtouchDebug>
         </xsl:if>
@@ -753,6 +756,12 @@
               <xsl:text>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</xsl:text>
             </ProjectTypeGuids>
           </xsl:when>
+          <xsl:when test="/Input/Generation/Platform = 'tvOS'">
+            <ProjectTypeGuids>
+              <xsl:text>{06FA79CB-D6CD-4721-BB4B-1BD202089C55};</xsl:text>
+              <xsl:text>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</xsl:text>
+            </ProjectTypeGuids>
+          </xsl:when>
           <xsl:when test="/Input/Generation/Platform = 'MacOS'">
             <ProjectTypeGuids>
               <xsl:choose>
@@ -827,7 +836,7 @@
                 <xsl:when test="/Input/Generation/Platform = 'Windows'">
                   <xsl:text>WinExe</xsl:text>
                 </xsl:when>
-                <xsl:when test="/Input/Generation/Platform = 'iOS'">
+                <xsl:when test="/Input/Generation/Platform = 'iOS' or /Input/Generation/Platform = 'tvOS'">
                   <xsl:text>Exe</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
@@ -861,7 +870,7 @@
                 <xsl:when test="/Input/Generation/Platform = 'Windows'">
                   <xsl:text>WinExe</xsl:text>
                 </xsl:when>
-                <xsl:when test="/Input/Generation/Platform = 'iOS'">
+                <xsl:when test="/Input/Generation/Platform = 'iOS' or /Input/Generation/Platform = 'tvOS'">
                   <xsl:text>Exe</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>
@@ -918,7 +927,7 @@
               <AndroidResgenClass>Resource</AndroidResgenClass>
             </xsl:if>
           </xsl:when>
-          <xsl:when test="/Input/Generation/Platform = 'iOS'">
+          <xsl:when test="/Input/Generation/Platform = 'iOS' or /Input/Generation/Platform = 'tvOS'">
             <SynchReleaseVersion>False</SynchReleaseVersion>
             <xsl:choose>
               <xsl:when test="$project/@Type = 'App'">
@@ -965,6 +974,94 @@
       </PropertyGroup>
       <xsl:choose>
         <xsl:when test="/Input/Generation/Platform = 'iOS'">
+          <xsl:call-template name="configuration">
+            <xsl:with-param name="type"><xsl:value-of select="$project/@Type" /></xsl:with-param>
+            <xsl:with-param name="debug">true</xsl:with-param>
+            <xsl:with-param name="config">Debug</xsl:with-param>
+            <xsl:with-param name="platform">iPhone</xsl:with-param>
+            <xsl:with-param name="projectname"><xsl:value-of select="$project/@Name" /></xsl:with-param>
+          </xsl:call-template>
+          <xsl:call-template name="configuration">
+            <xsl:with-param name="type"><xsl:value-of select="$project/@Type" /></xsl:with-param>
+            <xsl:with-param name="debug">false</xsl:with-param>
+            <xsl:with-param name="config">Release</xsl:with-param>
+            <xsl:with-param name="platform">iPhone</xsl:with-param>
+            <xsl:with-param name="projectname"><xsl:value-of select="$project/@Name" /></xsl:with-param>
+          </xsl:call-template>
+          <xsl:call-template name="configuration">
+            <xsl:with-param name="type"><xsl:value-of select="$project/@Type" /></xsl:with-param>
+            <xsl:with-param name="debug">true</xsl:with-param>
+            <xsl:with-param name="config">Debug</xsl:with-param>
+            <xsl:with-param name="platform">iPhoneSimulator</xsl:with-param>
+            <xsl:with-param name="projectname"><xsl:value-of select="$project/@Name" /></xsl:with-param>
+          </xsl:call-template>
+          <xsl:call-template name="configuration">
+            <xsl:with-param name="type"><xsl:value-of select="$project/@Type" /></xsl:with-param>
+            <xsl:with-param name="debug">false</xsl:with-param>
+            <xsl:with-param name="config">Release</xsl:with-param>
+            <xsl:with-param name="platform">iPhoneSimulator</xsl:with-param>
+            <xsl:with-param name="projectname"><xsl:value-of select="$project/@Name" /></xsl:with-param>
+          </xsl:call-template>
+          <xsl:call-template name="configuration">
+            <xsl:with-param name="type"><xsl:value-of select="$project/@Type" /></xsl:with-param>
+            <xsl:with-param name="debug">false</xsl:with-param>
+            <xsl:with-param name="config">Ad-Hoc</xsl:with-param>
+            <xsl:with-param name="platform">iPhone</xsl:with-param>
+            <xsl:with-param name="projectname"><xsl:value-of select="$project/@Name" /></xsl:with-param>
+          </xsl:call-template>
+          <xsl:call-template name="configuration">
+            <xsl:with-param name="type"><xsl:value-of select="$project/@Type" /></xsl:with-param>
+            <xsl:with-param name="debug">false</xsl:with-param>
+            <xsl:with-param name="config">AppStore</xsl:with-param>
+            <xsl:with-param name="platform">iPhone</xsl:with-param>
+            <xsl:with-param name="projectname"><xsl:value-of select="$project/@Name" /></xsl:with-param>
+          </xsl:call-template>
+        </xsl:when>
+        <xsl:when test="/Input/Generation/Platform = 'WindowsPhone'">
+          <xsl:call-template name="configuration">
+            <xsl:with-param name="type"><xsl:value-of select="$project/@Type" /></xsl:with-param>
+            <xsl:with-param name="debug">true</xsl:with-param>
+            <xsl:with-param name="config">Debug</xsl:with-param>
+            <xsl:with-param name="platform">AnyCPU</xsl:with-param>
+            <xsl:with-param name="projectname"><xsl:value-of select="$project/@Name" /></xsl:with-param>
+          </xsl:call-template>
+          <xsl:call-template name="configuration">
+            <xsl:with-param name="type"><xsl:value-of select="$project/@Type" /></xsl:with-param>
+            <xsl:with-param name="debug">false</xsl:with-param>
+            <xsl:with-param name="config">Release</xsl:with-param>
+            <xsl:with-param name="platform">AnyCPU</xsl:with-param>
+            <xsl:with-param name="projectname"><xsl:value-of select="$project/@Name" /></xsl:with-param>
+          </xsl:call-template>
+          <xsl:call-template name="configuration">
+            <xsl:with-param name="type"><xsl:value-of select="$project/@Type" /></xsl:with-param>
+            <xsl:with-param name="debug">true</xsl:with-param>
+            <xsl:with-param name="config">Debug</xsl:with-param>
+            <xsl:with-param name="platform">x86</xsl:with-param>
+            <xsl:with-param name="projectname"><xsl:value-of select="$project/@Name" /></xsl:with-param>
+          </xsl:call-template>
+          <xsl:call-template name="configuration">
+            <xsl:with-param name="type"><xsl:value-of select="$project/@Type" /></xsl:with-param>
+            <xsl:with-param name="debug">false</xsl:with-param>
+            <xsl:with-param name="config">Release</xsl:with-param>
+            <xsl:with-param name="platform">x86</xsl:with-param>
+            <xsl:with-param name="projectname"><xsl:value-of select="$project/@Name" /></xsl:with-param>
+          </xsl:call-template>
+          <xsl:call-template name="configuration">
+            <xsl:with-param name="type"><xsl:value-of select="$project/@Type" /></xsl:with-param>
+            <xsl:with-param name="debug">true</xsl:with-param>
+            <xsl:with-param name="config">Debug</xsl:with-param>
+            <xsl:with-param name="platform">ARM</xsl:with-param>
+            <xsl:with-param name="projectname"><xsl:value-of select="$project/@Name" /></xsl:with-param>
+          </xsl:call-template>
+          <xsl:call-template name="configuration">
+            <xsl:with-param name="type"><xsl:value-of select="$project/@Type" /></xsl:with-param>
+            <xsl:with-param name="debug">false</xsl:with-param>
+            <xsl:with-param name="config">Release</xsl:with-param>
+            <xsl:with-param name="platform">ARM</xsl:with-param>
+            <xsl:with-param name="projectname"><xsl:value-of select="$project/@Name" /></xsl:with-param>
+          </xsl:call-template>
+        </xsl:when>
+        <xsl:when test="/Input/Generation/Platform = 'tvOS'">
           <xsl:call-template name="configuration">
             <xsl:with-param name="type"><xsl:value-of select="$project/@Type" /></xsl:with-param>
             <xsl:with-param name="debug">true</xsl:with-param>
@@ -1149,6 +1246,10 @@
               <Reference Include="Xamarin.iOS" />
             </xsl:otherwise>
           </xsl:choose>
+        </xsl:if>
+
+        <xsl:if test="/Input/Generation/Platform = 'tvOS'">
+            <Reference Include="Xamarin.TVOS" />
         </xsl:if>
 
         <xsl:for-each select="$project/References/Reference">
@@ -1946,7 +2047,7 @@
                     </Link>
                   </AndroidAsset>
                 </xsl:when>
-                <xsl:when test="/Input/Generation/Platform = 'MacOS' or /Input/Generation/Platform = 'iOS'">
+                <xsl:when test="/Input/Generation/Platform = 'MacOS' or /Input/Generation/Platform = 'iOS' or /Input/Generation/Platform = 'tvOS'">
                   <Content>
                     <xsl:attribute name="Include">
                       <xsl:value-of
@@ -2045,6 +2146,9 @@
         </xsl:when>
         <xsl:when test="/Input/Generation/Platform = 'iOS' and not(user:IsTrue(/Input/Properties/UseLegacyiOSAPI))">
           <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+        </xsl:when>
+        <xsl:when test="/Input/Generation/Platform = 'tvOS'">
+          <Import Project="$(MSBuildExtensionsPath)\Xamarin\TVOS\Xamarin.TVOS.CSharp.targets" />
         </xsl:when>
         <xsl:otherwise>
           <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Build/GenerateSolution.xslt
+++ b/Build/GenerateSolution.xslt
@@ -57,6 +57,19 @@ MinimumVisualStudioVersion = 10.0.40219.1
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 </xsl:text>
       </xsl:when>
+      <xsl:when test="/Input/Generation/Platform = 'tvOS'">
+        <xsl:text>Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|iPhoneSimulator = Debug|iPhoneSimulator
+		Release|iPhoneSimulator = Release|iPhoneSimulator
+		Debug|iPhone = Debug|iPhone
+		Release|iPhone = Release|iPhone
+		Ad-Hoc|iPhone = Ad-Hoc|iPhone
+		AppStore|iPhone = AppStore|iPhone
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+</xsl:text>
+      </xsl:when>
       <xsl:when test="/Input/Generation/Platform = 'WindowsPhone'">
         <xsl:text>Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -150,6 +163,164 @@ EndGlobal
     
     <xsl:choose>
       <xsl:when test="/Input/Generation/Platform = 'iOS'">
+        <xsl:text>		{</xsl:text>
+        <xsl:value-of select="$guid" />
+        <xsl:text>}.Ad-Hoc|iPhone.ActiveCfg = </xsl:text>
+        <xsl:choose>
+          <xsl:when test="$adhoc-mapping != ''">
+            <xsl:value-of select="$adhoc-mapping" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>Ad-Hoc|iPhone</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:text>
+</xsl:text>
+        <xsl:text>		{</xsl:text>
+        <xsl:value-of select="$guid" />
+        <xsl:text>}.Ad-Hoc|iPhone.Build.0 = </xsl:text>
+        <xsl:choose>
+          <xsl:when test="$adhoc-mapping != ''">
+            <xsl:value-of select="$adhoc-mapping" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>Ad-Hoc|iPhone</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:text>
+</xsl:text>
+        <xsl:text>		{</xsl:text>
+        <xsl:value-of select="$guid" />
+        <xsl:text>}.AppStore|iPhone.ActiveCfg = </xsl:text>
+        <xsl:choose>
+          <xsl:when test="$appstore-mapping != ''">
+            <xsl:value-of select="$appstore-mapping" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>AppStore|iPhone</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:text>
+</xsl:text>
+        <xsl:text>		{</xsl:text>
+        <xsl:value-of select="$guid" />
+        <xsl:text>}.AppStore|iPhone.Build.0 = </xsl:text>
+        <xsl:choose>
+          <xsl:when test="$appstore-mapping != ''">
+            <xsl:value-of select="$appstore-mapping" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>AppStore|iPhone</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:text>
+</xsl:text>
+        <xsl:text>		{</xsl:text>
+        <xsl:value-of select="$guid" />
+        <xsl:text>}.Debug|iPhone.ActiveCfg = </xsl:text>
+        <xsl:choose>
+          <xsl:when test="$debug-mapping != ''">
+            <xsl:value-of select="$debug-mapping" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>Debug|iPhone</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:text>
+</xsl:text>
+        <xsl:text>		{</xsl:text>
+        <xsl:value-of select="$guid" />
+        <xsl:text>}.Debug|iPhone.Build.0 = </xsl:text>
+        <xsl:choose>
+          <xsl:when test="$debug-mapping != ''">
+            <xsl:value-of select="$debug-mapping" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>Debug|iPhone</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:text>
+</xsl:text>
+        <xsl:text>		{</xsl:text>
+        <xsl:value-of select="$guid" />
+        <xsl:text>}.Debug|iPhoneSimulator.ActiveCfg = </xsl:text>
+        <xsl:choose>
+          <xsl:when test="$debug-mapping != ''">
+            <xsl:value-of select="$debug-mapping" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>Debug|iPhoneSimulator</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:text>
+</xsl:text>
+        <xsl:text>		{</xsl:text>
+        <xsl:value-of select="$guid" />
+        <xsl:text>}.Debug|iPhoneSimulator.Build.0 = </xsl:text>
+        <xsl:choose>
+          <xsl:when test="$debug-mapping != ''">
+            <xsl:value-of select="$debug-mapping" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>Debug|iPhoneSimulator</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:text>
+</xsl:text>
+        <xsl:text>		{</xsl:text>
+        <xsl:value-of select="$guid" />
+        <xsl:text>}.Release|iPhone.ActiveCfg = </xsl:text>
+        <xsl:choose>
+          <xsl:when test="$release-mapping != ''">
+            <xsl:value-of select="$release-mapping" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>Release|iPhone</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:text>
+</xsl:text>
+        <xsl:text>		{</xsl:text>
+        <xsl:value-of select="$guid" />
+        <xsl:text>}.Release|iPhone.Build.0 = </xsl:text>
+        <xsl:choose>
+          <xsl:when test="$release-mapping != ''">
+            <xsl:value-of select="$release-mapping" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>Release|iPhone</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:text>
+</xsl:text>
+        <xsl:text>		{</xsl:text>
+        <xsl:value-of select="$guid" />
+        <xsl:text>}.Release|iPhoneSimulator.ActiveCfg = </xsl:text>
+        <xsl:choose>
+          <xsl:when test="$release-mapping != ''">
+            <xsl:value-of select="$release-mapping" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>Release|iPhoneSimulator</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:text>
+</xsl:text>
+        <xsl:text>		{</xsl:text>
+        <xsl:value-of select="$guid" />
+        <xsl:text>}.Release|iPhoneSimulator.Build.0 = </xsl:text>
+        <xsl:choose>
+          <xsl:when test="$release-mapping != ''">
+            <xsl:value-of select="$release-mapping" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>Release|iPhoneSimulator</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:text>
+</xsl:text>
+      </xsl:when>
+      <xsl:when test="/Input/Generation/Platform = 'tvOS'">
         <xsl:text>		{</xsl:text>
         <xsl:value-of select="$guid" />
         <xsl:text>}.Ad-Hoc|iPhone.ActiveCfg = </xsl:text>

--- a/Build/Module.xml
+++ b/Build/Module.xml
@@ -2,10 +2,10 @@
 <Module>
   <Name>MonoGame.Framework</Name>
   <DefaultAction>Generate</DefaultAction>
-  <DefaultLinuxPlatforms>Angle,Linux,WindowsGL,Web</DefaultLinuxPlatforms>
-  <DefaultMacOSPlatforms>Angle,MacOS,iOS,WindowsGL,Android</DefaultMacOSPlatforms>
-  <DefaultWindowsPlatforms>Android,Angle,Linux,Ouya,Windows8,Windows,WindowsGL,WindowsPhone,WindowsPhone81,WindowsUAP,iOS</DefaultWindowsPlatforms>
-  <SupportedPlatforms>Android,Angle,Linux,Ouya,Windows8,Windows,WindowsGL,WindowsPhone,WindowsPhone81,WindowsUAP,iOS,MacOS,Web</SupportedPlatforms>
+  <DefaultLinuxPlatforms>Angle,Linux,WindowsGL</DefaultLinuxPlatforms>
+  <DefaultMacOSPlatforms>Angle,MacOS,iOS,WindowsGL,Android,tvOS</DefaultMacOSPlatforms>
+  <DefaultWindowsPlatforms>Android,Angle,Linux,Ouya,Windows8,Windows,WindowsGL,WindowsPhone,WindowsPhone81,WindowsUAP,iOS,tvOS</DefaultWindowsPlatforms>
+  <SupportedPlatforms>Android,Angle,Linux,Ouya,Windows8,Windows,WindowsGL,WindowsPhone,WindowsPhone81,WindowsUAP,iOS,MacOS,Web,tvOS</SupportedPlatforms>
   <DisableSynchronisation>true</DisableSynchronisation>
   <GenerateNuGetRepositories>true</GenerateNuGetRepositories>
   <Packages>

--- a/Build/Projects/FrameworkReferences.Net.definition
+++ b/Build/Projects/FrameworkReferences.Net.definition
@@ -7,6 +7,12 @@
     <Reference Include="Lidgren.Network" />
   </Platform>
 
+  <Platform Type="tvOS">
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.TVOS" />
+    <Reference Include="Lidgren.Network" />
+  </Platform>
+
   <Platform Type="Linux">
     <Reference Include="Lidgren.Network" />
   </Platform>

--- a/Build/Projects/FrameworkReferences.definition
+++ b/Build/Projects/FrameworkReferences.definition
@@ -6,7 +6,11 @@
     <Reference Include="Xamarin.iOS" />
     <Reference Include="OpenTK-1.0" />
   </Platform>
-
+  <Platform Type="tvOS">
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.TVOS" />
+    <Reference Include="OpenTK-1.0" />
+  </Platform>
   <Platform Type="Linux">
     <Service Name="MonoGame.Framework/OpenGLGraphics">
       <Reference Include="System.Drawing" />

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Name="MonoGame.Framework" Path="MonoGame.Framework" Type="Library" Platforms="Android,Angle,iOS,Linux,MacOS,Ouya,Windows,Windows8,WindowsGL,WindowsPhone,WindowsPhone81,WindowsUAP,Web">
-
+<Project Name="MonoGame.Framework" Path="MonoGame.Framework" Type="Library" Platforms="Android,Angle,iOS,Linux,MacOS,Ouya,Windows,Windows8,WindowsGL,WindowsPhone,WindowsPhone81,WindowsUAP,Web,tvOS">
   <!--
     Using Protobuild in your own project?  ProjectGuids are only in use here
     for backwards compatibility with existing users of MonoGame, and are not
@@ -44,6 +43,7 @@
     <CustomDefinitions>
       <Platform Name="Android">TRACE;ANDROID;GLES;OPENGL;OPENAL</Platform>
       <Platform Name="iOS">IOS;GLES;OPENGL;OPENAL</Platform>
+      <Platform Name="tvOS">IOS;TVOS;GLES;OPENGL;OPENAL</Platform>
       <Platform Name="Linux">TRACE;LINUX;OPENGL;OPENAL;DESKTOPGL</Platform>
       <Platform Name="MacOS">MONOMAC;OPENGL;OPENAL</Platform>
       <Platform Name="Ouya">TRACE;ANDROID;GLES;OPENGL;OUYA;OPENAL</Platform>
@@ -63,7 +63,7 @@
       <Platforms>Angle</Platforms>
     </Uses>
     <Uses Name="OpenGLGraphics">
-      <Platforms>iOS,WindowsGL,Ouya,Android</Platforms>
+      <Platforms>iOS,WindowsGL,Ouya,Android,tvOS</Platforms>
     </Uses>
     <Uses Name="DirectXGraphics">
       <Platforms>Windows8,WindowsPhone,WindowsPhone81,WindowsUAP</Platforms>
@@ -98,7 +98,7 @@
     <Service Name="OpenGLGraphics">
       <RemoveDefine>DIRECTX;WINDOWS_MEDIA_SESSION</RemoveDefine>
       <AddDefine>OPENGL;OPENAL</AddDefine>
-      <Platforms>iOS,MacOS,Linux,Windows,WindowsGL,Ouya,Android</Platforms>
+      <Platforms>iOS,MacOS,Linux,Windows,WindowsGL,Ouya,Android,tvOS</Platforms>
       <Conflicts>ANGLEGraphics,DirectXGraphics,WebGraphics</Conflicts>
       <Requires>OpenALAudio,_GLCompatible</Requires>
     </Service>
@@ -115,7 +115,7 @@
 
     <!-- Audio APIs -->
     <Service Name="OpenALAudio">
-      <Platforms>Angle,iOS,Linux,Windows,WindowsGL,MacOS,Android,Ouya</Platforms>
+      <Platforms>Angle,iOS,Linux,Windows,WindowsGL,MacOS,Android,Ouya,tvOS</Platforms>
       <Conflicts>XAudioAudio,WebAudio</Conflicts>
     </Service>
     <Service Name="XAudioAudio">
@@ -236,13 +236,15 @@
       <Platforms>Angle,Linux,MacOS,Windows,WindowsGL,WindowsUAP</Platforms>
     </Compile>
     <Compile Include="Threading.cs">
-      <Platforms>Android,Angle,iOS,Linux,MacOS,Ouya,WindowsGL,WindowsPhone</Platforms>
+      <Platforms>Android,Angle,iOS,Linux,MacOS,Ouya,WindowsGL,WindowsPhone,tvOS</Platforms>
     </Compile>
     <Compile Include="TitleContainer.cs" />
     <Compile Include="Vector2.cs" />
     <Compile Include="Vector3.cs" />
     <Compile Include="Vector4.cs" />
-
+    <Compile Include="IPlatformBackButton.cs">
+      <Platforms>tvOS</Platforms>
+    </Compile>
 
     <!-- Microsoft.Xna.Framework.Audio -->
     <Compile Include="Audio\AudioChannels.cs" />
@@ -253,7 +255,7 @@
     </Compile>
     <Compile Include="Audio\InstancePlayLimitException.cs" />
     <Compile Include="Audio\MSADPCMToPCM.cs">
-      <Platforms>Android,Angle,iOS,Linux,MacOS,Ouya,WindowsGL,Web</Platforms>
+      <Platforms>Android,Angle,iOS,Linux,MacOS,Ouya,WindowsGL,Web,tvOS</Platforms>
     </Compile>
     <Compile Include="Audio\NoAudioHardwareException.cs" />
     <Compile Include="Audio\OALSoundBuffer.cs">
@@ -263,7 +265,7 @@
       <Services>OpenALAudio</Services>
     </Compile>
     <Compile Include="Audio\OpenALSupport.cs">
-      <Platforms>iOS,MacOS</Platforms>
+      <Platforms>iOS,MacOS,tvOS</Platforms>
     </Compile>
     <Compile Include="Audio\SoundEffect.cs" />
     <Compile Include="Audio\SoundEffect.OpenAL.cs">
@@ -362,10 +364,10 @@
       <Platforms>Angle,Linux,MacOS,Windows8,Windows,WindowsGL,WindowsPhone,WindowsPhone81,WindowsUAP</Platforms>
     </Compile>
     <Compile Include="Content\ContentReaders\TextureCubeReader.cs">
-      <Platforms>Android,Angle,iOS,Linux,MacOS,Ouya,Windows8,Windows,WindowsGL,WindowsPhone,WindowsPhone81,WindowsUAP</Platforms>
+      <Platforms>Android,Angle,iOS,Linux,MacOS,Ouya,Windows8,Windows,WindowsGL,WindowsPhone,WindowsPhone81,WindowsUAP,tvOS</Platforms>
     </Compile>
     <Compile Include="Content\ContentReaders\TextureReader.cs">
-      <Platforms>Android,Angle,iOS,Linux,MacOS,Ouya,Windows8,Windows,WindowsGL,WindowsPhone,WindowsPhone81,WindowsUAP</Platforms>
+      <Platforms>Android,Angle,iOS,Linux,MacOS,Ouya,Windows8,Windows,WindowsGL,WindowsPhone,WindowsPhone81,WindowsUAP,tvOS</Platforms>
     </Compile>
     <Compile Include="Content\ContentReaders\TimeSpanReader.cs" />
     <Compile Include="Content\ContentReaders\UInt16Reader.cs" />
@@ -377,7 +379,7 @@
     <Compile Include="Content\ContentReaders\VertexBufferReader.cs" />
     <Compile Include="Content\ContentReaders\VertexDeclarationReader.cs"/>
     <Compile Include="Content\ContentReaders\VideoReader.cs">
-      <ExcludePlatforms>Angle,Linux,WindowsGL,WindowsPhone,Web</ExcludePlatforms>
+      <ExcludePlatforms>Angle,Linux,WindowsGL,WindowsPhone,Web,tvOS</ExcludePlatforms>
     </Compile>
     <Compile Include="Content\ContentSerializerAttribute.cs" />
     <Compile Include="Content\ContentSerializerCollectionItemNameAttribute.cs" />
@@ -388,7 +390,7 @@
     <Compile Include="Content\ContentTypeReaderManager.cs" />
     <Compile Include="Content\LzxDecoder.cs" />
     <Compile Include="Content\ResourceContentManager.cs">
-      <Platforms>Angle,Android,iOS,Linux,Ouya,Windows,WindowsGL</Platforms>
+      <Platforms>Angle,Android,iOS,Linux,Ouya,Windows,WindowsGL,tvOS</Platforms>
     </Compile>
 
 
@@ -554,7 +556,7 @@
       <Services>WebGraphics</Services>
     </Compile>
     <Compile Include="Graphics\Shader\ShaderProgramCache.cs">
-      <Platforms>Android,Angle,iOS,Linux,MacOS,Ouya,WindowsGL</Platforms>
+      <Platforms>Android,Angle,iOS,Linux,MacOS,Ouya,WindowsGL,tvOS</Platforms>
     </Compile>
     <Compile Include="Graphics\Shader\ShaderStage.cs" />
     <Compile Include="Graphics\SpriteBatch.cs" />
@@ -741,6 +743,9 @@
     <Compile Include="Input\GamePad.IOS.cs">
       <Platforms>iOS</Platforms>
     </Compile>
+    <Compile Include="Input\GamePad.tvOS.cs">
+      <Platforms>tvOS</Platforms>
+    </Compile>
     <Compile Include="Input\GamePad.Ouya.cs">
       <Platforms>Ouya</Platforms>
     </Compile>
@@ -769,7 +774,7 @@
     <Compile Include="Input\JoystickHat.cs" />
     <Compile Include="Input\JoystickState.cs" />
     <Compile Include="Input\Joystick.Default.cs">
-      <Platforms>Android,Ouya,Windows8,Windows,WindowsPhone,WindowsPhone81,WindowsUAP,iOS</Platforms>
+      <Platforms>Android,Ouya,Windows8,Windows,WindowsPhone,WindowsPhone81,WindowsUAP,iOS,tvOS</Platforms>
     </Compile>
     <Compile Include="Input\Joystick.OpenTK.cs">
       <Platforms>Angle,Linux,MacOS,WindowsGL</Platforms>
@@ -868,7 +873,7 @@
       <Platforms>WindowsPhone</Platforms>
     </Compile>
     <Compile Include="Media\MediaPlayer.Default.cs">
-      <Platforms>Angle,WindowsGL,Linux,MacOS,iOS,Android,Ouya,Web</Platforms>
+      <Platforms>Angle,WindowsGL,Linux,MacOS,iOS,Android,Ouya,Web,tvOS</Platforms>
     </Compile>
     <Compile Include="Media\MediaQueue.cs" />
     <Compile Include="Media\MediaSource.cs" />
@@ -888,7 +893,7 @@
         <Platforms>Android,Ouya</Platforms>
     </Compile>
     <Compile Include="Media\Song.IOS.cs">
-        <Platforms>iOS</Platforms>
+        <Platforms>iOS,tvOS</Platforms>
     </Compile>
     <Compile Include="Media\Song.NVorbis.cs">
         <Platforms>WindowsGL,Linux</Platforms>
@@ -904,7 +909,7 @@
     </Compile>
     <Compile Include="Media\VideoSoundtrackType.cs" />
     <Compile Include="Media\Video.cs">
-      <ExcludePlatforms>Angle,Linux,WindowsGL,WindowsPhone,Web</ExcludePlatforms>
+      <ExcludePlatforms>Angle,Linux,WindowsGL,WindowsPhone,Web,tvOS</ExcludePlatforms>
     </Compile>
     <Compile Include="Media\Video.IOS.cs">
         <Platforms>iOS</Platforms>
@@ -919,7 +924,7 @@
         <Platforms>Windows</Platforms>
     </Compile>
     <Compile Include="Media\VideoPlayer.cs">
-      <ExcludePlatforms>Angle,Linux,WindowsGL,WindowsPhone,Web</ExcludePlatforms>
+      <ExcludePlatforms>Angle,Linux,WindowsGL,WindowsPhone,Web,tvOS</ExcludePlatforms>
     </Compile>
     <Compile Include="Media\VideoPlayer.IOS.cs">
         <Platforms>iOS</Platforms>
@@ -971,7 +976,7 @@
     <Compile Include="Storage\StorageContainer.cs" />
     <Compile Include="Storage\StorageDevice.cs" />
     <Compile Include="Storage\StorageDeviceHelper.cs">
-      <Platforms>Android,Angle,iOS,Ouya,Windows8,Windows,WindowsGL,WindowsPhone,Web,WindowsPhone81,WindowsUAP,Linux</Platforms>
+      <Platforms>Android,Angle,iOS,Ouya,Windows8,Windows,WindowsGL,WindowsPhone,Web,WindowsPhone81,WindowsUAP,Linux,tvOS</Platforms>
     </Compile>
 
 
@@ -1081,6 +1086,25 @@
       <Platforms>iOS</Platforms>
     </Compile>
 
+    <!-- tvOS Platform -->
+    <Compile Include="iOS\iOSGamePlatform.cs">
+      <Platforms>tvOS</Platforms>
+    </Compile>
+    <Compile Include="iOS\iOSGameViewController.cs">
+      <Platforms>tvOS</Platforms>
+    </Compile>
+    <Compile Include="iOS\iOSGameView.cs">
+      <Platforms>tvOS</Platforms>
+    </Compile>
+    <Compile Include="iOS\iOSGameView_GLAbstraction.cs">
+      <Platforms>tvOS</Platforms>
+    </Compile>
+    <Compile Include="iOS\iOSGameView_Touch.cs">
+      <Platforms>tvOS</Platforms>
+    </Compile>
+    <Compile Include="iOS\iOSGameWindow.cs">
+      <Platforms>tvOS</Platforms>
+    </Compile>
 
     <!-- MacOS Platform -->
     <Compile Include="MacOS\GameWindow.cs">

--- a/Documentation/config.xml
+++ b/Documentation/config.xml
@@ -44,6 +44,7 @@
     
     <topic id="Platform_Specific_Notes" name="Platform-Specific Notes" filename="platform_specific.md">
         <topic id="Android" name="Android" filename="android.md"/>
+        <topic id="tvOS" name="Android" filename="tvOS.md"/>
     </topic>
     
     <topic id="External_Links" name="External Links" filename="links.md"/>

--- a/Documentation/platform_specific.md
+++ b/Documentation/platform_specific.md
@@ -1,3 +1,4 @@
 While MonoGame aims to provide a platform-agnostic framework for developing games and apps, there are still some specific for each platform that need the developer needs to be aware of.  This section lists those specifics broken down by platform.
 
   - [Android](android.md)
+  - [tvOS](tvOS.md)

--- a/Documentation/tvOS.md
+++ b/Documentation/tvOS.md
@@ -1,0 +1,53 @@
+#
+
+## Menu Button Handling
+
+The Menu button will map to the "Back" button on the GamePad. However on tvOS,
+the Menu button requires some special processing. According to the Apple 
+documentation the Menu Button
+
+"*Pauses/resumes gameplay.
+Returns to previous screen, exits to main game menu, and/or exits to Apple TV Home screen.*"
+
+By default MonoGame will exit to the Apple TV Home screen when the Menu button is pressed, 
+this is not alawys the desired behviour. When in gameplay the Menu button really should
+Pause the game rather than Exiting to the Home screen.
+
+Because MonoGame has no idea of the game state, it is down to the developer to inform
+it when it can exit to the Home screen and when it should ignore the Menu event and allow
+the developer to the event.
+
+Some sample code.
+
+```csharp
+
+	public class Game1 : Game , IPlaformBackButton {
+
+		bool IsOnRootMenu = true;
+
+		public bool Handled () {
+			return IsOnRootMenu ? false : true;
+		}
+
+		public Game1 ()
+		{
+			Services.AddService<IPlaformBackButton>(this);
+		}
+
+		public override Update(GameTime gametime)
+		{
+			if (GamePad.GetState (PlayerIndex.One).Buttons.Back == ButtonState.Pressed)
+			{
+				// do something in game
+			}
+		}
+	}
+```
+
+The key to this working is the `IPlatformBackButton` interface. By implementing
+and registering this interface MonoGame can callback into your application to ask if it
+should let you handle the Menu button or if it should pass it up to tvOS. So in this case if
+the app is on the "Main menu" the developer will set *IsOnRootMenu* to true and when the Menu
+button is pressed the game with Exit. However if IsOnRootMenu is false then the "Menu" button 
+click will be routed to the GamePad Back button and the developer can check for the Back button
+press and act accordingly.

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Android/MonoDevelop.MonoGame.Android.csproj
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Android/MonoDevelop.MonoGame.Android.csproj
@@ -55,6 +55,10 @@
       <HintPath>/Applications/Xamarin Studio.app/Contents/Resources/lib/monodevelop/AddIns/Xamarin.Ide/Xamarin.Ide.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Xamarin.Ide.Insights">
+      <HintPath>/Applications/Xamarin Studio.app/Contents/Resources/lib/monodevelop//AddIns/Xamarin.Ide.Insights/Xamarin.Ide.Insights.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Android/templates/MonoGameAndroidProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Android/templates/MonoGameAndroidProject.xpt.xml
@@ -2,7 +2,7 @@
 <Template>
 	<TemplateConfiguration>
 		<_Name>MonoGame for Android Application</_Name>
-		<_Category>C#/MonoGame</_Category>
+		<Category>monogame/app/games</Category>
 		<Icon>monogame-project</Icon>
 		<LanguageName>C#</LanguageName>
 		<_Description>Creates an MonoGame for Android Project </_Description>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Android/templates/MonoGameOUYAProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Android/templates/MonoGameOUYAProject.xpt.xml
@@ -2,7 +2,7 @@
 <Template>
 	<TemplateConfiguration>
 		<_Name>MonoGame for OUYA Application</_Name>
-		<_Category>C#/MonoGame</_Category>
+		<Category>monogame/app/games</Category>
 		<Icon>monogame-project</Icon>
 		<LanguageName>C#</LanguageName>
 		<_Description>Creates an MonoGame for OUYA Project </_Description>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/MonoGameMacProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/MonoGameMacProject.xpt.xml
@@ -2,7 +2,7 @@
 <Template>
 	<TemplateConfiguration>
 		<_Name>MonoGame Mac Application (MonoMac)</_Name>
-		<_Category>C#/MonoGame</_Category>
+		<Category>monogame/app/games</Category>
 		<Icon>monogame-project</Icon>
 		<LanguageName>C#</LanguageName>
 		<_Description>Creates a MonoGame Application for Mac OS. This application uses MonoMac as a result you will need to have mono installed on your users machine.</_Description>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/MonoGameOSXProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/MonoGameOSXProject.xpt.xml
@@ -2,7 +2,7 @@
 <Template>
 	<TemplateConfiguration>
 		<_Name>MonoGame Mac Application (Xamarin.Mac)</_Name>
-		<_Category>C#/MonoGame</_Category>
+		<Category>monogame/app/games</Category>
 		<Icon>monogame-project</Icon>
 		<LanguageName>C#</LanguageName>
 		<_Description>Creates a MonoGame Application for Mac OS. This application uses Xamarin.Mac and is suitable for the Apple Store.</_Description>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/MonoDevelop.MonoGame.iOS.csproj
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/MonoDevelop.MonoGame.iOS.csproj
@@ -72,5 +72,14 @@
     <Content Include="templates\MonoGameMobileOnly-PCL.xpt.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="templates\MonoGametvOSProject.xpt.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="templates\iOS\Entitlements.plist.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="templates\iOS\Info_tvOS.plist.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/MonoGameMobileOnly-PCL.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/MonoGameMobileOnly-PCL.xpt.xml
@@ -2,7 +2,7 @@
 <Template>
 	<TemplateConfiguration>
 		<_Name>Universal MonoGame Mobile Application (Shared Project) </_Name>
-		<_Category>C#/MonoGame</_Category>
+		<Category>monogame/app/games</Category>
 		<Icon>monogame-project</Icon>
 		<LanguageName>C#</LanguageName>
 		<_Description>Creates a MonoGame Application for the iPhone/iPad and Android which uses a Shared Project to shared common code.</_Description>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/MonoGameMobileOnly-SAP.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/MonoGameMobileOnly-SAP.xpt.xml
@@ -2,7 +2,7 @@
 <Template>
 	<TemplateConfiguration>
 		<_Name>Universal MonoGame Mobile Application (Shared Project) </_Name>
-		<_Category>C#/MonoGame</_Category>
+		<Category>monogame/app/games</Category>
 		<Icon>monogame-project</Icon>
 		<LanguageName>C#</LanguageName>
 		<_Description>Creates a MonoGame Application for the iPhone/iPad and Android which uses a Shared Project to shared common code.</_Description>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/MonoGametvOSProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/MonoGametvOSProject.xpt.xml
@@ -1,38 +1,36 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0"?>
 <Template>
 	<TemplateConfiguration>
-		<_Name>MonoGame iPhone/iPad Application</_Name>
+		<_Name>MonoGame tvOS Application</_Name>
 		<Category>monogame/app/games</Category>
 		<Icon>monogame-project</Icon>
 		<LanguageName>C#</LanguageName>
-		<_Description>Creates a MonoGame Application for the iPhone/iPad</_Description>
+		<Wizard>MonoDevelop.IPhone.TVOSProjectTemplateWizard</Wizard>
+		<DefaultParameters>MinimumOSVersion=9.0</DefaultParameters>
+		<_Description>Creates a MonoGame Application for tvOS</_Description>
 	</TemplateConfiguration>
-	
 	<Actions>
-		<Open filename = "Game1.cs"/>
+		<Open filename="Game1.cs" />
 	</Actions>
-	
-	<Combine name = "${ProjectName}" directory = ".">
+	<Combine name="${ProjectName}" directory=".">
 		<Options>
 			<StartupProject>${ProjectName}</StartupProject>
 		</Options>
-		
-		<Project name = "${ProjectName}" directory = "." type = "XamarinIOS">
-			<Options />
+		<Project name="${ProjectName}" directory="." type="TVOS">
 			<References>
 				<Reference type="Gac" refto="System, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e" />
 				<Reference type="Gac" refto="System.Xml, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e" />
-				<Reference type="Gac" refto="System.Core, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e" />	
-				<Reference type="Gac" refto="Xamarin.iOS" />
+				<Reference type="Gac" refto="System.Core, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e" />
+				<Reference type="Gac" refto="Xamarin.TVOS" />
 			</References>
 			<Packages>
-				<Package id="MonoGame.Framework.iOS" version="3.3.0" targetFramework="XamariniOS" />
+				<Package id="MonoGame.Framework.iOS" version="3.3.0" targetFramework="Xamarin.TVOS10" />
 			</Packages>
 			<Files>
+				<File name="Info.plist" AddStandardHeader="False" src="iOS/Info_tvOS.plist.xml" />
+				<File name="Entitlements.plist" AddStandardHeader="False" src="iOS/Entitlements.plist.xml" />
 				<File name="Game1.cs" AddStandardHeader="True" src="Common/Game1.cs" />
 				<File name="Main.cs" AddStandardHeader="True" src="Common/Program.cs" />
-				<File name="Entitlements.plist" AddStandardHeader="False" src="iOS/Entitlements.plist.xml" />
-				<File name="Info.plist" AddStandardHeader="False" src="iOS/iOSInfo.plist" />
 				<RawFile name="Default.png" src="iOS/iOSDefault.png" />
 				<RawFile name="GameThumbnail.png" src="iOS/iOSGameThumbnail.png" />
 				<Directory name="Content">
@@ -43,6 +41,6 @@
 				</Directory>
 			</Files>
 		</Project>
+
 	</Combine>
 </Template>
-

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/Shared/Program.cs
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/Shared/Program.cs
@@ -5,7 +5,7 @@ using System.Linq;
 #if MONOMAC
 using MonoMac.AppKit;
 using MonoMac.Foundation;
-#elif __IOS__
+#elif __IOS__ || __TVOS__
 using Foundation;
 using UIKit;
 #endif
@@ -14,7 +14,7 @@ using UIKit;
 
 namespace ${Namespace}
 {
-	#if __IOS__
+	#if __IOS__ || __TVOS__
 	[Register("AppDelegate")]
 	class Program : UIApplicationDelegate
 	#else
@@ -32,7 +32,7 @@ namespace ${Namespace}
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
-		#if !MONOMAC && !__IOS__		 
+		#if !MONOMAC && !__IOS__ &&  !__TVOS__		 
         [STAThread]
 		#endif
 		static void Main(string[] args)
@@ -44,14 +44,14 @@ namespace ${Namespace}
 				NSApplication.SharedApplication.Delegate = new AppDelegate();
 				NSApplication.Main(args);
 			}
-			#elif __IOS__
+			#elif __IOS__ || __TVOS__
 			UIApplication.Main(args, null, "AppDelegate");
 			#else
 			RunGame();
 			#endif
         }
 
-		#if __IOS__
+		#if __IOS__ || __TVOS__
 		public override void FinishedLaunching(UIApplication app)
 		{
 			RunGame();

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/iOS/Entitlements.plist.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/iOS/Entitlements.plist.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/iOS/Info_tvOS.plist.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/iOS/Info_tvOS.plist.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>${AppName}</string>
+	<key>CFBundleName</key>
+	<string>${AppName}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${AppIdentifier}</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>MinimumOSVersion</key>
+	<string>${MinimumOSVersion}</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>3</integer>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>XSAppIconAssets</key>
+	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
+</dict>
+</plist>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame.addin.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame.addin.xml
@@ -43,6 +43,9 @@
     <Import file="templates/iOS/iOSDefault.png" />
     <Import file="templates/iOS/iOSGameThumbnail.png" />
     <Import file="templates/iOS/iOSInfo.plist" />
+    <Import file="templates/MonoGametvOSProject.xpt.xml" />
+    <Import file="templates/iOS/Entitlements.plist.xml" />
+    <Import file="templates/iOS/Info_tvOS.plist.xml" />
     <!-- Shared Templates -->
     <Import file="templates/MonoGameMobileOnly-SAP.xpt.xml" />
     <Import file="templates/Shared/Program.cs" />
@@ -86,6 +89,17 @@
     <DotNetProjectSubtype id="MonoGame" guid="{9b831fef-f496-498f-9fe8-180da5cb4258}" type="MonoDevelop.MonoGame.MonoGameProject">
       <!-- Add MonoGame Specific Imports  -->
     </DotNetProjectSubtype>
+  </Extension>
+  <Extension path="/MonoDevelop/Ide/ProjectTemplateCategories">
+    <Category id="monogame" name="MonoGame" icon="monogame-project" insertbefore="other">
+      <Category id="app" name="App">
+        <Category id="games" name="Games" mappedCategories="C#/MonoGame;monogame/app/games" />
+      </Category>
+      <Category id="library" name="Library">
+        <Category id="crossplat" name="Cross Platform" />
+        <Category id="pipeline" name="Content Pipeline" />
+      </Category>
+    </Category>
   </Extension>
   <Extension path="/MonoDevelop/Ide/FileTemplateTypes">
     <FileTemplateType name="ContentFile" class="MonoDevelop.MonoGame.ContentItemTemplate" />
@@ -158,6 +172,7 @@
     </Dependencies>
     <Extension path="/MonoDevelop/Ide/ProjectTemplates">
       <ProjectTemplate id="MonoGameForIPhoneProject" file="templates/MonoGameiOSProject.xpt.xml" />
+      <ProjectTemplate id="MonoGameFortvOSProject" file="templates/MonoGametvOSProject.xpt.xml" />
     </Extension>
   </Module>
   <Module>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame.csproj
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame.csproj
@@ -55,7 +55,10 @@
     <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="System.Xml" />
-    <Reference Include="Mono.Addins, Version=1.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756" />
+    <Reference Include="Mono.Addins">
+      <HintPath>/Applications/Xamarin Studio.app/Contents/Resources/lib/monodevelop/bin/Mono.Addins.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/Common/Game1.cs
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/Common/Game1.cs
@@ -59,7 +59,7 @@ namespace ${Namespace}
         {
             // For Mobile devices, this logic will close the Game when the Back button is pressed
 			// Exit() is obsolete on iOS
-			#if !__IOS__
+			#if !__IOS__ &&  !__TVOS__
 			if (GamePad.GetState (PlayerIndex.One).Buttons.Back == ButtonState.Pressed ||
 				Keyboard.GetState().IsKeyDown(Keys.Escape)) {
 				Exit ();

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/Common/Program.cs
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/Common/Program.cs
@@ -5,15 +5,15 @@ using System.Linq;
 #if MONOMAC
 using MonoMac.AppKit;
 using MonoMac.Foundation;
-#elif __IOS__
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
+#elif __IOS__ || __TVOS__
+using Foundation;
+using UIKit;
 #endif
 #endregion
 
 namespace ${Namespace}
 {
-	#if __IOS__
+	#if __IOS__ || __TVOS__
 	[Register("AppDelegate")]
 	class Program : UIApplicationDelegate
 	#else
@@ -31,7 +31,7 @@ namespace ${Namespace}
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
-		#if !MONOMAC && !__IOS__		 
+		#if !MONOMAC && !__IOS__  && !__TVOS__		 
         [STAThread]
 		#endif
 		static void Main(string[] args)
@@ -43,14 +43,14 @@ namespace ${Namespace}
 				NSApplication.SharedApplication.Delegate = new AppDelegate();
 				NSApplication.Main(args);
 			}
-			#elif __IOS__
+			#elif __IOS__ || __TVOS__
 			UIApplication.Main(args, null, "AppDelegate");
 			#else
 			RunGame();
 			#endif
         }
 
-		#if __IOS__
+		#if __IOS__ || __TVOS__
 		public override void FinishedLaunching(UIApplication app)
 		{
 			RunGame();

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGamePCLProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGamePCLProject.xpt.xml
@@ -2,7 +2,7 @@
 <Template>
 	<TemplateConfiguration>
 		<_Name>MonoGame Portable Library</_Name>
-		<_Category>C#/MonoGame</_Category>
+		<Category>monogame/library/crossplat</Category>
 		<Icon>monogame-project</Icon>
 		<LanguageName>C#</LanguageName>
 		<_Description>Creates a MonoGame Portable Library (PCL). This can be used to share most of your games code.</_Description>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGamePipelineProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGamePipelineProject.xpt.xml
@@ -2,7 +2,7 @@
 <Template>
 	<TemplateConfiguration>
 		<_Name>MonoGame Pipeline Library</_Name>
-		<_Category>C#/MonoGame</_Category>
+		<Category>monogame/library/pipeline</Category>
 		<Icon>monogame-project</Icon>
 		<LanguageName>C#</LanguageName>
 		<_Description>Creates a MonoGame Pipeline Extenson so you can extend the Content Pipeline.</_Description>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameProject.xpt.xml
@@ -2,7 +2,7 @@
 <Template>
 	<TemplateConfiguration>
 		<_Name>MonoGame Application (OpenGL)</_Name>
-		<_Category>C#/MonoGame</_Category>
+		<Category>monogame/app/games</Category>
 		<Icon>monogame-project</Icon>
 		<LanguageName>C#</LanguageName>
 		<_Description>Creates a new C# MonoGame Application. This applicaiton will use an OpenGL backend.</_Description>	   

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameSharedProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameSharedProject.xpt.xml
@@ -2,7 +2,7 @@
 <Template>
 	<TemplateConfiguration>
 		<_Name>MonoGame Shared Project</_Name>
-		<_Category>C#/MonoGame</_Category>
+		<Category>monogame/library/crossplat</Category>
 		<Icon>monogame-project</Icon>
 		<LanguageName>C#</LanguageName>
 		<_Description>Creates a MonoGame Shared Project to shared common code. This can be used to share most of your shared code, but you can also include platform specific code using #defines.

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameWindowsProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameWindowsProject.xpt.xml
@@ -2,7 +2,7 @@
 <Template>
 	<TemplateConfiguration>
 		<_Name>MonoGame Application (DirectX)</_Name>
-		<_Category>C#/MonoGame</_Category>
+		<Category>monogame/app/games</Category>
 		<Icon>monogame-project</Icon>
 		<LanguageName>C#</LanguageName>
 		<_Description>Creates a new C# MonoGame Windows Application. This application will use the DirectX backend.</_Description>	   

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -532,7 +532,7 @@ namespace Microsoft.Xna.Framework.Audio
         }
 #endif
 
-#if MONOMAC || IOS
+#if MONOMAC
 		public const string OpenALLibrary = "/System/Library/Frameworks/OpenAL.framework/OpenAL";
 
 		[DllImport(OpenALLibrary, EntryPoint = "alcMacOSXMixerOutputRate")]

--- a/MonoGame.Framework/Content/ContentTypeReaderManager.cs
+++ b/MonoGame.Framework/Content/ContentTypeReaderManager.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Xna.Framework.Content
 
                 // At the moment the Video class doesn't exist
                 // on all platforms... Allow it to compile anyway.
-#if ANDROID || IOS || MONOMAC || (WINDOWS && !OPENGL) || (WINRT && !WINDOWS_PHONE)
+#if ANDROID || (IOS && !TVOS) || MONOMAC || (WINDOWS && !OPENGL) || (WINRT && !WINDOWS_PHONE)
                 var hVideoReader = new VideoReader();
 #endif
             }

--- a/MonoGame.Framework/Graphics/PresentationParameters.cs
+++ b/MonoGame.Framework/Graphics/PresentationParameters.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 // If we are not on windows 8 set the value otherwise ignore it.
                 isFullScreen = value;				
 #endif
-#if IOS
+#if IOS && !TVOS
 				UIApplication.SharedApplication.StatusBarHidden = isFullScreen;
 #endif
 
@@ -169,7 +169,7 @@ namespace Microsoft.Xna.Framework.Graphics
             backBufferHeight = GraphicsDeviceManager.DefaultBackBufferHeight;     
 #endif
             deviceWindowHandle = IntPtr.Zero;
-#if IOS
+#if IOS && !TVOS
 			isFullScreen = UIApplication.SharedApplication.StatusBarHidden;
 #else
             // isFullScreen = false;

--- a/MonoGame.Framework/IPlatformBackButton.cs
+++ b/MonoGame.Framework/IPlatformBackButton.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Microsoft.Xna.Framework
+{
+    /// <summary>
+    /// Allows for platform specific handling of the Back button. 
+    /// </summary>
+    /// <seealso cref="http://www.monogame.net/documentation/?page=Platform_Specific_Notes"/>
+    public interface IPlatformBackButton
+    {
+        /// <summary>
+        /// Return true if your game has handled the back button event
+        /// retrn false if you want the operating system to handle it.
+        /// </summary>
+        bool Handled();
+    }
+}

--- a/MonoGame.Framework/Input/GamePad.IOS.cs
+++ b/MonoGame.Framework/Input/GamePad.IOS.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Xna.Framework.Input
                
         private static GamePadState PlatformGetState(int index, GamePadDeadZone deadZoneMode)
         {
-            return new GamePadState();
+            return new GamePadState() { IsConnected = false };
         }
 
         private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor)

--- a/MonoGame.Framework/Input/GamePad.tvOS.cs
+++ b/MonoGame.Framework/Input/GamePad.tvOS.cs
@@ -1,0 +1,205 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+using GameController;
+using System.Collections.Generic;
+using System.Linq;
+using UIKit;
+using System;
+
+namespace Microsoft.Xna.Framework.Input
+{
+    static partial class GamePad
+    {
+        internal static bool MenuPressed = false;
+
+        private static int PlatformGetMaxIndex()
+        {
+            return 4;
+        }
+
+        static bool IndexIsUsed (GCControllerPlayerIndex index)
+        {
+            foreach (var ctrl in GCController.Controllers)
+                if (ctrl.PlayerIndex==index) return true;
+
+            return false;
+        }
+
+        static void AssingIndex(GCControllerPlayerIndex index) {
+            if (IndexIsUsed(index))
+                return;
+            foreach (var controller in GCController.Controllers)
+            {
+                if (controller.PlayerIndex == index)
+                    break;
+                if (controller.PlayerIndex == GCControllerPlayerIndex.Unset)
+                {
+                    controller.PlayerIndex = index;
+                    break;
+                }
+            }
+        }
+
+        private static GamePadCapabilities PlatformGetCapabilities(int index)
+        {
+            var ind = (GCControllerPlayerIndex)index;
+
+            AssingIndex(ind);
+
+            foreach (var controller in GCController.Controllers)
+            {
+                if (controller == null)
+                    continue;
+                if (controller.PlayerIndex == ind)
+                    return GetCapabilities(controller);
+            }
+            return new GamePadCapabilities { IsConnected = false };
+        }
+               
+        private static GamePadState PlatformGetState(int index, GamePadDeadZone deadZoneMode)
+        {
+            var ind = (GCControllerPlayerIndex)index;
+
+
+            var buttons = new List<Buttons>();
+            bool connected = false;
+            ButtonState Up = ButtonState.Released;
+            ButtonState Down = ButtonState.Released;
+            ButtonState Left = ButtonState.Released;
+            ButtonState Right = ButtonState.Released;
+
+            AssingIndex(ind);
+
+            foreach  (var controller in GCController.Controllers) {
+
+                if (controller == null)
+                    continue;
+
+                if (controller.PlayerIndex != ind)
+                    continue;
+
+                connected = true;
+                if (MenuPressed)
+                {
+                    buttons.Add(Buttons.Back);
+                    MenuPressed = false;
+                }
+
+                if (controller.ExtendedGamepad != null)
+                {
+                    if (controller.ExtendedGamepad.ButtonA.IsPressed == true && !buttons.Contains (Buttons.A))
+                        buttons.Add(Buttons.A);
+                    if (controller.ExtendedGamepad.ButtonB.IsPressed == true && !buttons.Contains (Buttons.B))
+                        buttons.Add(Buttons.B);
+                    if (controller.ExtendedGamepad.ButtonX.IsPressed == true && !buttons.Contains (Buttons.X))
+                        buttons.Add(Buttons.X);
+                    if (controller.ExtendedGamepad.ButtonY.IsPressed == true && !buttons.Contains (Buttons.Y))
+                        buttons.Add(Buttons.Y);
+                    
+                    Up = controller.ExtendedGamepad.DPad.Up.IsPressed ? ButtonState.Pressed : ButtonState.Released;
+                    Down = controller.ExtendedGamepad.DPad.Down.IsPressed ? ButtonState.Pressed : ButtonState.Released;
+                    Left = controller.ExtendedGamepad.DPad.Left.IsPressed ? ButtonState.Pressed : ButtonState.Released;
+                    Right = controller.ExtendedGamepad.DPad.Right.IsPressed ? ButtonState.Pressed : ButtonState.Released;
+                   
+                }
+                else if (controller.Gamepad != null)
+                {
+                    if (controller.Gamepad.ButtonA.IsPressed == true && !buttons.Contains (Buttons.A))
+                        buttons.Add(Buttons.A);
+                    if (controller.Gamepad.ButtonB.IsPressed == true && !buttons.Contains (Buttons.B))
+                        buttons.Add(Buttons.B);
+                    if (controller.Gamepad.ButtonX.IsPressed == true && !buttons.Contains (Buttons.X))
+                        buttons.Add(Buttons.X);
+                    if (controller.Gamepad.ButtonY.IsPressed == true && !buttons.Contains (Buttons.Y))
+                        buttons.Add(Buttons.Y);
+                    Up = controller.Gamepad.DPad.Up.IsPressed ? ButtonState.Pressed : ButtonState.Released;
+                    Down = controller.Gamepad.DPad.Down.IsPressed ? ButtonState.Pressed : ButtonState.Released;
+                    Left = controller.Gamepad.DPad.Left.IsPressed ? ButtonState.Pressed : ButtonState.Released;
+                    Right = controller.Gamepad.DPad.Right.IsPressed ? ButtonState.Pressed : ButtonState.Released;
+
+                }
+                else if (controller.MicroGamepad != null)
+                {
+                    if (controller.MicroGamepad.ButtonA.IsPressed == true && !buttons.Contains (Buttons.A))
+                        buttons.Add(Buttons.A);
+                    if (controller.MicroGamepad.ButtonX.IsPressed == true && !buttons.Contains (Buttons.X))
+                        buttons.Add(Buttons.X);
+                    Up = controller.MicroGamepad.Dpad.Up.IsPressed ? ButtonState.Pressed : ButtonState.Released;
+                    Down = controller.MicroGamepad.Dpad.Down.IsPressed ? ButtonState.Pressed : ButtonState.Released;
+                    Left = controller.MicroGamepad.Dpad.Left.IsPressed ? ButtonState.Pressed : ButtonState.Released;
+                    Right = controller.MicroGamepad.Dpad.Right.IsPressed ? ButtonState.Pressed : ButtonState.Released;
+                }
+            }
+            var state = new GamePadState(
+                new GamePadThumbSticks(),
+                new GamePadTriggers(),
+                new GamePadButtons(buttons.ToArray()),
+                new GamePadDPad (Up, Down, Left, Right));
+            state.IsConnected = connected;
+            return state;
+        }
+
+        private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor)
+        {
+            return false;
+        }
+
+        private static GamePadCapabilities GetCapabilities(GCController controller)
+        {
+            //All iOS controllers have these basics
+            var capabilities = new GamePadCapabilities()
+                {
+                    IsConnected = false,
+                    GamePadType = GamePadType.GamePad,
+                };
+            if (controller.ExtendedGamepad != null)
+            {
+                capabilities.HasAButton = true;
+                capabilities.HasBButton = true;
+                capabilities.HasXButton = true;
+                capabilities.HasYButton = true;
+                capabilities.HasBackButton = true;
+                capabilities.HasDPadUpButton = true;
+                capabilities.HasDPadDownButton = true;
+                capabilities.HasDPadLeftButton = true;
+                capabilities.HasDPadRightButton = true;
+                capabilities.HasLeftShoulderButton = true;
+                capabilities.HasRightShoulderButton = true;
+                capabilities.HasLeftTrigger = true;
+                capabilities.HasRightTrigger = true;
+                capabilities.HasLeftXThumbStick = true;
+                capabilities.HasLeftYThumbStick = true;
+                capabilities.HasRightXThumbStick = true;
+                capabilities.HasRightYThumbStick = true;
+            }
+            else if (controller.Gamepad != null)
+            {
+                capabilities.HasAButton = true;
+                capabilities.HasBButton = true;
+                capabilities.HasXButton = true;
+                capabilities.HasYButton = true;
+                capabilities.HasBackButton = true;
+                capabilities.HasDPadUpButton = true;
+                capabilities.HasDPadDownButton = true;
+                capabilities.HasDPadLeftButton = true;
+                capabilities.HasDPadRightButton = true;
+                capabilities.HasLeftShoulderButton = true;
+                capabilities.HasRightShoulderButton = true;
+            }
+            else if (controller.MicroGamepad != null)
+            {
+                capabilities.HasAButton = true;
+                capabilities.HasXButton = true;
+                capabilities.HasBackButton = true;
+                capabilities.HasDPadUpButton = true;
+                capabilities.HasDPadDownButton = true;
+                capabilities.HasDPadLeftButton = true;
+                capabilities.HasDPadRightButton = true;
+            }
+            return capabilities;
+        }
+
+
+    }
+}

--- a/MonoGame.Framework/Media/Album.cs
+++ b/MonoGame.Framework/Media/Album.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Xna.Framework.Media
                 return this.album.HasArt;
 #elif WINDOWS_STOREAPP || WINDOWS_UAP
                 return this.thumbnail != null;
-#elif IOS
+#elif IOS && !TVOS
                 // If album art is missing the bounds will be: Infinity, Infinity, 0, 0
                 return this.thumbnail != null && this.thumbnail.Bounds.Width != 0;
 #elif ANDROID
@@ -201,7 +201,7 @@ namespace Microsoft.Xna.Framework.Media
 #endif
         }
         
-#if IOS
+#if IOS && !TVOS
         [CLSCompliant(false)]
         public UIImage GetAlbumArt(int width = 0, int height = 0)
         {
@@ -242,7 +242,7 @@ namespace Microsoft.Xna.Framework.Media
         }
 #endif
 
-#if IOS
+#if IOS && !TVOS
         [CLSCompliant(false)]
         public UIImage GetThumbnail()
         {

--- a/MonoGame.Framework/Media/MediaPlayer.Default.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.Default.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Xna.Framework.Media
             return _queue.ActiveSong.Position;
         }
 
-#if IOS || ANDROID
+#if (IOS && !TVOS) || ANDROID
         private static void PlatformSetPlayPosition(TimeSpan playPosition)
         {
             if (_queue.ActiveSong != null)

--- a/MonoGame.Framework/Media/MediaPlayer.cs
+++ b/MonoGame.Framework/Media/MediaPlayer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Xna.Framework.Media
         public static TimeSpan PlayPosition
         {
             get { return PlatformGetPlayPosition(); }
-#if IOS || ANDROID
+#if (IOS && !TVOS) || ANDROID
             set { PlatformSetPlayPosition(value); }
 #endif
         }

--- a/MonoGame.Framework/Media/Song.IOS.cs
+++ b/MonoGame.Framework/Media/Song.IOS.cs
@@ -18,7 +18,9 @@ namespace Microsoft.Xna.Framework.Media
         private Genre genre;
         private string title;
         private TimeSpan duration;
+        #if !TVOS
         private MPMediaItem mediaItem;
+        #endif
         private AVPlayerItem _sound;
         private AVPlayer _player;
         private NSUrl assetUrl;
@@ -30,14 +32,20 @@ namespace Microsoft.Xna.Framework.Media
             get { return this.assetUrl; }
         }
 
+        #if !TVOS
         internal Song(Album album, Artist artist, Genre genre, string title, TimeSpan duration, MPMediaItem mediaItem, NSUrl assetUrl)
+        #else
+        internal Song(Album album, Artist artist, Genre genre, string title, TimeSpan duration, object mediaItem, NSUrl assetUrl)
+        #endif
         {
             this.album = album;
             this.artist = artist;
             this.genre = genre;
             this.title = title;
             this.duration = duration;
+            #if !TVOS
             this.mediaItem = mediaItem;
+            #endif
             this.assetUrl = assetUrl;
         }
 
@@ -188,9 +196,10 @@ namespace Microsoft.Xna.Framework.Media
 
         private TimeSpan PlatformGetDuration()
         {
+            #if !TVOS
             if (this.mediaItem != null)
                 return this.duration;
-
+            #endif
             return _duration;
         }
 

--- a/MonoGame.Framework/iOS/iOSGamePlatform.cs
+++ b/MonoGame.Framework/iOS/iOSGamePlatform.cs
@@ -105,7 +105,9 @@ namespace Microsoft.Xna.Framework
 
             _applicationObservers = new List<NSObject>();
 
+            #if !TVOS
             UIApplication.SharedApplication.SetStatusBarHidden(true, UIStatusBarAnimation.Fade);
+            #endif
 
             // Create a full-screen window
             _mainWindow = new UIWindow (UIScreen.MainScreen.Bounds);
@@ -298,6 +300,9 @@ namespace Microsoft.Xna.Framework
         private void Application_DidBecomeActive(NSNotification notification)
         {
             IsActive = true;
+            #if TVOS
+            _viewController.ControllerUserInteractionEnabled = false;
+            #endif
             //TouchPanel.Reset();
         }
 
@@ -317,10 +322,23 @@ namespace Microsoft.Xna.Framework
 
         #endregion Notification Handling
 
+        #region Helper Property
+
+        private DisplayOrientation CurrentOrientation {
+            get {
+                #if TVOS
+                return DisplayOrientation.LandscapeLeft;
+                #else
+                return OrientationConverter.ToDisplayOrientation(_viewController.InterfaceOrientation);
+                #endif
+            }
+        }
+
+        #endregion
+
 		private void ViewController_InterfaceOrientationChanged (object sender, EventArgs e)
 		{
-			var orientation = OrientationConverter.ToDisplayOrientation (
-				_viewController.InterfaceOrientation);
+			var orientation = CurrentOrientation;
 
 			// FIXME: The presentation parameters for the GraphicsDevice should
 			//        be managed by the GraphicsDevice itself.  Not by

--- a/MonoGame.Framework/iOS/iOSGameView.cs
+++ b/MonoGame.Framework/iOS/iOSGameView.cs
@@ -106,7 +106,9 @@ namespace Microsoft.Xna.Framework {
 
 		private void Initialize ()
 		{
+            #if !TVOS
 			MultipleTouchEnabled = true;
+            #endif
 			Opaque = true;
 		}
 

--- a/MonoGame.Framework/iOS/iOSGameWindow.cs
+++ b/MonoGame.Framework/iOS/iOSGameWindow.cs
@@ -102,7 +102,9 @@ namespace Microsoft.Xna.Framework {
                 // TODO: Calculate this only when dirty.
                 if (_viewController is iOSGameViewController)
                 {
-                    var currentOrientation = OrientationConverter.ToDisplayOrientation(_viewController.InterfaceOrientation);
+
+                    var currentOrientation = CurrentOrientation;
+
                     int width;
                     int height;
 
@@ -133,7 +135,11 @@ namespace Microsoft.Xna.Framework {
 
 		public override DisplayOrientation CurrentOrientation {
 			get {
+                #if TVOS
+                return DisplayOrientation.LandscapeLeft;
+                #else
 				return OrientationConverter.ToDisplayOrientation(_viewController.InterfaceOrientation);
+                #endif
 			}
 		}
 

--- a/NuGetPackages/MonoGame.Framework.iOS.nuspec
+++ b/NuGetPackages/MonoGame.Framework.iOS.nuspec
@@ -20,6 +20,10 @@
     <files>
         <file src="iOS\iPhoneSimulator\Release\MonoGame.Framework.dll" target="lib\XamariniOS\MonoGame.Framework.dll" />
         <file src="iOS\iPhoneSimulator\Release\MonoGame.Framework.xml" target="lib\XamariniOS\MonoGame.Framework.xml" />
+        <!--
+        <file src="tvOS\iPhoneSimulator\Release\MonoGame.Framework.dll" target="lib\Xamarin.TVOS10\MonoGame.Framework.dll" />
+        <file src="tvOS\iPhoneSimulator\Release\MonoGame.Framework.xml" target="lib\Xamarin.TVOS10\MonoGame.Framework.xml" />
+        -->
         <file src="..\..\NuGetPackages\readme\MonoGame.Framework\readme.txt" target="readme.txt" />
     </files>
 </package>


### PR DESCRIPTION
This generates a new solution file and project for tvOS which can be found in MonoGame.Framework.tvOS.

Conflicts:
	Build/Module.xml
	Build/Projects/MonoGame.Framework.definition


Thanks to the CocosSharp Team ( @kjpou1 m @rtabbara ) for their work on this.
Nant script stuff will follow once we have the tvOS stuff installed on the build machine.