### PR TITLE
[Pipeline Tool] Use system gtk-sharp 3

### DIFF
--- a/Build/GenerateProject.CSharp.xslt
+++ b/Build/GenerateProject.CSharp.xslt
@@ -1344,6 +1344,11 @@
                             '.csproj'),
                           @Path)" />
                     </HintPath>
+                    <xsl:choose>
+                      <xsl:when test="@LocalCopy">
+                        <Private><xsl:value-of select="@LocalCopy" /></Private>
+                      </xsl:when>
+                    </xsl:choose>
                   </Reference>
                 </xsl:for-each>
                 <xsl:for-each select="./Service">

--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -269,69 +269,6 @@
       <Platforms>Linux</Platforms>
     </EmbeddedResource>
 
-    <!-- Copy config files to output directory -->
-    <None Include="..\..\ThirdParty\Dependencies\Gtk3\atk-sharp.dll.config">
-      <Platforms>Linux</Platforms>
-      <Link>atk-sharp.dll.config</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\ThirdParty\Dependencies\Gtk3\gdk-sharp.dll.config">
-      <Platforms>Linux</Platforms>
-      <Link>gdk-sharp.dll.config</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\ThirdParty\Dependencies\Gtk3\gio-sharp.dll.config">
-      <Platforms>Linux</Platforms>
-      <Link>gio-sharp.dll.config</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\ThirdParty\Dependencies\Gtk3\glib-sharp.dll.config">
-      <Platforms>Linux</Platforms>
-      <Link>glib-sharp.dll.config</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\ThirdParty\Dependencies\Gtk3\gtk-sharp.dll.config">
-      <Platforms>Linux</Platforms>
-      <Link>gtk-sharp.dll.config</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\ThirdParty\Dependencies\Gtk3\pango-sharp.dll.config">
-      <Platforms>Linux</Platforms>
-      <Link>pango-sharp.dll.config</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-
-    <None Include="..\..\ThirdParty\Dependencies\Gtk\atk-sharp.dll.config">
-      <Platforms>MacOS</Platforms>
-      <Link>atk-sharp.dll.config</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\ThirdParty\Dependencies\Gtk\gdk-sharp.dll.config">
-      <Platforms>MacOS</Platforms>
-      <Link>gdk-sharp.dll.config</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\ThirdParty\Dependencies\Gtk\glade-sharp.dll.config">
-      <Platforms>MacOS</Platforms>
-      <Link>glade-sharp.dll.config</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\ThirdParty\Dependencies\Gtk\glib-sharp.dll.config">
-      <Platforms>MacOS</Platforms>
-      <Link>glib-sharp.dll.config</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\ThirdParty\Dependencies\Gtk\gtk-sharp.dll.config">
-      <Platforms>MacOS</Platforms>
-      <Link>gtk-sharp.dll.config</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\ThirdParty\Dependencies\Gtk\pango-sharp.dll.config">
-      <Platforms>MacOS</Platforms>
-      <Link>pango-sharp.dll.config</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-
     <!-- Copy the template resources to the output -->
 	<None Include="Templates\Effect.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Build/Projects/PipelineReferences.definition
+++ b/Build/Projects/PipelineReferences.definition
@@ -4,28 +4,36 @@
   <Platform Type="Linux">
     <Binary
       Name="gtk-sharp"
-      Path="ThirdParty\Dependencies\Gtk3\gtk-sharp.dll" />
+      Path="ThirdParty\Dependencies\Gtk3\gtk-sharp.dll"
+      LocalCopy="False" />
     <Binary
       Name="atk-sharp"
-      Path="ThirdParty\Dependencies\Gtk3\atk-sharp.dll" />
+      Path="ThirdParty\Dependencies\Gtk3\atk-sharp.dll"
+      LocalCopy="False" />
     <Binary
       Name="gdk-sharp"
-      Path="ThirdParty\Dependencies\Gtk3\gdk-sharp.dll" />
+      Path="ThirdParty\Dependencies\Gtk3\gdk-sharp.dll"
+      LocalCopy="False" />
     <Binary
       Name="glade-sharp"
-      Path="ThirdParty\Dependencies\Gtk3\gio-sharp.dll" />
+      Path="ThirdParty\Dependencies\Gtk3\gio-sharp.dll"
+      LocalCopy="False" />
     <Binary
       Name="glib-sharp"
-      Path="ThirdParty\Dependencies\Gtk3\glib-sharp.dll" />
+      Path="ThirdParty\Dependencies\Gtk3\glib-sharp.dll"
+      LocalCopy="False" />
     <Binary
       Name="gtk-dotnet"
-      Path="ThirdParty\Dependencies\Gtk3\gtk-dotnet.dll" />
+      Path="ThirdParty\Dependencies\Gtk3\gtk-dotnet.dll"
+      LocalCopy="False" />
     <Binary
       Name="pango-sharp"
-      Path="ThirdParty\Dependencies\Gtk3\pango-sharp.dll" />
+      Path="ThirdParty\Dependencies\Gtk3\pango-sharp.dll"
+      LocalCopy="False" />
     <Binary
       Name="Mono.Posix"
-      Path="ThirdParty\Dependencies\Gtk\Mono.Posix.dll" />
+      Path="ThirdParty\Dependencies\Gtk\Mono.Posix.dll"
+      LocalCopy="False" />
   </Platform>
 
   <Platform Type="MacOS">

--- a/Documentation/setting_up_monogame_linux.md
+++ b/Documentation/setting_up_monogame_linux.md
@@ -27,11 +27,13 @@ sudo apt-get install libopenal-dev mono-runtime
 * Open up terminal and type in:
 ```
 cd Downloads
+chmod +x monogame-sdk.run
 sudo ./monogame-sdk.run
 ```
 * During the installation process the installer will ask you if you wish to install any missing dependencies automatically. If you for some reason don't want to install them automatically or the dependency installer is not available for your linux distribution, here is the list of needed packages:
   * monodevelop ([http://www.monodevelop.com/download/](http://www.monodevelop.com/download/))
   * libopenal-dev
   * referenceassemblies-pcl
+  * gtk-sharp3
   * ttf-mscorefonts-installer (recommended, but not needed)
 * That's it, MonoGame SDK is installed

--- a/Installers/Linux/DEBIAN/control
+++ b/Installers/Linux/DEBIAN/control
@@ -1,6 +1,6 @@
 Package: monogame-sdk
 Section: Development
 Architecture: amd64
-Depends: libgtk-3-0 (>= 3.0.0), mono-complete (>= 3.0.0), ttf-mscorefonts-installer (>= 1.0), monodevelop (>= 5.0)
+Depends: libgtk-3-0 (>= 3.0.0), ttf-mscorefonts-installer (>= 1.0), monodevelop (>= 5.0), gtk-sharp3 (>= 2.99), referenceassemblies-pcl (>= 2014.04)
 Maintainer: Harry <cra0zy@email.com>
 Description: MonoGame SDK

--- a/Installers/Linux/RUN/Dependencies/dependencies_deb.sh
+++ b/Installers/Linux/RUN/Dependencies/dependencies_deb.sh
@@ -2,4 +2,4 @@
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
 sudo apt-get update
-sudo apt-get install -y monodevelop libopenal-dev libsdl-mixer1.2 referenceassemblies-pcl ttf-mscorefonts-installer libstdc++6
+sudo apt-get install -y monodevelop libopenal-dev referenceassemblies-pcl ttf-mscorefonts-installer gtk-sharp3


### PR DESCRIPTION
Stuff done:
 - added LocalCopy argument to protobuild and disabled copying of gtk-sharp3 dll files, this forces system gtk-sharp3 libraries to be used instead
 - disabled copying of gtk-sharp3 config files because of the above
 - updated installer and documentation dependencies