### PR TITLE
LerpPrecise for Color and Vector2/3/4

### DIFF
--- a/MonoGame.Framework/Color.cs
+++ b/MonoGame.Framework/Color.cs
@@ -1719,6 +1719,25 @@ namespace Microsoft.Xna.Framework
                 (int)MathHelper.Lerp(value1.B, value2.B, amount),
                 (int)MathHelper.Lerp(value1.A, value2.A, amount) );
         }
+
+        /// <summary>
+        /// Performs linear interpolation of <see cref="Color"/> using <see cref="MathHelper.LerpPrecise"/> on MathHelper.
+        /// Less efficient but more precise compared to <see cref="Color.Lerp"/>.
+        /// See remarks section of <see cref="MathHelper.LerpPrecise"/> on MathHelper for more info.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Color"/>.</param>
+        /// <param name="value2">Destination <see cref="Color"/>.</param>
+        /// <param name="amount">Interpolation factor.</param>
+        /// <returns>Interpolated <see cref="Color"/>.</returns>
+        public static Color LerpPrecise(Color value1, Color value2, Single amount)
+        {
+            amount = MathHelper.Clamp(amount, 0, 1);
+            return new Color(
+                (int)MathHelper.LerpPrecise(value1.R, value2.R, amount),
+                (int)MathHelper.LerpPrecise(value1.G, value2.G, amount),
+                (int)MathHelper.LerpPrecise(value1.B, value2.B, amount),
+                (int)MathHelper.LerpPrecise(value1.A, value2.A, amount));
+        }
 		
 	/// <summary>
         /// Multiply <see cref="Color"/> by value.

--- a/MonoGame.Framework/MathHelper.cs
+++ b/MonoGame.Framework/MathHelper.cs
@@ -162,10 +162,10 @@ namespace Microsoft.Xna.Framework
         /// <param name="value2">Destination value.</param>
         /// <param name="amount">Value between 0 and 1 indicating the weight of value2.</param>
         /// <returns>Interpolated value.</returns> 
-        /// <remarks>This method performs the linear interpolation based on the following formula.
-        /// <c>value1 + (value2 - value1) * amount</c>
+        /// <remarks>This method performs the linear interpolation based on the following formula:
+        /// <code>value1 + (value2 - value1) * amount</code>.
         /// Passing amount a value of 0 will cause value1 to be returned, a value of 1 will cause value2 to be returned.
-        /// <seealso cref="MathHelper.LerpPrecise"/> For a less efficient version with more precision around edge cases.
+        /// See <see cref="MathHelper.LerpPrecise"/> for a less efficient version with more precision around edge cases.
         /// </remarks>
         public static float Lerp(float value1, float value2, float amount)
         {
@@ -182,8 +182,8 @@ namespace Microsoft.Xna.Framework
         /// <param name="value2">Destination value.</param>
         /// <param name="amount">Value between 0 and 1 indicating the weight of value2.</param>
         /// <returns>Interpolated value.</returns>
-        /// <remarks>This method performs the linear interpolation based on the following formula.
-        /// <c> ((1 - amount) * value1) + (value2 * amount) </c>
+        /// <remarks>This method performs the linear interpolation based on the following formula:
+        /// <code>((1 - amount) * value1) + (value2 * amount)</code>.
         /// Passing amount a value of 0 will cause value1 to be returned, a value of 1 will cause value2 to be returned.
         /// This method does not have the floating point precision issue that <see cref="MathHelper.Lerp"/> has.
         /// i.e. If there is a big gap between value1 and value2 in magnitude (e.g. value1=10000000000000000, value2=1),
@@ -193,7 +193,7 @@ namespace Microsoft.Xna.Framework
         /// Relevant Wikipedia Article: https://en.wikipedia.org/wiki/Linear_interpolation#Programming_language_support
         /// Relevant StackOverflow Answer: http://stackoverflow.com/questions/4353525/floating-point-linear-interpolation#answer-23716956
         /// </remarks>
-        public static object LerpPrecise(float value1, float value2, float amount)
+        public static float LerpPrecise(float value1, float value2, float amount)
         {
             return ((1 - amount) * value1) + (value2 * amount);
         }

--- a/MonoGame.Framework/Vector2.cs
+++ b/MonoGame.Framework/Vector2.cs
@@ -598,6 +598,39 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
+        /// Creates a new <see cref="Vector2"/> that contains linear interpolation of the specified vectors.
+        /// Uses <see cref="MathHelper.LerpPrecise"/> on MathHelper for the interpolation.
+        /// Less efficient but more precise compared to <see cref="Vector2.Lerp(Vector2, Vector2, float)"/>.
+        /// See remarks section of <see cref="MathHelper.LerpPrecise"/> on MathHelper for more info.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
+        /// <returns>The result of linear interpolation of the specified vectors.</returns>
+        public static Vector2 LerpPrecise(Vector2 value1, Vector2 value2, float amount)
+        {
+            return new Vector2(
+                MathHelper.LerpPrecise(value1.X, value2.X, amount),
+                MathHelper.LerpPrecise(value1.Y, value2.Y, amount));
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector2"/> that contains linear interpolation of the specified vectors.
+        /// Uses <see cref="MathHelper.LerpPrecise"/> on MathHelper for the interpolation.
+        /// Less efficient but more precise compared to <see cref="Vector2.Lerp(ref Vector2, ref Vector2, float, out Vector2)"/>.
+        /// See remarks section of <see cref="MathHelper.LerpPrecise"/> on MathHelper for more info.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
+        /// <param name="result">The result of linear interpolation of the specified vectors as an output parameter.</param>
+        public static void LerpPrecise(ref Vector2 value1, ref Vector2 value2, float amount, out Vector2 result)
+        { 
+            result.X = MathHelper.LerpPrecise(value1.X, value2.X, amount);
+            result.Y = MathHelper.LerpPrecise(value1.Y, value2.Y, amount);
+        }
+
+        /// <summary>
         /// Creates a new <see cref="Vector2"/> that contains a maximal values from the two vectors.
         /// </summary>
         /// <param name="value1">The first vector.</param>

--- a/MonoGame.Framework/Vector3.cs
+++ b/MonoGame.Framework/Vector3.cs
@@ -606,6 +606,41 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains linear interpolation of the specified vectors.
+        /// Uses <see cref="MathHelper.LerpPrecise"/> on MathHelper for the interpolation.
+        /// Less efficient but more precise compared to <see cref="Vector3.Lerp(Vector3, Vector3, float)"/>.
+        /// See remarks section of <see cref="MathHelper.LerpPrecise"/> on MathHelper for more info.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
+        /// <returns>The result of linear interpolation of the specified vectors.</returns>
+        public static Vector3 LerpPrecise(Vector3 value1, Vector3 value2, float amount)
+        {
+            return new Vector3(
+                MathHelper.LerpPrecise(value1.X, value2.X, amount),
+                MathHelper.LerpPrecise(value1.Y, value2.Y, amount),
+                MathHelper.LerpPrecise(value1.Z, value2.Z, amount));
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains linear interpolation of the specified vectors.
+        /// Uses <see cref="MathHelper.LerpPrecise"/> on MathHelper for the interpolation.
+        /// Less efficient but more precise compared to <see cref="Vector3.Lerp(ref Vector3, ref Vector3, float, out Vector3)"/>.
+        /// See remarks section of <see cref="MathHelper.LerpPrecise"/> on MathHelper for more info.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
+        /// <param name="result">The result of linear interpolation of the specified vectors as an output parameter.</param>
+        public static void LerpPrecise(ref Vector3 value1, ref Vector3 value2, float amount, out Vector3 result)
+        {
+            result.X = MathHelper.LerpPrecise(value1.X, value2.X, amount);
+            result.Y = MathHelper.LerpPrecise(value1.Y, value2.Y, amount);
+            result.Z = MathHelper.LerpPrecise(value1.Z, value2.Z, amount);
+        }
+
+        /// <summary>
         /// Creates a new <see cref="Vector3"/> that contains a maximal values from the two vectors.
         /// </summary>
         /// <param name="value1">The first vector.</param>

--- a/MonoGame.Framework/Vector4.cs
+++ b/MonoGame.Framework/Vector4.cs
@@ -567,6 +567,43 @@ namespace Microsoft.Xna.Framework
         }
 
         /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains linear interpolation of the specified vectors.
+        /// Uses <see cref="MathHelper.LerpPrecise"/> on MathHelper for the interpolation.
+        /// Less efficient but more precise compared to <see cref="Vector4.Lerp(Vector4, Vector4, float)"/>.
+        /// See remarks section of <see cref="MathHelper.LerpPrecise"/> on MathHelper for more info.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
+        /// <returns>The result of linear interpolation of the specified vectors.</returns>
+        public static Vector4 LerpPrecise(Vector4 value1, Vector4 value2, float amount)
+        {
+            return new Vector4(
+                MathHelper.LerpPrecise(value1.X, value2.X, amount),
+                MathHelper.LerpPrecise(value1.Y, value2.Y, amount),
+                MathHelper.LerpPrecise(value1.Z, value2.Z, amount),
+                MathHelper.LerpPrecise(value1.W, value2.W, amount));
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains linear interpolation of the specified vectors.
+        /// Uses <see cref="MathHelper.LerpPrecise"/> on MathHelper for the interpolation.
+        /// Less efficient but more precise compared to <see cref="Vector4.Lerp(ref Vector4, ref Vector4, float, out Vector4)"/>.
+        /// See remarks section of <see cref="MathHelper.LerpPrecise"/> on MathHelper for more info.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
+        /// <param name="result">The result of linear interpolation of the specified vectors as an output parameter.</param>
+        public static void LerpPrecise(ref Vector4 value1, ref Vector4 value2, float amount, out Vector4 result)
+        {
+            result.X = MathHelper.LerpPrecise(value1.X, value2.X, amount);
+            result.Y = MathHelper.LerpPrecise(value1.Y, value2.Y, amount);
+            result.Z = MathHelper.LerpPrecise(value1.Z, value2.Z, amount);
+            result.W = MathHelper.LerpPrecise(value1.W, value2.W, amount);
+        }
+
+        /// <summary>
         /// Creates a new <see cref="Vector4"/> that contains a maximal values from the two vectors.
         /// </summary>
         /// <param name="value1">The first vector.</param>


### PR DESCRIPTION
Adds LerpPrecise for Color, Vector2, Vector3, and Vector4
Includes a couple of minor documentation tweaks

Also has the fix for MathHelper.LerpPrecise return type, because it looks like #4280 was not merged