### PR TITLE
Fix for content pipeline models being drawn entirely black

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/OpenAssetImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/OpenAssetImporter.cs
@@ -311,20 +311,15 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                     material.Textures.Add("Bump", texture);
                 }
 
-                if (aiMaterial.HasColorDiffuse)
-                    material.DiffuseColor = ToXna(aiMaterial.ColorDiffuse);
+                material.DiffuseColor = ToXna(aiMaterial.ColorDiffuse);
 
-                if (aiMaterial.HasColorEmissive)
-                    material.EmissiveColor = ToXna(aiMaterial.ColorEmissive);
+                material.EmissiveColor = ToXna(aiMaterial.ColorEmissive);
 
-                if (aiMaterial.HasOpacity)
-                    material.Alpha = aiMaterial.Opacity;
+                material.Alpha = aiMaterial.Opacity;
 
-                if (aiMaterial.HasColorSpecular)
-                    material.SpecularColor = ToXna(aiMaterial.ColorSpecular);
+                material.SpecularColor = ToXna(aiMaterial.ColorSpecular);
 
-                if (aiMaterial.HasShininessStrength)
-                    material.SpecularPower = aiMaterial.ShininessStrength;
+                material.SpecularPower = aiMaterial.ShininessStrength;
 
                 _materials.Add(material);
             }

--- a/MonoGame.Framework.Content.Pipeline/OpenAssetImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/OpenAssetImporter.cs
@@ -311,15 +311,20 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                     material.Textures.Add("Bump", texture);
                 }
 
-                material.DiffuseColor = ToXna(aiMaterial.ColorDiffuse);
+                if (aiMaterial.HasColorDiffuse)
+                    material.DiffuseColor = ToXna(aiMaterial.ColorDiffuse);
 
-                material.EmissiveColor = ToXna(aiMaterial.ColorEmissive);
+                if (aiMaterial.HasColorEmissive)
+                    material.EmissiveColor = ToXna(aiMaterial.ColorEmissive);
 
-                material.Alpha = aiMaterial.Opacity;
+                if (aiMaterial.HasOpacity)
+                    material.Alpha = aiMaterial.Opacity;
 
-                material.SpecularColor = ToXna(aiMaterial.ColorSpecular);
+                if (aiMaterial.HasColorSpecular)
+                    material.SpecularColor = ToXna(aiMaterial.ColorSpecular);
 
-                material.SpecularPower = aiMaterial.ShininessStrength;
+                if (aiMaterial.HasShininessStrength)
+                    material.SpecularPower = aiMaterial.ShininessStrength;
 
                 _materials.Add(material);
             }

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/BasicEffectWriter.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/BasicEffectWriter.cs
@@ -12,12 +12,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Compiler
         protected internal override void Write(ContentWriter output, BasicMaterialContent value)
         {
             output.WriteExternalReference(value.Textures.ContainsKey(BasicMaterialContent.TextureKey) ? value.Texture : null);
-            output.Write(value.DiffuseColor.GetValueOrDefault());
-            output.Write(value.EmissiveColor.GetValueOrDefault());
-            output.Write(value.SpecularColor.GetValueOrDefault());
-            output.Write(value.SpecularPower.GetValueOrDefault());
-            output.Write(value.Alpha.GetValueOrDefault());
-            output.Write(value.VertexColorEnabled.GetValueOrDefault());
+            output.Write(value.DiffuseColor ?? new Vector3(1, 1, 1));
+            output.Write(value.EmissiveColor ?? new Vector3(0, 0, 0));
+            output.Write(value.SpecularColor ?? new Vector3(1, 1, 1));
+            output.Write(value.SpecularPower ?? 16);
+            output.Write(value.Alpha ?? 1);
+            output.Write(value.VertexColorEnabled ?? false);
         }
     }
 }


### PR DESCRIPTION
*Disclaimer: I know nothing about 3D graphics, XNA or MonoGame (aside from simple SpriteBatch stuff) so everything below could be wrong.*

This push request is a quick fix to solve the black model problem with the content pipeline. Processing a model with MonoGame's pipeline and then drawing it using model.Draw() causes it to be drawn entirely black. However, if you process the model with XNA's pipeline and then load and Draw() the xnb in MonoGame it displays as expected. See these threads for more information on the problem:

https://github.com/mono/MonoGame/issues/4069
http://community.monogame.net/t/3d-models-appear-black/2596
http://community.monogame.net/t/problem-with-3d-objects-textures/2474
http://community.monogame.net/t/diagnosing-rendering-issues-for-3d-model-in-new-content-pipeline/1432

The problem occurs here:

https://github.com/mono/MonoGame/blob/develop/MonoGame.Framework.Content.Pipeline/OpenAssetImporter.cs#L320

The pipeline checks if Assimp has imported a particular lighting property from the model's material, and if so, sets the relevant nullable property in a BasicMaterialContent object. If the particular lighting property is not found then the relevant BasicMaterialContent property remains null. When the BasicMaterialContent is serialized it uses GetValueOrDefault() which sets all the unfound lighting properties to the default float value of 0. Thus the resulting xnb model has Alpha and SpecularPower set to 0 causing it to be drawn entirely black:

https://github.com/mono/MonoGame/blob/develop/MonoGame.Framework.Content.Pipeline/Serialization/Compiler/BasicEffectWriter.cs

Assimp .NET seems to provide sensible defaults when getting a lighting property for which no corresponding property was found in the model's material:

https://github.com/assimp/assimp-net/blob/master/AssimpNet/Material.cs#L253

So this patch changes the pipeline to always accept the value provided by Assimp .NET, which will be either the property from the model or the default value provided. This solves the black rendering problem on the handful of models I have tried (on Windows 10) but I don't know if it is a correct or appropriate fix.

As a final note here are the final lighting values from importing a simple untextured model in various ways (unlisted properties do not differ between the three methods).

XNA Pipeline
------------
Alpha = 1
DiffuseColor = 1 1 1
SpecularColor = 1 1 1
SpecularPower = 16

Current MonoGame Pipeline
-------------------------
Alpha = 0
DiffuseColor = 0.8 0.8 0.8
SpecularColor = 0 0 0
SpecularPower = 0

Patched MonoGame Pipeline
-------------------------
Alpha = 1
DiffuseColor = 0.8 0.8 0.8
SpecularColor = 0 0 0
SpecularPower = 1