### PR TITLE
Fix for OS X OpenAL implementation when accessing a disposed source

### DIFF
--- a/MonoGame.Framework/Media/Song.NVorbis.cs
+++ b/MonoGame.Framework/Media/Song.NVorbis.cs
@@ -31,11 +31,18 @@ namespace Microsoft.Xna.Framework.Media
 		
         void PlatformDispose(bool disposing)
         {
+            if (stream == null)
+                return;
+
             stream.Dispose();
+            stream = null;
         }
 
         internal void Play(TimeSpan? startPosition)
         {
+            if (stream == null)
+                return;
+
             stream.Play();
             if (startPosition != null)
                 stream.SeekToPosition((TimeSpan)startPosition);
@@ -45,27 +52,42 @@ namespace Microsoft.Xna.Framework.Media
 
         internal void Resume()
         {
+            if (stream == null)
+                return;
+
             stream.Resume();
         }
 
         internal void Pause()
         {
+            if (stream == null)
+                return;
+
             stream.Pause();
         }
 
         internal void Stop()
         {
+            if (stream == null)
+                return;
+
             stream.Stop();
             _playCount = 0;
         }
 
         internal float Volume
         {
-            get { return _volume; }
+            get
+            {
+                if (stream == null)
+                    return 0.0f;
+                return _volume; 
+            }
             set
             {
                 _volume = value;
-                stream.Volume = _volume;
+                if (stream == null)
+                    stream.Volume = _volume;
             }
         }
 
@@ -73,6 +95,8 @@ namespace Microsoft.Xna.Framework.Media
         {
             get
             {
+                if (stream == null)
+                    return TimeSpan.FromSeconds(0.0);
                 return stream.GetPosition();
             }
         }

--- a/MonoGame.Framework/Media/Song.NVorbis.cs
+++ b/MonoGame.Framework/Media/Song.NVorbis.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Xna.Framework.Media
             set
             {
                 _volume = value;
-                if (stream == null)
+                if (stream != null)
                     stream.Volume = _volume;
             }
         }

--- a/MonoGame.Framework/Utilities/OggStream.cs
+++ b/MonoGame.Framework/Utilities/OggStream.cs
@@ -52,6 +52,8 @@ namespace MonoGame.Utilities
         public Action FinishedAction { get; private set; }
         public int BufferCount { get; private set; }
 
+        private bool _isDisposed = false;
+
         public OggStream(string filename, Action finishedAction = null, int bufferCount = DefaultBufferCount) : this(File.OpenRead(filename), finishedAction, bufferCount) { }
         public OggStream(Stream stream, Action finishedAction = null, int bufferCount = DefaultBufferCount)
         {
@@ -158,6 +160,9 @@ namespace MonoGame.Utilities
 
         public void Stop()
         {
+            if (_isDisposed)
+                return;
+
             var state = AL.GetSourceState(alSourceId);
             if (state == ALSourceState.Playing || state == ALSourceState.Paused)
                 StopPlayback();
@@ -243,8 +248,10 @@ namespace MonoGame.Utilities
 
             if (ALHelper.Efx.IsInitialized)
                 ALHelper.Efx.DeleteFilter(alFilterId);
-
+            
             ALHelper.Check();
+
+            _isDisposed = true;
         }
 
         void StopPlayback()

--- a/MonoGame.Framework/Utilities/OggStream.cs
+++ b/MonoGame.Framework/Utilities/OggStream.cs
@@ -52,8 +52,6 @@ namespace MonoGame.Utilities
         public Action FinishedAction { get; private set; }
         public int BufferCount { get; private set; }
 
-        private bool _isDisposed = false;
-
         public OggStream(string filename, Action finishedAction = null, int bufferCount = DefaultBufferCount) : this(File.OpenRead(filename), finishedAction, bufferCount) { }
         public OggStream(Stream stream, Action finishedAction = null, int bufferCount = DefaultBufferCount)
         {
@@ -160,9 +158,6 @@ namespace MonoGame.Utilities
 
         public void Stop()
         {
-            if (_isDisposed)
-                return;
-
             var state = AL.GetSourceState(alSourceId);
             if (state == ALSourceState.Playing || state == ALSourceState.Paused)
                 StopPlayback();
@@ -250,8 +245,6 @@ namespace MonoGame.Utilities
                 ALHelper.Efx.DeleteFilter(alFilterId);
             
             ALHelper.Check();
-
-            _isDisposed = true;
         }
 
         void StopPlayback()


### PR DESCRIPTION
It looks like OS X OpenAL implementation handles ```AL.GetSourceState``` differently. It raises an error flag if ```alSourceId``` is disposed, while on other systems it returns ```ALSourceState.Stopped``` with no error. Hence, calling ```OggStream.Stop()``` should be prevented if the stream has already been disposed, otherwise it just crash on OS X.

Fixes #4346 

More details in the issue report.

@cra0zy Mind reviewing this one?