### PR TITLE
Reduced garbage generation in SpriteBatcher

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatcher.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatcher.cs
@@ -119,6 +119,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 Array.Resize(ref _batchItemList, newSize);
                 for(int i=oldSize; i<newSize; i++)
                     _batchItemList[i]=new SpriteBatchItem();
+
+                EnsureArrayCapacity(Math.Min(newSize, MaxBatchSize));
             }
             var item = _batchItemList[_batchItemCount++];
             return item;
@@ -214,7 +216,6 @@ namespace Microsoft.Xna.Framework.Graphics
                 {
                     numBatchesToProcess = MaxBatchSize;
                 }
-                EnsureArrayCapacity(numBatchesToProcess);
                 // Draw the batches
                 for(int i = 0; i < numBatchesToProcess; i++, batchIndex++) 
                 {


### PR DESCRIPTION
I was doing some profiling of my game, and came across this:

![before](https://cloud.githubusercontent.com/assets/5249498/11946231/7ba8c8ae-a893-11e5-93a2-06ebd9e1a0c9.png)

What was happening was that the vertex array was only growing to exactly match the number of items in a batch, rather than growing by a percentage like the sprite batch array is. This could put a lot of load on the GC if the number of sprites being drawn was increasing over time (which was happening in my game) as the vertex array would continually be getting resized.

To resolve this, I changed the vertex array to grow in line with the sprite batch array instead. After profiling again, it now looks like this:

![after](https://cloud.githubusercontent.com/assets/5249498/11946313/29ff48ba-a894-11e5-883a-9709ea1f6546.png)