### PR TITLE
Updating TargetPlatformVersion to latest SDK (November 2015)

### DIFF
--- a/ProjectTemplates/VisualStudio2015/WindowsUniversal/Application.csproj
+++ b/ProjectTemplates/VisualStudio2015/WindowsUniversal/Application.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>$projectname$</AssemblyName>
     <DefaultLanguage>$currentuiculturename$</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.10240.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.10586.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>


### PR DESCRIPTION
Fixes #4369
 
This sets the target version to the current SDK while maintaining backward compatibility for anyone who only has the RTM version of the SDK installed.