### PR TITLE
Enable gamepad vibration for Windows DirectX

### DIFF
--- a/MonoGame.Framework/Input/GamePad.XInput.cs
+++ b/MonoGame.Framework/Input/GamePad.XInput.cs
@@ -303,7 +303,6 @@ namespace Microsoft.Xna.Framework.Input
 
         private static bool PlatformSetVibration(int index, float leftMotor, float rightMotor)
         {
-#if DIRECTX11_1
             if (!_connected[index])
                 return false;
 
@@ -315,9 +314,6 @@ namespace Microsoft.Xna.Framework.Input
             });
 
             return result == SharpDX.Result.Ok;
-#else
-            return false;
-#endif            
         }
     }
 }


### PR DESCRIPTION
This PR enables gamepad vibration for Windows DirectX.

The code was actually already there, but only enabled for `DIRECTX11_1` builds. So I guess at some point this wasn't supported by SharpDX on Windows desktop? But they must have since added support for it as Windows Desktop is listed as a supported platform here: http://sharpdx.org/documentation/api/m-sharpdx-xinput-controller-setvibration

I've tested this on Windows 7 and it works correctly.