### PR TITLE
Add automated.build so I can track MonoGame upstream on my build server

### DIFF
--- a/automated.build
+++ b/automated.build
@@ -1,0 +1,18 @@
+#version 1
+
+set build-target Rebuild
+set build-property Configuration Release
+set execute-configuration Release
+
+if host Windows
+  set target-platforms Windows,WindowsGL,Linux,Web,Android,Ouya,Windows8,WindowsPhone,WindowsPhone81,WindowsUniversal
+endif
+if host MacOS
+  set target-platforms Linux,MacOS,iOS,Android,Ouya
+endif
+if host Linux
+  set target-platforms Windows,WindowsGL,Linux,Web
+endif
+
+generate
+build


### PR DESCRIPTION
I expect this not to initially work for all of the platforms, but I'm submitting the PR so it runs on the MG build server.

This uses the new automated build script functionality in Protobuild to generate and build for all relevant platforms.  It simplifies the `default.build` script greatly, and removes a bunch of conditional logic that is no longer necessary.

I'd like to get the `automated.build` script also running the tests, but since these run through NUnit and make use of a NAnt script, I don't want to do that until I know whether or not it'll impact the reporting of tests in TeamCity.

(I also removed the old GenerateProject / GenerateSolution files since they're no longer needed with WindowsUniversal and tvOS being merged into Protobuild).