### PR TITLE
Fix XNA test regressions

### DIFF
--- a/Test/Framework/Components/Colored3DCubeComponent.cs
+++ b/Test/Framework/Components/Colored3DCubeComponent.cs
@@ -136,7 +136,7 @@ namespace MonoGame.Tests.Components {
 			foreach (EffectPass pass in basicEffect.CurrentTechnique.Passes) {
                 pass.Apply();
 
-				GraphicsDevice.DrawIndexedPrimitives (PrimitiveType.TriangleList, 0, 0, number_of_indices / 3);
+				GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, number_of_vertices, 0, number_of_indices / 3);
 
 			}
 			base.Draw (gameTime);

--- a/Test/Framework/Components/Simple3DCubeComponent.cs
+++ b/Test/Framework/Components/Simple3DCubeComponent.cs
@@ -64,7 +64,7 @@ namespace MonoGame.Tests.Components {
 			foreach (EffectPass pass in basicEffect.CurrentTechnique.Passes) {
                 pass.Apply();
 
-				GraphicsDevice.DrawIndexedPrimitives (PrimitiveType.TriangleList, 0, 0, number_of_indices / 3);
+				GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, number_of_vertices, 0, number_of_indices / 3);
 			}
 
 			base.Draw (gameTime);

--- a/Test/Framework/MathHelperTest.cs
+++ b/Test/Framework/MathHelperTest.cs
@@ -50,6 +50,7 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual(MathHelper.Lerp(10000000000000000f, 1f, 1f), 0f, "Lerp test failed on [10000000000000000,1,1]");
         }
 
+#if !XNA
         [Test]
         public void LerpPreciseTest()
         {
@@ -59,6 +60,7 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual(MathHelper.LerpPrecise(-5f, -1f, 0.5f), -3f, "LerpPrecise test failed on [-5,-1, 0.5]");
             Assert.AreEqual(MathHelper.LerpPrecise(10000000000000000f, 1f, 1f), 1, "LerpPrecise test failed on [10000000000000000,1,1]");
         }
+#endif
 
         [Test]
         public void Min()

--- a/Test/Framework/Visual/GraphicsDeviceTest.cs
+++ b/Test/Framework/Visual/GraphicsDeviceTest.cs
@@ -110,6 +110,8 @@ namespace MonoGame.Tests.Visual
             Game.Run();
         }
 
+        // This overload of DrawIndexedPrimitives is not supported on XNA.
+#if !XNA
         [Test]
         public void DrawIndexedPrimitivesParameterValidation2()
         {
@@ -140,35 +142,24 @@ namespace MonoGame.Tests.Visual
                 // Success - "normal" usage.
                 Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, 1));
 
-                // XNA doesn't do upfront parameter validation on the Assert.DoesNotThrow tests,
-                // but it *sometimes* fails later with an AccessViolationException, so we can't actually
-                // run these tests as part of the XNA test suite.
-
                 // baseVertex too small / large.
-#if !XNA
                 Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, -1, 0, 1));
                 Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 3, 0, 1));
-#endif
 
                 // startIndex too small / large.
-#if !XNA
                 Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, -1, 1));
                 Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 3, 1));
-#endif
 
                 // primitiveCount too small / large.
                 Assert.Throws<ArgumentOutOfRangeException>(() => Game.GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, 0));
-#if !XNA
                 Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, 2));
-#endif
 
                 // startIndex + primitiveCount too large.
-#if !XNA
                 Assert.DoesNotThrow(() => Game.GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 1, 1));
-#endif
             };
             Game.Run();
         }
+#endif
 
 #if XNA || DIRECTX
         [Test]


### PR DESCRIPTION
The XNA test project was broken by a couple recent(-ish) PRs.

* As part of #4098 the 3D cube components were updated to use a `DrawIndexedPrimitives` overload that does not exist in XNA. Reverted the calls back to the old overload, which internally uses the new code.
* Also as part of #4098 a test for the new overload was added. Added `#if !XNA` around the test.
* The test for `MathHelper.LerpPrecise` function introduced in #4233 was included in the XNA project too. Added `#if !XNA` around the test.

As a disclaimer, I only have the XNA redist installed at the moment, so I had to exclude the Content Pipeline tests from compilation on my machine. Therefore I cannot guarantee that the project is completely buildable even with these changes, and this must be given a full test before merging.

I assume that #3550 is dead? Besides, how important are these compatibility tests anymore, as they can be broken for months and XNA has been long dead? We have a few missing features to implement and some edge cases for which crosstesting will be useful, but otherwise these seem to be neglected.