### PR TITLE
Fixed Icon crash

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
@@ -339,10 +339,16 @@ namespace Microsoft.Xna.Framework
 
             Title = assembly != null ? AssemblyHelper.GetDefaultWindowTitle() : "MonoGame Application";
 
-            if (t == null && assembly != null)
-                window.Icon = Icon.ExtractAssociatedIcon(assembly.Location);
-            else
-                window.Icon = new Icon(Assembly.GetExecutingAssembly().GetManifestResourceStream("Microsoft.Xna.Framework.monogame.ico"));
+            // In case when DesktopGL dll is compiled using .Net, and you
+            // try to load it using Mono, it will cause a crash because of this.
+            try
+            {
+                if (t == null && assembly != null)
+                    window.Icon = Icon.ExtractAssociatedIcon(assembly.Location);
+                else
+                    window.Icon = new Icon(Assembly.GetExecutingAssembly().GetManifestResourceStream("Microsoft.Xna.Framework.monogame.ico"));
+            }
+            catch { }
 
             updateClientBounds = false;
             clientBounds = new Rectangle(window.ClientRectangle.X, window.ClientRectangle.Y,


### PR DESCRIPTION
It seems that Mono's System.Drawing can't load embedded resources correctly when the dll file is compiled with .Net.

The crash was:
```
System.ArgumentException: The argument 'stream' must be a picture that can be used as a Icon
Parameter name: stream
  at System.Drawing.Icon.InitFromStreamWithSize (System.IO.Stream stream, Int32 width, Int32 height) [0x00013] in /builddir/build/BUILD/mono-4.2.1/mcs/class/System.Drawing/System.Drawing/Icon.cs:685
  at System.Drawing.Icon..ctor (System.IO.Stream stream, Int32 width, Int32 height) [0x00011] in /builddir/build/BUILD/mono-4.2.1/mcs/class/System.Drawing/System.Drawing/Icon.cs:218
  at System.Drawing.Icon..ctor (System.IO.Stream stream) [0x00000] in /builddir/build/BUILD/mono-4.2.1/mcs/class/System.Drawing/System.Drawing/Icon.cs:212
  at at (wrapper remoting-invoke-with-check) System.Drawing.Icon:.ctor (System.IO.Stream)
  at Microsoft.Xna.Framework.OpenTKGameWindow.Initialize (Microsoft.Xna.Framework.Game game) [0x00102] in <filename unknown>:0
  at Microsoft.Xna.Framework.OpenTKGameWindow..ctor (Microsoft.Xna.Framework.Game game) [0x00006] in <filename unknown>:0
  at Microsoft.Xna.Framework.OpenTKGamePlatform..ctor (Microsoft.Xna.Framework.Game game) [0x0000e] in <filename unknown>:0
  at Microsoft.Xna.Framework.GamePlatform.Create (Microsoft.Xna.Framework.Game game) [0x00000] in <filename unknown>:0
  at Microsoft.Xna.Framework.Game..ctor () [0x001fb] in <filename unknown>:0
  at mgdelll.Game1..ctor () [0x00000] in /home/harry/Projects/mgdelll/mgdelll/Game1.cs:21
  at mgdelll.Program.RunGame () [0x00001] in /home/harry/Projects/mgdelll/mgdelll/Program.cs:30
  at mgdelll.Program.Main (System.String[] args) [0x00001] in /home/harry/Projects/mgdelll/mgdelll/Program.cs:52
```