### PR TITLE
Fix for OpenTK Viewport initialization

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -252,6 +252,12 @@ namespace Microsoft.Xna.Framework
                 PresentationParameters parms = device.PresentationParameters;
                 parms.BackBufferHeight = (int)bounds.Height;
                 parms.BackBufferWidth = (int)bounds.Width;
+
+                var viewport = new Viewport(0, 0,
+                            parms.BackBufferWidth,
+                            parms.BackBufferHeight);
+
+                device.Viewport = viewport;
             }
 
             if (graphicsDeviceManager.IsFullScreen != isCurrentlyFullScreen)


### PR DESCRIPTION
Fixes #4354

> I've noticed a discrepancy between Windows and DesktopGL platforms regarding GraphicsDevice.Viewport initialization.

> On Windows, the GraphicsDevice.Viewport is initialized by GraphicsDeviceManager.ApplyChanges(), but on DesktopGL, GraphicsDeviceManager.ApplyChanges() doesn't initialize it.
It seems to be only initialized upon Game.Initialize() (base class).

@cra0zy Would mind reviewing it?