### PR TITLE
[Pipeline] indent log

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
@@ -565,6 +565,8 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             var rebuild = pipelineEvent.NeedsRebuild(this, cachedEvent);
             if (!rebuild)
             {
+                Logger.LogMessage("Skipping {0}", pipelineEvent.SourceFile);
+
                 // While this asset doesn't need to be rebuilt the dependent assets might.
                 foreach (var asset in cachedEvent.BuildAsset)
                 {
@@ -610,11 +612,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
 
                 // Store the new event into the intermediate folder.
                 pipelineEvent.Save(eventFilepath);
-            }
-            else
-            {
-                Logger.LogMessage("Skipping {0}", pipelineEvent.SourceFile);
-            }
+            }           
 
             Logger.PopFile();
         }

--- a/MonoGame.Framework.Content.Pipeline/ContentBuildLogger.cs
+++ b/MonoGame.Framework.Content.Pipeline/ContentBuildLogger.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
     {
         Stack<string> filenames = new Stack<string>();
 
+        protected string Indent { get { return String.Empty.PadLeft(Math.Max(0,filenames.Count - 1), '\t'); } }
+
         /// <summary>
         /// Gets or sets the base reference path used when reporting errors during the content build process.
         /// </summary>

--- a/MonoGame.Framework.Content.Pipeline/ContentBuildLogger.cs
+++ b/MonoGame.Framework.Content.Pipeline/ContentBuildLogger.cs
@@ -15,8 +15,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
     public abstract class ContentBuildLogger
     {
         Stack<string> filenames = new Stack<string>();
+        private int indentCount = 0;
 
-        protected string Indent { get { return String.Empty.PadLeft(Math.Max(0,filenames.Count - 1), '\t'); } }
+        protected string IndentString { get { return String.Empty.PadLeft(Math.Max(0, indentCount), '\t'); } }
 
         /// <summary>
         /// Gets or sets the base reference path used when reporting errors during the content build process.
@@ -111,6 +112,16 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
         public void PushFile(string filename)
         {
             filenames.Push(filename);
+        }
+
+        public void Indent()
+        {
+            indentCount++;
+        }
+
+        public void Unindent()
+        {
+            indentCount--;
         }
     }
 }

--- a/Tools/MGCB/ConsoleLogger.cs
+++ b/Tools/MGCB/ConsoleLogger.cs
@@ -11,13 +11,13 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
     {
         public override void LogMessage(string message, params object[] messageArgs)
         {
-			Console.WriteLine(message, messageArgs);
+			Console.WriteLine(Indent + message, messageArgs);
         }
 
         public override void LogImportantMessage(string message, params object[] messageArgs)
         {
             // TODO: How do i make it high importance?
-            Console.WriteLine(message, messageArgs);
+            Console.WriteLine(Indent + message, messageArgs);
         }
 
         public override void LogWarning(string helpLink, ContentIdentity contentIdentity, string message, params object[] messageArgs)

--- a/Tools/MGCB/ConsoleLogger.cs
+++ b/Tools/MGCB/ConsoleLogger.cs
@@ -11,13 +11,13 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
     {
         public override void LogMessage(string message, params object[] messageArgs)
         {
-			Console.WriteLine(Indent + message, messageArgs);
+			Console.WriteLine(IndentString + message, messageArgs);
         }
 
         public override void LogImportantMessage(string message, params object[] messageArgs)
         {
             // TODO: How do i make it high importance?
-            Console.WriteLine(Indent + message, messageArgs);
+            Console.WriteLine(IndentString + message, messageArgs);
         }
 
         public override void LogWarning(string helpLink, ContentIdentity contentIdentity, string message, params object[] messageArgs)


### PR DESCRIPTION
New Rebuild output:
```
Build started 18/12/2015 1:04:36 πμ

Cleaning P:/TestPipeline/bin/Windows/texUV_0.xnb
Cleaning P:/TestPipeline/bin/Windows/Model.xnb
P:/TestPipeline/Model.fbx
	P:/TestPipeline/texUV.png
	Skipping P:/TestPipeline/texUV.png
	Skipping P:/TestPipeline/texUV.png

Build 1 succeeded, 0 failed.
```

New Build output (Skipping):
```
Build started 18/12/2015 1:07:18 πμ

Skipping P:/TestPipeline/Model.fbx
	Skipping P:/TestPipeline/texUV.png

Build 1 succeeded, 0 failed.

Time elapsed 00:00:00.20.
```