### PR TITLE
Gtk Pipeline, Use Common Filter Output Code and minor bugfix

### DIFF
--- a/Tools/Pipeline/Common/OutputParser.cs
+++ b/Tools/Pipeline/Common/OutputParser.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Text.RegularExpressions;
 
-namespace MonoGame.Tools.Pipeline.Common
+namespace MonoGame.Tools.Pipeline
 {
     enum OutputState
     {
@@ -33,8 +33,8 @@ namespace MonoGame.Tools.Pipeline.Common
 
 
         Regex _reBuildBegin = new Regex(@"^(Build started)\W+(?<buildBeginTime>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        Regex _reCleaning = new Regex(@"^(Cleaning)\W+(?<filename>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        Regex _reSkipping = new Regex(@"^(Skipping)\W+(?<filename>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        Regex _reCleaning = new Regex(@"^(Cleaning)\W(?<filename>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        Regex _reSkipping = new Regex(@"^(Skipping)\W(?<filename>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reBuildAsset = new Regex(@"^(?<filename>([a-zA-Z]:)?/.+?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reBuildError = new Regex(@"^(?<filename>([a-zA-Z]:)?/.+?)\W*?:\W*?error\W*?:\W*(?<errorMessage>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         Regex _reBuildEnd = new Regex(@"^(Build)\W+(?<buildInfo>.*?)\r?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);

--- a/Tools/Pipeline/Gtk/MainWindow.cs
+++ b/Tools/Pipeline/Gtk/MainWindow.cs
@@ -153,6 +153,8 @@ namespace MonoGame.Tools.Pipeline
 
         public void OnShowEvent()
         {
+            PipelineSettings.Default.Load ();
+
             if (string.IsNullOrEmpty(OpenProjectPath))
             {
                 var startupProject = PipelineSettings.Default.StartupProject;
@@ -829,7 +831,6 @@ namespace MonoGame.Tools.Pipeline
 
         public void UpdateRecentProjectList()
         {
-            PipelineSettings.Default.Load ();
             recentMenu.Submenu = null;
             var m = new Menu ();
 

--- a/Tools/Pipeline/Windows/Controls/FilterOutputControl.cs
+++ b/Tools/Pipeline/Windows/Controls/FilterOutputControl.cs
@@ -5,7 +5,6 @@
 using System;
 using System.IO;
 using System.Windows.Forms;
-using MonoGame.Tools.Pipeline.Common;
 
 namespace MonoGame.Tools.Pipeline.Windows.Controls
 {


### PR DESCRIPTION
Stuff done:
 - Use common code for Gtk Pipline output filtering from #4272
   - Fix Clean / Skip Regex
 - Disable loading setting from file for Gtk Pipeline on menu update... no point, they are already in memory