### PR TITLE
SpriteBatch performance optimisation

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -402,19 +402,33 @@ namespace Microsoft.Xna.Framework.Graphics
 				_texCoordTL.X = temp;
 			}
 
-			item.Set (destinationRectangle.X,
-					destinationRectangle.Y, 
-					-origin.X, 
-					-origin.Y,
-					destinationRectangle.Z,
-					destinationRectangle.W,
-					(float)Math.Sin (rotation), 
-					(float)Math.Cos (rotation), 
-					color, 
-					_texCoordTL, 
-					_texCoordBR,
-                    depth);
-			
+		    if (rotation == 0f)
+		    {
+                item.Set(destinationRectangle.X - origin.X,
+                        destinationRectangle.Y - origin.Y,
+                        destinationRectangle.Z,
+                        destinationRectangle.W,
+                        color,
+                        _texCoordTL,
+                        _texCoordBR,
+                        depth);
+            }
+            else
+		    {
+                item.Set(destinationRectangle.X,
+                        destinationRectangle.Y,
+                        -origin.X,
+                        -origin.Y,
+                        destinationRectangle.Z,
+                        destinationRectangle.W,
+                        (float)Math.Sin(rotation),
+                        (float)Math.Cos(rotation),
+                        color,
+                        _texCoordTL,
+                        _texCoordBR,
+                        depth);
+            }
+
 			if (autoFlush)
 			{
 				FlushIfNeeded();

--- a/MonoGame.Framework/Graphics/SpriteBatchItem.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatchItem.cs
@@ -53,6 +53,37 @@ namespace Microsoft.Xna.Framework.Graphics
             vertexBR.TextureCoordinate.Y = texCoordBR.Y;
 		}
 
+        public void Set(float x, float y, float w, float h, Color color, Vector2 texCoordTL, Vector2 texCoordBR, float depth)
+        {
+            vertexTL.Position.X = x;
+            vertexTL.Position.Y = y;
+            vertexTL.Position.Z = depth;
+            vertexTL.Color = color;
+            vertexTL.TextureCoordinate.X = texCoordTL.X;
+            vertexTL.TextureCoordinate.Y = texCoordTL.Y;
+
+            vertexTR.Position.X = x + w;
+            vertexTR.Position.Y = y;
+            vertexTR.Position.Z = depth;
+            vertexTR.Color = color;
+            vertexTR.TextureCoordinate.X = texCoordBR.X;
+            vertexTR.TextureCoordinate.Y = texCoordTL.Y;
+
+            vertexBL.Position.X = x;
+            vertexBL.Position.Y = y + h;
+            vertexBL.Position.Z = depth;
+            vertexBL.Color = color;
+            vertexBL.TextureCoordinate.X = texCoordTL.X;
+            vertexBL.TextureCoordinate.Y = texCoordBR.Y;
+
+            vertexBR.Position.X = x + w;
+            vertexBR.Position.Y = y + h;
+            vertexBR.Position.Z = depth;
+            vertexBR.Color = color;
+            vertexBR.TextureCoordinate.X = texCoordBR.X;
+            vertexBR.TextureCoordinate.Y = texCoordBR.Y;
+        }
+
         #region Implement IComparable
         public int CompareTo(SpriteBatchItem other)
         {


### PR DESCRIPTION
This is an optimisation for the common case of drawing sprites without any rotation.

I benchmarked my optimised `SpriteBatchItem.Set` method against the normal version and found it to be roughly 3 times faster.

My top-down 2D game uses a mix of unrotated sprites (e.g. tiles) and rotated sprites (e.g. characters and objects), and this optimisation gives it a fairly respectable frame rate increase (around 10%).

Obviously your results may vary though depending on the number of sprites being drawn and how many of those are rotated. But I believe this should be a worthwhile optimisation in general for most users.