### PR TITLE
Tidying OpenAL constants

### DIFF
--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -36,7 +36,27 @@ namespace Microsoft.Xna.Framework.Audio
 		//int[] buffers;
         private AlcError _lastOpenALError;
         private int[] allSourcesArray;
-        private const int MAX_NUMBER_OF_SOURCES = 32;
+#if DESKTOPGL || ANGLE
+
+        // MacOS & Linux shares a limit of 256.
+        internal const int MAX_NUMBER_OF_SOURCES = 256;
+
+#elif MONOMAC
+
+        // Reference: http://stackoverflow.com/questions/3894044/maximum-number-of-openal-sound-buffers-on-iphone
+        internal const int MAX_NUMBER_OF_SOURCES = 256;
+
+#elif IOS
+
+        // Reference: http://stackoverflow.com/questions/3894044/maximum-number-of-openal-sound-buffers-on-iphone
+        internal const int MAX_NUMBER_OF_SOURCES = 32;
+
+#elif ANDROID
+
+        // Set to the same as OpenAL on iOS
+        internal const int MAX_NUMBER_OF_SOURCES = 32;
+
+#endif
 #if MONOMAC || IOS
         private const double PREFERRED_MIX_RATE = 44100;
 #elif ANDROID

--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -25,27 +25,7 @@ namespace Microsoft.Xna.Framework.Audio
 {
     public sealed partial class SoundEffect : IDisposable
     {
-#if DESKTOPGL || ANGLE
-
-        // These platforms are only limited by memory.
-        internal const int MAX_PLAYING_INSTANCES = int.MaxValue;
-
-#elif MONOMAC
-
-        // Reference: http://stackoverflow.com/questions/3894044/maximum-number-of-openal-sound-buffers-on-iphone
-        internal const int MAX_PLAYING_INSTANCES = 256;
-
-#elif IOS
-
-        // Reference: http://stackoverflow.com/questions/3894044/maximum-number-of-openal-sound-buffers-on-iphone
-        internal const int MAX_PLAYING_INSTANCES = 32;
-
-#elif ANDROID
-
-        // Set to the same as OpenAL on iOS
-        internal const int MAX_PLAYING_INSTANCES = 32;
-
-#endif
+        internal const int MAX_PLAYING_INSTANCES = OpenALSoundController.MAX_NUMBER_OF_SOURCES - 1; // one source should be reserved to MediaPlayer
 
         internal byte[] _data;
 

--- a/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
@@ -8,34 +8,6 @@ namespace Microsoft.Xna.Framework.Audio
 {
     internal static class SoundEffectInstancePool
     {
-
-#if WINDOWS || (WINRT && !WINDOWS_PHONE) || DESKTOPGL || WEB || ANGLE
-
-        // These platforms are only limited by memory.
-        private const int MAX_PLAYING_INSTANCES = int.MaxValue;
-
-#elif MONOMAC
-
-        // Reference: http://stackoverflow.com/questions/3894044/maximum-number-of-openal-sound-buffers-on-iphone
-        private const int MAX_PLAYING_INSTANCES = 256;
-
-#elif WINDOWS_PHONE
-
-        // Reference: http://msdn.microsoft.com/en-us/library/microsoft.xna.framework.audio.instanceplaylimitexception.aspx
-        private const int MAX_PLAYING_INSTANCES = 64;
-
-#elif IOS
-
-        // Reference: http://stackoverflow.com/questions/3894044/maximum-number-of-openal-sound-buffers-on-iphone
-        private const int MAX_PLAYING_INSTANCES = 32;
-
-#elif ANDROID
-
-        // Set to the same as OpenAL on iOS
-        internal const int MAX_PLAYING_INSTANCES = 32;
-
-#endif
-
         private static readonly List<SoundEffectInstance> _playingInstances;
         private static readonly List<SoundEffectInstance> _pooledInstances;
 


### PR DESCRIPTION
Fixes #4403

```SoundEffectInstancePool``` unused constants have been removed, and ```SoundEffect``` constants are now based upon ```OpenALSoundController``` constants (minus 1, because NVorbis uses a sound source and this should be subtracted).

The maximum of playing instances for DesktopGL has been set to 256, beause MacOS & Linux share this limit (even though Windows doesn't have a limit).