### PR TITLE
Moved MAX_PLAYING_INSTANCES

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -25,6 +25,28 @@ namespace Microsoft.Xna.Framework.Audio
 {
     public sealed partial class SoundEffect : IDisposable
     {
+#if DESKTOPGL || ANGLE
+
+        // These platforms are only limited by memory.
+        internal const int MAX_PLAYING_INSTANCES = int.MaxValue;
+
+#elif MONOMAC
+
+        // Reference: http://stackoverflow.com/questions/3894044/maximum-number-of-openal-sound-buffers-on-iphone
+        internal const int MAX_PLAYING_INSTANCES = 256;
+
+#elif IOS
+
+        // Reference: http://stackoverflow.com/questions/3894044/maximum-number-of-openal-sound-buffers-on-iphone
+        internal const int MAX_PLAYING_INSTANCES = 32;
+
+#elif ANDROID
+
+        // Set to the same as OpenAL on iOS
+        internal const int MAX_PLAYING_INSTANCES = 32;
+
+#endif
+
         internal byte[] _data;
 
 		internal float Rate { get; set; }

--- a/MonoGame.Framework/Audio/SoundEffect.Web.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.Web.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Xna.Framework.Audio
 {
     public sealed partial class SoundEffect : IDisposable
     {
+        // This platform is only limited by memory.
+        internal const int MAX_PLAYING_INSTANCES = int.MaxValue;
+
         private void PlatformLoadAudioStream(Stream s)
         {
         }

--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -14,6 +14,18 @@ namespace Microsoft.Xna.Framework.Audio
 {
     public sealed partial class SoundEffect : IDisposable
     {
+#if WINDOWS || (WINRT && !WINDOWS_PHONE)
+
+        // These platforms are only limited by memory.
+        private const int MAX_PLAYING_INSTANCES = int.MaxValue;
+
+#elif WINDOWS_PHONE
+
+        // Reference: http://msdn.microsoft.com/en-us/library/microsoft.xna.framework.audio.instanceplaylimitexception.aspx
+        private const int MAX_PLAYING_INSTANCES = 64;
+
+#endif
+
         #region Static Fields & Properties
 
         internal static XAudio2 Device { get; private set; }

--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Xna.Framework.Audio
 #if WINDOWS || (WINRT && !WINDOWS_PHONE)
 
         // These platforms are only limited by memory.
-        private const int MAX_PLAYING_INSTANCES = int.MaxValue;
+        internal const int MAX_PLAYING_INSTANCES = int.MaxValue;
 
 #elif WINDOWS_PHONE
 
         // Reference: http://msdn.microsoft.com/en-us/library/microsoft.xna.framework.audio.instanceplaylimitexception.aspx
-        private const int MAX_PLAYING_INSTANCES = 64;
+        internal const int MAX_PLAYING_INSTANCES = 64;
 
 #endif
 

--- a/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Xna.Framework.Audio
         {
             // Reduce garbage generation by allocating enough capacity for
             // the maximum playing instances or at least some reasonable value.
-            var maxInstances = MAX_PLAYING_INSTANCES < 1024 ? MAX_PLAYING_INSTANCES : 1024;
+            var maxInstances = SoundEffect.MAX_PLAYING_INSTANCES < 1024 ? SoundEffect.MAX_PLAYING_INSTANCES : 1024;
             _playingInstances = new List<SoundEffectInstance>(maxInstances);
             _pooledInstances = new List<SoundEffectInstance>(maxInstances);
         }
@@ -56,7 +56,7 @@ namespace Microsoft.Xna.Framework.Audio
         {
             get
             {
-                return _playingInstances.Count < MAX_PLAYING_INSTANCES;
+                return _playingInstances.Count < SoundEffect.MAX_PLAYING_INSTANCES;
             }
         }
 


### PR DESCRIPTION
This PR moves MAX_PLAYING_INSTANCES into the partial `SoundEffect` file so that it can be overloaded on console platforms.