### PR TITLE
[Pipeline] Add FilterOutput view

### DIFF
--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -59,6 +59,7 @@
     <Compile Include="Common\IProjectItem.cs" />
     <Compile Include="Common\IProjectObserver.cs" />
     <Compile Include="Common\IView.cs" />
+    <Compile Include="Common\OutputParser.cs" />
     <Compile Include="Common\PipelineProjectParser.cs" />
     <Compile Include="Common\Util.cs" />
     <Compile Include="Common\StringExtensions.cs" />

--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -71,6 +71,9 @@
     <Compile Include="Windows\UpdateAction.cs" />
 
     <!-- The Windows specific stuff -->
+    <Compile Include="Windows\BuildIcons.cs">
+      <Platforms>Windows</Platforms>
+    </Compile>
     <Compile Include="Windows\ContentIcons.cs">
       <Platforms>Windows</Platforms>
     </Compile>
@@ -97,6 +100,14 @@
       <DependentUpon>NewContentDialog.cs</DependentUpon>
     </Compile>
     <Compile Include="Windows\MultiSelectTreeview.cs">
+      <Platforms>Windows</Platforms>
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="Windows\Controls\FilterOutputControl.cs">
+      <Platforms>Windows</Platforms>
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="Windows\Controls\TabControlEx.cs">
       <Platforms>Windows</Platforms>
       <SubType>Component</SubType>
     </Compile>

--- a/Tools/Pipeline/Common/OutputParser.cs
+++ b/Tools/Pipeline/Common/OutputParser.cs
@@ -1,0 +1,150 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Text.RegularExpressions;
+
+namespace MonoGame.Tools.Pipeline.Common
+{
+    enum OutputState
+    {
+        Initialized,
+        BuildBegin,
+        Cleaning,
+        Skipping,
+        BuildAsset,
+        BuildError,
+        BuildErrorContinue,
+        BuildEnd,
+        BuildTime,
+
+        Unknown
+    }
+
+    class OutputParser
+    {
+        internal OutputState State { get; private set; }
+        internal String Filename { get; private set; }
+        internal String ErrorMessage { get; private set; }
+        internal String BuildBeginTime { get; private set; }
+        internal String BuildInfo { get; private set; }
+        internal String BuildElapsedTime { get; private set; }
+
+
+        Regex _reBuildBegin = new Regex(@"^(Build started)\W+(?<buildBeginTime>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        Regex _reCleaning = new Regex(@"^(Cleaning)\W+(?<filename>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        Regex _reSkipping = new Regex(@"^(Skipping)\W+(?<filename>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        Regex _reBuildAsset = new Regex(@"^(?<filename>([a-zA-Z]:)?/.+?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        Regex _reBuildError = new Regex(@"^(?<filename>([a-zA-Z]:)?/.+?)\W*?:\W*?error\W*?:\W*(?<errorMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        Regex _reBuildEnd = new Regex(@"^(Build)\W+(?<buildInfo>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        Regex _reBuildTime = new Regex(@"^(Time elapsed)\W+(?<buildElapsedTime>.*?)\.\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        
+
+        public OutputParser()
+        {
+            Reset();
+        }
+
+        internal void Reset()
+        {
+            State = OutputState.Initialized;
+            Filename = null;
+            BuildBeginTime = null;
+            BuildInfo = null;
+            BuildElapsedTime = null;
+            ErrorMessage = null;
+        }
+
+        internal void Parse(string text)
+        {   
+            ParseLine(text);
+        }
+
+
+        private void ParseLine(string line)
+        {
+            /* 
+             * Line <-- BuildBegin
+             * Line <-- BuildEnd
+             * Line <-- BuildTime
+             * Line <-- Cleaning
+             * Line <-- Skipping
+             * Line <-- BuildError (BuildErrorContinue)+
+             * Line <-- BuildAsset
+             * BuildBegin   <-- "Build" "started" buildBeginTime
+             * Cleaning     <-- "Cleaning" filenane
+             * Skipping     <-- "Skipping" filenane
+             * BuildAsset   <-- filename
+             * BuildError   <-- filename ':' "Error" ':' errorMessage
+             * BuildErrorContinue <-- errorMessage
+             * BuildEnd     <-- "Build" buildInfo
+             * BuildTime    <-- "Time" "elapsed" buildElapsedTime
+             */
+
+            var prevState = State;
+            var prevFilename = Filename;
+
+            State = OutputState.Unknown;
+            Filename = null;            
+            BuildBeginTime = null;
+            BuildInfo = null;
+            BuildElapsedTime = null;
+            ErrorMessage = null;
+
+            if (_reBuildBegin.IsMatch(line))
+            {
+                State = OutputState.BuildBegin;
+                var m = _reBuildBegin.Match(line);
+                BuildBeginTime = m.Groups["buildBeginTime"].Value;
+            }
+            else if (_reBuildEnd.IsMatch(line))
+            {
+                State = OutputState.BuildEnd;
+                var m = _reBuildEnd.Match(line);
+                BuildInfo = m.Groups["buildInfo"].Value;
+            }
+            else if (_reBuildTime.IsMatch(line))
+            {
+                State = OutputState.BuildTime;
+                var m = _reBuildTime.Match(line);
+                BuildElapsedTime = m.Groups["buildElapsedTime"].Value;
+            }
+            else if (_reCleaning.IsMatch(line))
+            {
+                State = OutputState.Cleaning;
+                var m = _reCleaning.Match(line);
+                Filename = m.Groups["filename"].Value;
+            }
+            else if (_reSkipping.IsMatch(line))
+            {
+                State = OutputState.Skipping;
+                var m = _reSkipping.Match(line);
+                Filename = m.Groups["filename"].Value;
+            }
+            else if (_reBuildError.IsMatch(line))
+            {
+                State = OutputState.BuildError;
+                var m = _reBuildError.Match(line);
+                Filename = m.Groups["filename"].Value;
+                ErrorMessage = m.Groups["errorMessage"].Value;
+            }
+            else if (_reBuildAsset.IsMatch(line))
+            {
+                State = OutputState.BuildAsset;
+                var m = _reBuildAsset.Match(line);
+                Filename = m.Groups["filename"].Value;
+            }
+            else if (prevState == OutputState.BuildError || prevState == OutputState.BuildErrorContinue)
+            {
+                State = OutputState.BuildErrorContinue;
+                Filename = prevFilename;
+                ErrorMessage = line.TrimEnd();
+            }
+            else
+            {
+                State = OutputState.Unknown;
+            }
+        }
+    }
+}

--- a/Tools/Pipeline/Common/PipelineController.cs
+++ b/Tools/Pipeline/Common/PipelineController.cs
@@ -51,13 +51,16 @@ namespace MonoGame.Tools.Pipeline
 
         public bool LaunchDebugger { get; set; }
 
-        public string ProjectLocation {
-            get
-            {
-                return _project.Location;
-            }
+        public string ProjectLocation 
+        {
+            get { return _project.Location; }
         }
 
+        public string ProjectOutputDir
+        {
+            get { return _project.OutputDir; }
+        }
+        
         public bool ProjectOpen { get; private set; }
 
         public bool ProjectDirty { get; set; }

--- a/Tools/Pipeline/Windows/BuildIcons.cs
+++ b/Tools/Pipeline/Windows/BuildIcons.cs
@@ -1,0 +1,60 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Drawing;
+using System.IO;
+using System.Reflection;
+using System.Windows.Forms;
+
+namespace MonoGame.Tools.Pipeline
+{
+    public class BuildIcons: IDisposable
+    {
+        public ImageList Icons { get; private set; }
+
+        public const int BeginEnd = 0;
+        public const int Clean = 1;
+        public const int Fail = 2;
+        public const int Processing = 3;
+        public const int Skip = 4;
+        public const int Succeed = 5;
+        public const int Null = 6; // set to >= Icons.Images.Count for no icon
+     
+
+        public BuildIcons()
+        {
+            Icons = new ImageList();
+            Icons.ColorDepth = ColorDepth.Depth32Bit;
+
+            var asm = Assembly.GetExecutingAssembly();
+            Icons.Images.Add(Image.FromStream(asm.GetManifestResourceStream(@"MonoGame.Tools.Pipeline.Icons.build_begin_end.png")));
+            Icons.Images.Add(Image.FromStream(asm.GetManifestResourceStream(@"MonoGame.Tools.Pipeline.Icons.build_clean.png")));
+            Icons.Images.Add(Image.FromStream(asm.GetManifestResourceStream(@"MonoGame.Tools.Pipeline.Icons.build_fail.png")));
+            Icons.Images.Add(Image.FromStream(asm.GetManifestResourceStream(@"MonoGame.Tools.Pipeline.Icons.build_processing.png")));
+            Icons.Images.Add(Image.FromStream(asm.GetManifestResourceStream(@"MonoGame.Tools.Pipeline.Icons.build_skip.png")));
+            Icons.Images.Add(Image.FromStream(asm.GetManifestResourceStream(@"MonoGame.Tools.Pipeline.Icons.build_succeed.png")));
+        }
+
+        ~BuildIcons()
+        {
+            Dispose(false);
+        }
+        
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Icons.Dispose();
+            }
+            Icons = null;
+        }
+    }
+}

--- a/Tools/Pipeline/Windows/Controls/FilterOutputControl.cs
+++ b/Tools/Pipeline/Windows/Controls/FilterOutputControl.cs
@@ -42,6 +42,11 @@ namespace MonoGame.Tools.Pipeline.Windows.Controls
             outputUri = new Uri(pod);
         }
 
+        protected override void OnBeforeSelect(TreeViewCancelEventArgs e)
+        {
+            // disable selection for all nodes
+            e.Cancel = true;
+        }
 
         internal void AppendText(string text)
         {

--- a/Tools/Pipeline/Windows/Controls/FilterOutputControl.cs
+++ b/Tools/Pipeline/Windows/Controls/FilterOutputControl.cs
@@ -87,14 +87,6 @@ namespace MonoGame.Tools.Pipeline.Windows.Controls
                     AddSubItem(tn, text);
                     break;
                 case OutputState.BuildError:
-
-                    if (_prevFilename != outputParser.Filename)
-                    {
-                        tn = AddItem(BuildIcons.Processing, "Building " + GetRelativePath(outputParser.Filename));
-                        tn.ToolTipText = outputParser.Filename;
-                        AddSubItem(tn, outputParser.Filename);
-                    }
-
                     _lastTreeNode.ImageIndex = BuildIcons.Fail;
                     _lastTreeNode.SelectedImageIndex = BuildIcons.Fail;
                     _lastTreeNode.ToolTipText += Environment.NewLine + Environment.NewLine + outputParser.ErrorMessage;

--- a/Tools/Pipeline/Windows/Controls/FilterOutputControl.cs
+++ b/Tools/Pipeline/Windows/Controls/FilterOutputControl.cs
@@ -74,7 +74,7 @@ namespace MonoGame.Tools.Pipeline.Windows.Controls
                 tn.ToolTipText = text;
                 AddSubItem(tn, text.Substring(9));
             }
-            else if (File.Exists(text))
+            else if (Char.IsLetter(text[0]) && text[1]==':' && !text.Contains("error"))
             {
                 var tn = AddItem(BuildIcons.Processing, "Building " + GetRelativePath(text));
                 tn.ToolTipText = text;

--- a/Tools/Pipeline/Windows/Controls/FilterOutputControl.cs
+++ b/Tools/Pipeline/Windows/Controls/FilterOutputControl.cs
@@ -1,0 +1,138 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.IO;
+using System.Windows.Forms;
+
+namespace MonoGame.Tools.Pipeline.Windows.Controls
+{
+    public partial class FilterOutputControl : TreeView
+    {
+        const int WM_VSCROLL = 0x0115;
+        const int SB_BOTTOM  = 0x07;
+        [System.Runtime.InteropServices.DllImport("user32.dll", CharSet = System.Runtime.InteropServices.CharSet.Auto, SetLastError = false)]
+        static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, int wParam, int lParam);
+
+        BuildIcons _buildIcons;
+        TreeNode tmpIter;
+        
+        Uri folderUri;
+        Uri outputUri;
+
+        public FilterOutputControl(): base()
+        {
+            this._buildIcons = new BuildIcons();
+            this.ImageList = _buildIcons.Icons;
+        }
+        
+        
+        internal void SetBaseFolder(IController controller)
+        {
+            string pl = ((PipelineController)controller).ProjectLocation;
+            if (!pl.EndsWith(System.IO.Path.DirectorySeparatorChar.ToString()))
+                pl += System.IO.Path.DirectorySeparatorChar;
+            folderUri = new Uri(pl);
+
+            string pod = ((PipelineController)controller).ProjectOutputDir;
+            if (!pod.EndsWith(System.IO.Path.DirectorySeparatorChar.ToString()))
+                pod += System.IO.Path.DirectorySeparatorChar;
+            pod = Path.Combine(pl, pod);
+            outputUri = new Uri(pod);
+        }
+
+
+        internal void AppendText(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+                return;
+
+            this.SuspendLayout();
+            this.BeginUpdate();
+
+            text = text.TrimEnd(new[] { ' ','\n','\r','\t' });
+            
+            if (text.StartsWith("Build "))
+            {
+                AddItem(BuildIcons.BeginEnd, text);
+            }
+            else if (text.StartsWith("Time "))
+            {
+                tmpIter.Text = tmpIter.Text.TrimEnd(new[] {'.', ' '} ) + ", " + text;
+                SendMessage(this.Handle, WM_VSCROLL, SB_BOTTOM, 0); //scroll down to the end
+            }
+            else if (text.StartsWith("Skipping"))
+            {
+                var tn = AddItem(BuildIcons.Skip, "Skipping " + GetRelativePath(text.Substring(9)));
+                tn.ToolTipText = text; 
+                AddSubItem(tn, text.Substring(9));
+            }
+            else if (text.StartsWith("Cleaning"))
+            {
+                var tn = AddItem(BuildIcons.Clean, "Cleaning " + GetRelativeOutputPath(text.Substring(9)));
+                tn.ToolTipText = text;
+                AddSubItem(tn, text.Substring(9));
+            }
+            else if (File.Exists(text))
+            {
+                var tn = AddItem(BuildIcons.Processing, "Building " + GetRelativePath(text));
+                tn.ToolTipText = text;
+                AddSubItem(tn, text);
+            }
+            else
+            {
+                if (text.ToLower().Contains("error") || (text.Contains("System") && text.Contains("Exception")))
+                {
+                    tmpIter.ImageIndex = BuildIcons.Fail;
+                    tmpIter.SelectedImageIndex = BuildIcons.Fail;
+                    tmpIter.ToolTipText += Environment.NewLine;
+                }
+
+                AddSubItem(tmpIter, text);
+                tmpIter.ToolTipText += Environment.NewLine + text;
+            }
+
+            this.EndUpdate();
+            this.ResumeLayout();  
+        }
+        
+        private TreeNode AddItem(int iconIdx, string text)
+        {
+            if (tmpIter != null && tmpIter.ImageIndex == BuildIcons.Processing)
+            {
+                tmpIter.ImageIndex = BuildIcons.Succeed;
+                tmpIter.SelectedImageIndex = BuildIcons.Succeed;
+            }
+            
+            tmpIter = new TreeNode(text, iconIdx, iconIdx);
+            this.Nodes.Add(tmpIter);
+            //tmpIter.EnsureVisible(); // too much flicker & doesn't work between BeginUpdate()/EndUpdate()
+            SendMessage(this.Handle, WM_VSCROLL, SB_BOTTOM, 0); //scroll down to the end
+            return tmpIter;
+        }
+
+        private static void AddSubItem(TreeNode treeNode, string text)
+        {
+            var subTreeNode = new TreeNode(text, BuildIcons.Null, BuildIcons.Null);
+            treeNode.Nodes.Add(subTreeNode);
+        }
+        
+        private string GetRelativePath(string path)
+        {
+            var pathUri = new Uri(path);
+            return Uri.UnescapeDataString(folderUri.MakeRelativeUri(pathUri).ToString().Replace('/', System.IO.Path.DirectorySeparatorChar));     
+        }
+
+        private string GetRelativeOutputPath(string path)
+        {
+            var pathUri = new Uri(path);
+            return Uri.UnescapeDataString(outputUri.MakeRelativeUri(pathUri).ToString().Replace('/', System.IO.Path.DirectorySeparatorChar));
+        }
+        
+        internal void Clear()
+        {
+            this.Nodes.Clear();
+        }
+    }
+}

--- a/Tools/Pipeline/Windows/Controls/TabControlEx.cs
+++ b/Tools/Pipeline/Windows/Controls/TabControlEx.cs
@@ -1,0 +1,41 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.ComponentModel;
+using System.Windows.Forms;
+
+namespace MonoGame.Tools.Pipeline.Windows.Controls
+{
+    public partial class TabControlEx : TabControl
+    {
+        const int TCM_ADJUSTRECT = 0x1328;
+
+        [Browsable(true)]
+        [EditorBrowsable(EditorBrowsableState.Always)]
+        [Category("Behavior")]
+        [DefaultValue(false)]
+        public bool HideTabHeader { get; set; }
+
+        public TabControlEx():base()
+        {
+        }
+
+        protected override void WndProc(ref Message m)
+        {
+            switch (m.Msg)
+            {
+                case TCM_ADJUSTRECT:
+                    if (HideTabHeader && !DesignMode)
+                    {
+                        m.Result = (IntPtr)1;
+                        return;
+                    }
+                    break;
+            }
+            
+            base.WndProc(ref m);
+        }        
+    }
+}

--- a/Tools/Pipeline/Windows/MainView.Designer.cs
+++ b/Tools/Pipeline/Windows/MainView.Designer.cs
@@ -42,7 +42,11 @@ namespace MonoGame.Tools.Pipeline
             System.Windows.Forms.SplitContainer _splitEditorOutput;
             this._treeView = new MonoGame.Tools.Pipeline.MultiSelectTreeview();
             this._propertyGrid = new System.Windows.Forms.PropertyGrid();
+            this._outputTabs = new MonoGame.Tools.Pipeline.Windows.Controls.TabControlEx();
+            this._outputTabPage1 = new System.Windows.Forms.TabPage();
             this._outputWindow = new System.Windows.Forms.RichTextBox();
+            this._outputTabPage2 = new System.Windows.Forms.TabPage();
+            this._filterOutputWindow = new MonoGame.Tools.Pipeline.Windows.Controls.FilterOutputControl();
             this._mainMenu = new System.Windows.Forms.MenuStrip();
             this._fileMenu = new System.Windows.Forms.ToolStripMenuItem();
             this._newProjectMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -72,6 +76,7 @@ namespace MonoGame.Tools.Pipeline
             this._rebuildMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._cleanMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
+            this._filterOutputMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._debuggerMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._cancelBuildSeparator = new System.Windows.Forms.ToolStripSeparator();
             this._cancelBuildMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -105,6 +110,9 @@ namespace MonoGame.Tools.Pipeline
             _splitEditorOutput.Panel1.SuspendLayout();
             _splitEditorOutput.Panel2.SuspendLayout();
             _splitEditorOutput.SuspendLayout();
+            this._outputTabs.SuspendLayout();
+            this._outputTabPage1.SuspendLayout();
+            this._outputTabPage2.SuspendLayout();
             this._mainMenu.SuspendLayout();
             this._treeContextMenu.SuspendLayout();
             this.SuspendLayout();
@@ -162,6 +170,7 @@ namespace MonoGame.Tools.Pipeline
             // 
             // _propertyGrid
             // 
+            this._propertyGrid.CategoryForeColor = System.Drawing.SystemColors.InactiveCaptionText;
             this._propertyGrid.Dock = System.Windows.Forms.DockStyle.Fill;
             this._propertyGrid.Location = new System.Drawing.Point(0, 0);
             this._propertyGrid.Name = "_propertyGrid";
@@ -181,11 +190,38 @@ namespace MonoGame.Tools.Pipeline
             // 
             // _splitEditorOutput.Panel2
             // 
-            _splitEditorOutput.Panel2.Controls.Add(this._outputWindow);
+            _splitEditorOutput.Panel2.Controls.Add(this._outputTabs);
             _splitEditorOutput.Size = new System.Drawing.Size(784, 537);
             _splitEditorOutput.SplitterDistance = 249;
             _splitEditorOutput.TabIndex = 2;
             _splitEditorOutput.TabStop = false;
+            // 
+            // _outputTabs
+            // 
+            this._outputTabs.Appearance = System.Windows.Forms.TabAppearance.FlatButtons;
+            this._outputTabs.Controls.Add(this._outputTabPage1);
+            this._outputTabs.Controls.Add(this._outputTabPage2);
+            this._outputTabs.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._outputTabs.HideTabHeader = true;
+            this._outputTabs.Location = new System.Drawing.Point(0, 0);
+            this._outputTabs.Margin = new System.Windows.Forms.Padding(0);
+            this._outputTabs.Name = "_outputTabs";
+            this._outputTabs.Padding = new System.Drawing.Point(0, 0);
+            this._outputTabs.SelectedIndex = 0;
+            this._outputTabs.Size = new System.Drawing.Size(531, 537);
+            this._outputTabs.TabIndex = 0;
+            this._outputTabs.TabStop = false;
+            // 
+            // _outputTabPage1
+            // 
+            this._outputTabPage1.Controls.Add(this._outputWindow);
+            this._outputTabPage1.Location = new System.Drawing.Point(4, 25);
+            this._outputTabPage1.Margin = new System.Windows.Forms.Padding(0);
+            this._outputTabPage1.Name = "_outputTabPage1";
+            this._outputTabPage1.Size = new System.Drawing.Size(523, 508);
+            this._outputTabPage1.TabIndex = 0;
+            this._outputTabPage1.Text = "_outputTabPage1";
+            this._outputTabPage1.UseVisualStyleBackColor = true;
             // 
             // _outputWindow
             // 
@@ -195,10 +231,36 @@ namespace MonoGame.Tools.Pipeline
             this._outputWindow.Name = "_outputWindow";
             this._outputWindow.ReadOnly = true;
             this._outputWindow.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.Vertical;
-            this._outputWindow.Size = new System.Drawing.Size(531, 537);
+            this._outputWindow.Size = new System.Drawing.Size(523, 508);
             this._outputWindow.TabIndex = 0;
             this._outputWindow.TabStop = false;
             this._outputWindow.Text = "";
+            // 
+            // _outputTabPage2
+            // 
+            this._outputTabPage2.Controls.Add(this._filterOutputWindow);
+            this._outputTabPage2.Location = new System.Drawing.Point(4, 25);
+            this._outputTabPage2.Margin = new System.Windows.Forms.Padding(0);
+            this._outputTabPage2.Name = "_outputTabPage2";
+            this._outputTabPage2.Size = new System.Drawing.Size(523, 508);
+            this._outputTabPage2.TabIndex = 0;
+            this._outputTabPage2.Text = "_outputTabPage2";
+            this._outputTabPage2.UseVisualStyleBackColor = true;
+            // 
+            // _filterOutputWindow
+            // 
+            this._filterOutputWindow.BackColor = System.Drawing.SystemColors.Control;
+            this._filterOutputWindow.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._filterOutputWindow.FullRowSelect = true;
+            this._filterOutputWindow.ImageIndex = 0;
+            this._filterOutputWindow.SelectedImageIndex = 0;
+            this._filterOutputWindow.ItemHeight = 20;
+            this._filterOutputWindow.Location = new System.Drawing.Point(0, 0);
+            this._filterOutputWindow.Name = "_filterOutputWindow";
+            this._filterOutputWindow.ShowLines = false;
+            this._filterOutputWindow.ShowNodeToolTips = true;
+            this._filterOutputWindow.Size = new System.Drawing.Size(523, 508);
+            this._filterOutputWindow.TabIndex = 0;
             // 
             // _mainMenu
             // 
@@ -406,6 +468,7 @@ namespace MonoGame.Tools.Pipeline
             this._rebuildMenuItem,
             this._cleanMenuItem,
             this.toolStripSeparator5,
+            this._filterOutputMenuItem,
             this._debuggerMenuItem,
             this._cancelBuildSeparator,
             this._cancelBuildMenuItem});
@@ -439,6 +502,16 @@ namespace MonoGame.Tools.Pipeline
             // 
             this.toolStripSeparator5.Name = "toolStripSeparator5";
             this.toolStripSeparator5.Size = new System.Drawing.Size(170, 6);
+            // 
+            // _filterOutputMenuItem
+            // 
+            this._filterOutputMenuItem.Checked = true;
+            this._filterOutputMenuItem.CheckOnClick = true;
+            this._filterOutputMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this._filterOutputMenuItem.Name = "_filterOutputMenuItem";
+            this._filterOutputMenuItem.Size = new System.Drawing.Size(173, 22);
+            this._filterOutputMenuItem.Text = "Filter Output";
+            this._filterOutputMenuItem.CheckedChanged += new System.EventHandler(this.FilterOutputMenuItem_CheckedChanged);
             // 
             // _debuggerMenuItem
             // 
@@ -602,6 +675,7 @@ namespace MonoGame.Tools.Pipeline
             this.ClientSize = new System.Drawing.Size(784, 561);
             this.Controls.Add(_splitEditorOutput);
             this.Controls.Add(this._mainMenu);
+            this.DoubleBuffered = true;
             this.MainMenuStrip = this._mainMenu;
             this.MinimumSize = new System.Drawing.Size(320, 240);
             this.Name = "MainView";
@@ -619,6 +693,9 @@ namespace MonoGame.Tools.Pipeline
             _splitEditorOutput.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(_splitEditorOutput)).EndInit();
             _splitEditorOutput.ResumeLayout(false);
+            this._outputTabs.ResumeLayout(false);
+            this._outputTabPage1.ResumeLayout(false);
+            this._outputTabPage2.ResumeLayout(false);
             this._mainMenu.ResumeLayout(false);
             this._mainMenu.PerformLayout();
             this._treeContextMenu.ResumeLayout(false);
@@ -645,6 +722,9 @@ namespace MonoGame.Tools.Pipeline
         private System.Windows.Forms.ToolStripMenuItem _viewHelpMenuItem;
         private System.Windows.Forms.ToolStripMenuItem _aboutMenuItem;
         private System.Windows.Forms.ToolStripMenuItem _saveAsMenuItem;
+        private MonoGame.Tools.Pipeline.Windows.Controls.TabControlEx _outputTabs;
+        private System.Windows.Forms.TabPage _outputTabPage1;
+        private System.Windows.Forms.TabPage _outputTabPage2;
         private System.Windows.Forms.RichTextBox _outputWindow;
         private System.Windows.Forms.ToolStripMenuItem _closeMenuItem;
         private System.Windows.Forms.ToolStripMenuItem _importProjectMenuItem;
@@ -662,6 +742,7 @@ namespace MonoGame.Tools.Pipeline
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
         private System.Windows.Forms.ToolStripMenuItem _treeRebuildMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
+        private System.Windows.Forms.ToolStripMenuItem _filterOutputMenuItem;
         private System.Windows.Forms.ToolStripMenuItem _debuggerMenuItem;
         private System.Windows.Forms.ToolStripSeparator _treeSeparator1;
         private System.Windows.Forms.ToolStripMenuItem _treeOpenFileMenuItem;
@@ -681,6 +762,7 @@ namespace MonoGame.Tools.Pipeline
         private ToolStripMenuItem toolStripMenuItem6;
         private ToolStripMenuItem _renameMenuItem;
         private ToolStripMenuItem _treeRenameMenuItem;
+        private Windows.Controls.FilterOutputControl _filterOutputWindow;
     }
 }
 


### PR DESCRIPTION
Add a Filtered output view similar to https://github.com/mono/MonoGame/pull/4168.

There are few hacks to hide the Header from the TabControl and also to scroll the treeview without flickering.

One difference from GTK version is that 'Cleaning' show short paths relative to project Output Directory.

Another is that I didn't merge the two views under one control , everything in Winforms is public and visible from MainForm, the original _outputView had already too many references and not sure the best way to do this in WinForms.
