### PR TITLE
Fixes OpenAL crashing upon exiting on MacOS

### DIFF
--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -280,11 +280,24 @@ namespace Microsoft.Xna.Framework.Audio
         private void CleanUpOpenAL()
         {
             Alc.MakeContextCurrent (ContextHandle.Zero);
+#if DESKTOPGL
             if (_acontext != null)
             {
                 _acontext.Dispose();
                 _acontext = null;
             }
+#else
+            if (_context != ContextHandle.Zero)
+            {
+                Alc.DestroyContext (_context);
+                _context = ContextHandle.Zero;
+            }
+            if (_device != IntPtr.Zero)
+            {
+                Alc.CloseDevice (_device);
+                _device = IntPtr.Zero;
+            }
+#endif
             _bSoundAvailable = false;
         }
 

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -277,19 +277,16 @@ namespace Microsoft.Xna.Framework.Audio
         /// <summary>
         /// Destroys the AL context and closes the device, when they exist.
         /// </summary>
-		private void CleanUpOpenAL()
-		{
-			Alc.MakeContextCurrent (ContextHandle.Zero);
-			if (_context != ContextHandle.Zero) {
-				Alc.DestroyContext (_context);
-				_context = ContextHandle.Zero;
-			}
-			if (_device != IntPtr.Zero) {
-				Alc.CloseDevice (_device);
-				_device = IntPtr.Zero;
-			}
+        private void CleanUpOpenAL()
+        {
+            Alc.MakeContextCurrent (ContextHandle.Zero);
+            if (_acontext != null)
+            {
+                _acontext.Dispose();
+                _acontext = null;
+            }
             _bSoundAvailable = false;
-		}
+        }
 
         /// <summary>
         /// Dispose of the OpenALSoundCOntroller.


### PR DESCRIPTION
This fixes an exit error discussed in #4153 where ```Alc.DestroyContext()``` could be called twice and raise an error on MacOS.

@dellis1972 You may be interested in testing this.