### PR TITLE
[Pipeline] Change ItemHeight from default(16) to 18

### DIFF
--- a/Tools/Pipeline/Windows/MainView.Designer.cs
+++ b/Tools/Pipeline/Windows/MainView.Designer.cs
@@ -149,6 +149,7 @@ namespace MonoGame.Tools.Pipeline
             this._treeView.Dock = System.Windows.Forms.DockStyle.Fill;
             this._treeView.DragOverNodeBackColor = System.Drawing.SystemColors.Highlight;
             this._treeView.DragOverNodeForeColor = System.Drawing.SystemColors.HighlightText;
+            this._treeView.ItemHeight = 18;
             this._treeView.Location = new System.Drawing.Point(0, 0);
             this._treeView.Name = "_treeView";
             this._treeView.Size = new System.Drawing.Size(249, 210);


### PR DESCRIPTION
Add 2 pixel space between icons/items in the treeview.

![pipeline_itemheight](https://cloud.githubusercontent.com/assets/3018589/11215772/8f139e04-8d50-11e5-9819-b122ce325dbc.png)
