### PR TITLE
WindowsDX: Fixed "HasVibrationMotor" properties

### DIFF
--- a/MonoGame.Framework/Input/GamePad.XInput.cs
+++ b/MonoGame.Framework/Input/GamePad.XInput.cs
@@ -132,8 +132,8 @@ namespace Microsoft.Xna.Framework.Input
             ret.HasLeftVibrationMotor = hasForceFeedback && capabilities.Vibration.LeftMotorSpeed > 0;
             ret.HasRightVibrationMotor = hasForceFeedback && capabilities.Vibration.RightMotorSpeed > 0;
 #else
-            ret.HasLeftVibrationMotor = false;
-            ret.HasRightVibrationMotor = false;
+            ret.HasLeftVibrationMotor = (capabilities.Vibration.LeftMotorSpeed > 0);
+            ret.HasRightVibrationMotor = (capabilities.Vibration.RightMotorSpeed > 0);
 #endif
 
             // other


### PR DESCRIPTION
Fixes #4395 

The `SharpDX.XInput.CapabilityFlags.FfbSupported` (force-feedback) flag is not available in DirectX 11.0. However, it seems sufficient to just check the "motor speed" properties to determine if vibration is supported.

So this should work, but I was only able to test it with XInput gamepads which have vibration motors.

If anyone actually has an XInput controller which doesn't have vibration motors, then it would be awesome if you could test this and confirm that the `HasLeftVibrationMotor` and `HasRightVibrationMotor` properties both return the expected values.