### PR TITLE
Fix UAP/UWP Build

### DIFF
--- a/Build/Module.xml
+++ b/Build/Module.xml
@@ -7,9 +7,11 @@
   <DefaultWindowsPlatforms>Android,Angle,Linux,Ouya,Windows8,Windows,WindowsGL,WindowsPhone,WindowsPhone81,WindowsUAP,iOS,tvOS</DefaultWindowsPlatforms>
   <SupportedPlatforms>Android,Angle,Linux,Ouya,Windows8,Windows,WindowsGL,WindowsPhone,WindowsPhone81,WindowsUAP,iOS,MacOS,Web,tvOS</SupportedPlatforms>
   <DisableSynchronisation>true</DisableSynchronisation>
+  <!--
   <GenerateNuGetRepositories>true</GenerateNuGetRepositories>
   <Packages>
     <Package Uri="https-git://github.com/OutOfOrder/MonoKickstart.git" Folder="ThirdParty/Kickstart" GitRef="master" />
     <Package Uri="https-git://github.com/Mono-Game/MonoGame.Dependencies.git" Folder="ThirdParty/Dependencies" GitRef="master" />
   </Packages>
+  -->
 </Module>

--- a/default.build
+++ b/default.build
@@ -171,6 +171,14 @@
     <if test="${os == 'Win32NT'}">
       <if test="${file::exists('c:\Program Files (x86)\MSBuild\Microsoft\WindowsXaml\v14.0\Microsoft.Windows.UI.Xaml.CSharp.targets')}">
         <exec program="Protobuild" commandline="-generate WindowsUAP" />
+
+        <!--
+            Currently MSBuild doesn't restore the nuget packages like buiding from the
+            IDE does.  So we have to do it ourselves using the recommended work around.
+        -->
+        <exec program="${nuget3path}\nuget.exe " commandline='restore MonoGame.Framework\MonoGame.Framework.WindowsUAP.project.json -NonInteractive' />
+        <exec program="${nuget3path}\nuget.exe " commandline='restore MonoGame.Framework\MonoGame.Framework.Net.WindowsUAP.project.json -NonInteractive' />
+
         <exec program="${msbuild14dir}\msbuild.exe " commandline='MonoGame.Framework.WindowsUAP.sln /t:Clean /p:Configuration=Release /p:Platform="Any CPU"' />
         <exec program="${msbuild14dir}\msbuild.exe " commandline='MonoGame.Framework.WindowsUAP.sln /t:Build /p:Configuration=Release /p:Platform="Any CPU"' />
       </if>


### PR DESCRIPTION
This PR fixes the Windows UAP/UWP build which was silently broken for months now.

The main issue is that MSBuild doesn't perform the NuGet restore like running from the IDE.  So we applied the recommended work around.

Also we detected that Protobuild was smashing over the existing dependences and kickstart folders with its own git operation on the build agents.  I've disabled this Protobuild feature until that can be fixed.

More details in https://github.com/mono/MonoGame/pull/4323.
