### PR TITLE
[Gtk Pipeline] Headerbar Update

### DIFF
--- a/Tools/Pipeline/Gtk/Gtk3Integration.cs
+++ b/Tools/Pipeline/Gtk/Gtk3Integration.cs
@@ -54,6 +54,21 @@ namespace MonoGame.Tools.Pipeline
 
         [DllImport (giolibpath, CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr g_file_query_info (IntPtr gfile, string attributes, int flag, IntPtr cancelable, IntPtr error);
+
+        [DllImport (gtklibpath, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr gtk_popover_new (IntPtr relative_to_widget);
+
+        [DllImport (gtklibpath, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr gtk_menu_button_new ();
+
+        [DllImport (gtklibpath, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr gtk_menu_button_get_popover (IntPtr menu_button);
+
+        [DllImport (gtklibpath, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void gtk_menu_button_set_popover (IntPtr menu_button, IntPtr popover);
+
+        [DllImport (gtklibpath, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void gtk_tree_view_set_activate_on_single_click (IntPtr treeview, bool value);
     }
 
     public class ColorChooserDialog : Dialog
@@ -119,6 +134,33 @@ namespace MonoGame.Tools.Pipeline
         {
             Gtk3Wrapper.gtk_window_set_titlebar(window.Handle, this.Handle);
         }
+    }
+
+    public class Popover : Bin
+    {
+        public Popover(Widget relativeWidget) : base(Gtk3Wrapper.gtk_popover_new(relativeWidget.Handle)) { }
+
+        public Popover(IntPtr handle) : base(handle) { }
+    }
+
+    public class MenuButton : ToggleButton
+    {
+        public Popover Popup
+        {
+            get
+            {
+                var ret = Gtk3Wrapper.gtk_menu_button_get_popover(this.Handle);
+                return new Popover(ret);
+            }
+            set
+            {
+                Gtk3Wrapper.gtk_menu_button_set_popover(this.Handle, value.Handle);
+            }
+        }
+
+        public MenuButton() : base(Gtk3Wrapper.gtk_menu_button_new()) { }
+
+        public MenuButton(IntPtr handle) : base(handle) { }
     }
 }
 

--- a/Tools/Pipeline/Gtk/MainWindow.HeaderBar.glade
+++ b/Tools/Pipeline/Gtk/MainWindow.HeaderBar.glade
@@ -5,7 +5,32 @@
   <object class="GtkImage" id="build_image">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
+    <property name="icon_name">emblem-system-symbolic</property>
+  </object>
+  <object class="GtkImage" id="rebuild_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="icon_name">system-run-symbolic</property>
+  </object>
+  <object class="GtkImage" id="cancel_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">media-playback-stop-symbolic</property>
+  </object>
+  <object class="GtkImage" id="new_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">document-new-symbolic</property>
+  </object>
+  <object class="GtkImage" id="filteroutput_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">format-indent-more-symbolic</property>
+  </object>
+  <object class="GtkImage" id="menu_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">open-menu-symbolic</property>
   </object>
   <object class="GtkMenu" id="menu1">
     <property name="visible">True</property>
@@ -15,16 +40,6 @@
     <property name="visible">True</property>
     <property name="can_focus">False</property>
   </object>
-  <object class="GtkImage" id="menu_image">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">open-menu-symbolic</property>
-  </object>
-  <object class="GtkImage" id="new_image">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">document-new-symbolic</property>
-  </object>
   <object class="GtkHeaderBar" id="headerbar">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -32,32 +47,40 @@
     <child>
       <object class="GtkButton" id="build_button">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
+        <property name="can_focus">False</property>
         <property name="can_default">True</property>
         <property name="receives_default">False</property>
-        <property name="tooltip_text" translatable="yes">Builds content</property>
+        <property name="tooltip_text" translatable="yes">Build</property>
         <property name="valign">center</property>
         <property name="image">build_image</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkButton" id="rebuild_button">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="can_default">True</property>
+        <property name="receives_default">False</property>
+        <property name="tooltip_text" translatable="yes">Rebuild</property>
+        <property name="valign">center</property>
+        <property name="image">rebuild_image</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkButton" id="cancel_button">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="can_default">True</property>
+        <property name="receives_default">False</property>
+        <property name="tooltip_text" translatable="yes">Cancel</property>
+        <property name="valign">center</property>
+        <property name="image">cancel_image</property>
       </object>
     </child>
     <child>
       <object class="GtkSeparator" id="separator1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-      </object>
-      <packing>
-        <property name="position">1</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkButton" id="open_button">
-        <property name="label" translatable="yes">Open</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="can_default">True</property>
-        <property name="receives_default">False</property>
-        <property name="tooltip_text" translatable="yes">Open a mgcb file</property>
-        <property name="valign">center</property>
       </object>
     </child>
     <child>
@@ -66,19 +89,29 @@
         <property name="can_focus">False</property>
         <property name="can_default">True</property>
         <property name="receives_default">False</property>
-        <property name="tooltip_text" translatable="yes">Create a new mgcb file</property>
+        <property name="tooltip_text" translatable="yes">New</property>
         <property name="valign">center</property>
         <property name="image">new_image</property>
       </object>
-      <packing>
-        <property name="position">1</property>
-      </packing>
+    </child>
+    <child>
+      <object class="GtkMenuButton" id="open_button">
+        <property name="label" translatable="yes">Open</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="can_default">True</property>
+        <property name="receives_default">False</property>
+        <property name="tooltip_text" translatable="yes">Open</property>
+        <!--property name="popup">menu1</property-->
+        <property name="valign">center</property>
+      </object>
     </child>
     <child>
       <object class="GtkMenuButton" id="gear_button">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="receives_default">False</property>
+        <property name="tooltip_text" translatable="yes">Menu</property>
         <property name="valign">center</property>
         <property name="image">menu_image</property>
         <property name="popup">menu2</property>
@@ -90,16 +123,30 @@
       </packing>
     </child>
     <child>
+      <object class="GtkToggleButton" id="filteroutput_button">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="receives_default">False</property>
+        <property name="tooltip_text" translatable="yes">Filter Output</property>
+        <property name="valign">center</property>
+        <property name="image">filteroutput_image</property>
+      </object>
+      <packing>
+        <property name="pack_type">end</property>
+        <property name="position">3</property>
+      </packing>
+    </child>
+    <child>
       <object class="GtkButton" id="save_button">
         <property name="label" translatable="yes">Save</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="receives_default">True</property>
-        <property name="tooltip_text" translatable="yes">Save current project</property>
+        <property name="tooltip_text" translatable="yes">Save</property>
       </object>
       <packing>
         <property name="pack_type">end</property>
-        <property name="position">3</property>
+        <property name="position">4</property>
       </packing>
     </child>
     <style>


### PR DESCRIPTION
Since I added new toolbars I thought why not update headerbar as well to match it :)

Stuff done in short(applies only to headerbar):
 - added rebuild button
 - added cancel build button
 - build/rebuild and cancel button will switch depending on if pipeline tool is building something
 - added new open popup with recent list
 - added filter output toggle

Screenshots
=
Old HeaderBar:
![headerbar_old](https://cloud.githubusercontent.com/assets/6773302/12281914/71654238-b99a-11e5-86aa-5cf3dc9e6c0d.png)

New Headerbar:
![headerbar_new](https://cloud.githubusercontent.com/assets/6773302/12281915/74a72c90-b99a-11e5-9fb0-1981e838ff21.png)

During build:
![headerbar_new_building](https://cloud.githubusercontent.com/assets/6773302/12281928/854f8a1a-b99a-11e5-951e-771b81c21cb8.png)

Open popup:
![headerbar_new_open_recent](https://cloud.githubusercontent.com/assets/6773302/12312771/52d41b78-ba62-11e5-96fd-3a8e7ff1e335.png)
