### PR TITLE
Fixes OpenAL buffers and sources management

### DIFF
--- a/MonoGame.Framework/Audio/OALSoundBuffer.cs
+++ b/MonoGame.Framework/Audio/OALSoundBuffer.cs
@@ -18,9 +18,7 @@ namespace Microsoft.Xna.Framework.Audio
 		ALFormat openALFormat;
 		int dataSize;
 		int sampleRate;
-		private int _sourceId;
         bool _isDisposed;
-        internal int _pauseCount;
 
 		public OALSoundBuffer ()
 		{
@@ -91,20 +89,6 @@ namespace Microsoft.Xna.Framework.Audio
 
         }
 
-        public void Pause()
-        {
-            if (_pauseCount == 0)
-                AL.SourcePause(_sourceId);
-            ++_pauseCount;
-        }
-
-        public void Resume()
-        {
-            --_pauseCount;
-            if (_pauseCount == 0)
-                AL.SourcePlay(_sourceId);
-        }
-
 		public void Dispose()
 		{
             Dispose(true);
@@ -128,31 +112,6 @@ namespace Microsoft.Xna.Framework.Audio
                 _isDisposed = true;
             }
         }
-
-		public int SourceId
-		{
-			get {
-				return _sourceId;
-			}
-
-			set {
-				_sourceId = value;
-				if (Reserved != null)
-					Reserved(this, EventArgs.Empty);
-
-			}
-		}
-
-		public void RecycleSoundBuffer()
-		{
-			if (Recycled != null)
-				Recycled(this, EventArgs.Empty);
-		}
-
-		#region Events
-		public event EventHandler<EventArgs> Reserved;
-		public event EventHandler<EventArgs> Recycled;
-		#endregion
 	}
 }
 

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -36,7 +36,27 @@ namespace Microsoft.Xna.Framework.Audio
 		//int[] buffers;
         private AlcError _lastOpenALError;
         private int[] allSourcesArray;
-        private const int MAX_NUMBER_OF_SOURCES = 32;
+#if DESKTOPGL || ANGLE
+
+        // MacOS & Linux shares a limit of 256.
+        internal const int MAX_NUMBER_OF_SOURCES = 256;
+
+#elif MONOMAC
+
+        // Reference: http://stackoverflow.com/questions/3894044/maximum-number-of-openal-sound-buffers-on-iphone
+        internal const int MAX_NUMBER_OF_SOURCES = 256;
+
+#elif IOS
+
+        // Reference: http://stackoverflow.com/questions/3894044/maximum-number-of-openal-sound-buffers-on-iphone
+        internal const int MAX_NUMBER_OF_SOURCES = 32;
+
+#elif ANDROID
+
+        // Set to the same as OpenAL on iOS
+        internal const int MAX_NUMBER_OF_SOURCES = 32;
+
+#endif
 #if MONOMAC || IOS
         private const double PREFERRED_MIX_RATE = 44100;
 #elif ANDROID

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -297,19 +297,29 @@ namespace Microsoft.Xna.Framework.Audio
         /// <summary>
         /// Destroys the AL context and closes the device, when they exist.
         /// </summary>
-		private void CleanUpOpenAL()
-		{
-			Alc.MakeContextCurrent (ContextHandle.Zero);
-			if (_context != ContextHandle.Zero) {
-				Alc.DestroyContext (_context);
-				_context = ContextHandle.Zero;
-			}
-			if (_device != IntPtr.Zero) {
-				Alc.CloseDevice (_device);
-				_device = IntPtr.Zero;
-			}
+        private void CleanUpOpenAL()
+        {
+            Alc.MakeContextCurrent(ContextHandle.Zero);
+#if DESKTOPGL
+            if (_acontext != null)
+            {
+                _acontext.Dispose();
+                _acontext = null;
+            }
+#else
+            if (_context != ContextHandle.Zero)
+            {
+                Alc.DestroyContext (_context);
+                _context = ContextHandle.Zero;
+            }
+            if (_device != IntPtr.Zero)
+            {
+                Alc.CloseDevice (_device);
+                _device = IntPtr.Zero;
+            }
+#endif
             _bSoundAvailable = false;
-		}
+        }
 
         /// <summary>
         /// Dispose of the OpenALSoundCOntroller.

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -353,43 +353,33 @@ namespace Microsoft.Xna.Framework.Audio
         /// </summary>
         /// <param name="soundBuffer">The sound buffer you want to play</param>
         /// <returns>True if the buffer can be played, and false if not.</returns>
-		public bool ReserveSource (SoundEffectInstance inst)
+		public int ReserveSource()
 		{
             if (!CheckInitState())
             {
-                return(false);
+                throw new InstancePlayLimitException();
             }
             int sourceNumber;
-			if (availableSourcesCollection.Count == 0) {
-
-                inst.SourceId = 0;
-                inst.HasSourceId = false;
-				return false;
+			if (availableSourcesCollection.Count == 0)
+            {
+                throw new InstancePlayLimitException();
 			}
 			
-
 			sourceNumber = availableSourcesCollection.First ();
-            inst.SourceId = sourceNumber;
-            inst.HasSourceId = true;
-            inUseSourcesCollection.Add(inst.SourceId);
-
+            inUseSourcesCollection.Add(sourceNumber);
 			availableSourcesCollection.Remove (sourceNumber);
 
-			//sourceId = sourceNumber;
-			return true;
+            return sourceNumber;
 		}
 
-        public void RecycleSource(SoundEffectInstance inst)
+        public void RecycleSource(int sourceId)
 		{
             if (!CheckInitState())
             {
                 return;
             }
-            inUseSourcesCollection.Remove(inst.SourceId);
-            availableSourcesCollection.Add(inst.SourceId);
-            inst.SourceId = 0;
-            inst.HasSourceId = false;
-            inst.SoundState = SoundState.Stopped;
+            inUseSourcesCollection.Remove(sourceId);
+            availableSourcesCollection.Add(sourceId);
 		}
 
         public void PlaySound(SoundEffectInstance inst)
@@ -410,7 +400,10 @@ namespace Microsoft.Xna.Framework.Audio
             lock (playingSourcesCollection) {
                 playingSourcesCollection.Remove(inst.SourceId);
             }
-            RecycleSource(inst);
+            RecycleSource(inst.SourceId);
+            inst.SourceId = 0;
+            inst.HasSourceId = false;
+            inst.SoundState = SoundState.Stopped;
 		}
 
         /// <summary>

--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -49,6 +49,8 @@ namespace Microsoft.Xna.Framework.Audio
 
         internal byte[] _data;
 
+        internal OALSoundBuffer SoundBuffer;
+
 		internal float Rate { get; set; }
 
         internal int Size { get; set; }
@@ -152,7 +154,6 @@ namespace Microsoft.Xna.Framework.Audio
 
             _data = buffer;
             Format = (channels == AudioChannels.Stereo) ? ALFormat.Stereo16 : ALFormat.Mono16;
-            return;
 
 #endif
 
@@ -170,6 +171,10 @@ namespace Microsoft.Xna.Framework.Audio
             _data = buffer;
 
 #endif
+
+            // bind buffer
+            SoundBuffer = new OALSoundBuffer();
+            SoundBuffer.BindDataBuffer(_data, Format, Size, (int)Rate);
         }
 
         private void PlatformInitialize(byte[] buffer, int offset, int count, int sampleRate, AudioChannels channels, int loopStart, int loopLength)
@@ -186,7 +191,6 @@ namespace Microsoft.Xna.Framework.Audio
         private void PlatformSetupInstance(SoundEffectInstance inst)
         {
             inst.InitializeSound();
-            inst.BindDataBuffer(_data, Format, Size, (int)Rate);
         }
 
         #endregion
@@ -195,7 +199,11 @@ namespace Microsoft.Xna.Framework.Audio
 
         private void PlatformDispose(bool disposing)
         {
-            // A no-op for OpenAL
+            if (SoundBuffer != null)
+            {
+                SoundBuffer.Dispose();
+                SoundBuffer = null;
+            }
         }
 
         #endregion

--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -25,27 +25,7 @@ namespace Microsoft.Xna.Framework.Audio
 {
     public sealed partial class SoundEffect : IDisposable
     {
-#if DESKTOPGL || ANGLE
-
-        // These platforms are only limited by memory.
-        internal const int MAX_PLAYING_INSTANCES = int.MaxValue;
-
-#elif MONOMAC
-
-        // Reference: http://stackoverflow.com/questions/3894044/maximum-number-of-openal-sound-buffers-on-iphone
-        internal const int MAX_PLAYING_INSTANCES = 256;
-
-#elif IOS
-
-        // Reference: http://stackoverflow.com/questions/3894044/maximum-number-of-openal-sound-buffers-on-iphone
-        internal const int MAX_PLAYING_INSTANCES = 32;
-
-#elif ANDROID
-
-        // Set to the same as OpenAL on iOS
-        internal const int MAX_PLAYING_INSTANCES = 32;
-
-#endif
+        internal const int MAX_PLAYING_INSTANCES = OpenALSoundController.MAX_NUMBER_OF_SOURCES;
 
         internal byte[] _data;
 

--- a/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
@@ -14,16 +14,16 @@ namespace Microsoft.Xna.Framework.Audio
 {
     public partial class SoundEffectInstance : IDisposable
     {
-		private SoundState soundState = SoundState.Stopped;
+		internal SoundState SoundState = SoundState.Stopped;
 		private bool _looped = false;
 		private float _alVolume = 1;
 
-		int sourceId;
-
-        private OALSoundBuffer soundBuffer;
+		internal int SourceId;
+        int pauseCount;
+        
         private OpenALSoundController controller;
         
-        bool hasSourceId = false;
+        internal bool HasSourceId = false;
 
         #region Initialization
 
@@ -33,25 +33,6 @@ namespace Microsoft.Xna.Framework.Audio
         internal void PlatformInitialize(byte[] buffer, int sampleRate, int channels)
         {
             InitializeSound();
-            BindDataBuffer(
-                buffer,
-                (channels == 2) ? ALFormat.Stereo16 : ALFormat.Mono16,
-                buffer.Length,
-                sampleRate
-			    );
-        }
-
-        /// <summary>
-        /// Preserves the given data buffer by reference and binds its contents to the OALSoundBuffer
-        /// that is created in the InitializeSound method.
-        /// </summary>
-        /// <param name="data">The sound data buffer</param>
-        /// <param name="format">The sound buffer data format, e.g. Mono, Mono16 bit, Stereo, etc.</param>
-        /// <param name="size">The size of the data buffer</param>
-        /// <param name="rate">The sampling rate of the sound effect, e.g. 44 khz, 22 khz.</param>
-        internal void BindDataBuffer(byte[] data, ALFormat format, int size, int rate)
-        {
-            soundBuffer.BindDataBuffer(data, format, size, rate);
         }
 
         /// <summary>
@@ -61,35 +42,6 @@ namespace Microsoft.Xna.Framework.Audio
         internal void InitializeSound()
         {
             controller = OpenALSoundController.GetInstance;
-            soundBuffer = new OALSoundBuffer();
-            soundBuffer.Reserved += HandleSoundBufferReserved;
-            soundBuffer.Recycled += HandleSoundBufferRecycled;
-        }
-
-        /// <summary>
-        /// Event handler that resets internal state of this instance. The sound state will report
-        /// SoundState.Stopped after this event handler.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void HandleSoundBufferRecycled(object sender, EventArgs e)
-        {
-            sourceId = 0;
-            hasSourceId = false;
-            soundState = SoundState.Stopped;
-            //Console.WriteLine ("recycled: " + soundEffect.Name);
-        }
-
-        /// <summary>
-        /// Called after the hardware has allocated a sound buffer, this event handler will
-        /// maintain the numberical ID of the source ID.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void HandleSoundBufferReserved(object sender, EventArgs e)
-        {
-            sourceId = soundBuffer.SourceId;
-            hasSourceId = true;
         }
 
         #endregion // Initialization
@@ -133,80 +85,104 @@ namespace Microsoft.Xna.Framework.Audio
             finalVel = Vector3.Transform(finalVel, orientation);
 
             // set the position based on relative positon
-            AL.Source(sourceId, ALSource3f.Position, finalPos.X, finalPos.Y, finalPos.Z);
-            AL.Source(sourceId, ALSource3f.Velocity, finalVel.X, finalVel.Y, finalVel.Z);
+            AL.Source(SourceId, ALSource3f.Position, finalPos.X, finalPos.Y, finalPos.Z);
+            AL.Source(SourceId, ALSource3f.Velocity, finalVel.X, finalVel.Y, finalVel.Z);
         }
 
         private void PlatformPause()
         {
-            if (!hasSourceId || soundState != SoundState.Playing)
+            if (!HasSourceId || SoundState != SoundState.Playing)
                 return;
 
-            controller.PauseSound(soundBuffer);
-            soundState = SoundState.Paused;
+            if (!controller.CheckInitState())
+            {
+                return;
+            }
+
+            if (pauseCount == 0)
+                AL.SourcePause(SourceId);
+            ++pauseCount;
+            SoundState = SoundState.Paused;
         }
 
         private void PlatformPlay()
         {
-            if (hasSourceId)
-                return;
+
             
-            bool isSourceAvailable = controller.ReserveSource (soundBuffer);
+            bool isSourceAvailable = controller.ReserveSource (this);
             if (!isSourceAvailable)
                 throw new InstancePlayLimitException();
 
-            int bufferId = soundBuffer.OpenALDataBuffer;
-            AL.Source(soundBuffer.SourceId, ALSourcei.Buffer, bufferId);
+            int bufferId = _effect.SoundBuffer.OpenALDataBuffer;
+            AL.Source(SourceId, ALSourcei.Buffer, bufferId);
 
             // Send the position, gain, looping, pitch, and distance model to the OpenAL driver.
-            if (!hasSourceId)
+            if (!HasSourceId)
 				return;
 
 			// Distance Model
 			AL.DistanceModel (ALDistanceModel.InverseDistanceClamped);
 			// Pan
-			AL.Source (sourceId, ALSource3f.Position, _pan, 0, 0.1f);
+			AL.Source (SourceId, ALSource3f.Position, _pan, 0, 0.1f);
 			// Volume
-			AL.Source (sourceId, ALSourcef.Gain, _alVolume);
+			AL.Source (SourceId, ALSourcef.Gain, _alVolume);
 			// Looping
-			AL.Source (sourceId, ALSourceb.Looping, IsLooped);
+			AL.Source (SourceId, ALSourceb.Looping, IsLooped);
 			// Pitch
-			AL.Source (sourceId, ALSourcef.Pitch, XnaPitchToAlPitch(_pitch));
+			AL.Source (SourceId, ALSourcef.Pitch, XnaPitchToAlPitch(_pitch));
 
-            controller.PlaySound (soundBuffer);
+            controller.PlaySound (this);
             //Console.WriteLine ("playing: " + sourceId + " : " + soundEffect.Name);
-            soundState = SoundState.Playing;
+            SoundState = SoundState.Playing;
         }
 
         private void PlatformResume()
         {
-            if (!hasSourceId)
+            if (!HasSourceId)
             {
                 Play();
                 return;
             }
-            
-            if (soundState == SoundState.Paused)
-                controller.ResumeSound(soundBuffer);
-            soundState = SoundState.Playing;
+
+            if (SoundState == SoundState.Paused)
+            {
+                if (!controller.CheckInitState())
+                {
+                    return;
+                }
+                --pauseCount;
+                if (pauseCount == 0)
+                    AL.SourcePlay(SourceId);
+            }
+            SoundState = SoundState.Playing;
         }
 
         private void PlatformStop(bool immediate)
         {
-            if (hasSourceId)
+            if (HasSourceId)
             {
                 //Console.WriteLine ("stop " + sourceId + " : " + soundEffect.Name);
-                controller.StopSound(soundBuffer);
+                
+
+                if (!controller.CheckInitState())
+                {
+                    return;
+                }
+                AL.SourceStop(SourceId);
+
+                AL.Source(SourceId, ALSourcei.Buffer, 0);
+
+                controller.FreeSource(this);
             }
-            soundState = SoundState.Stopped;
+            SoundState = SoundState.Stopped;
         }
 
         private void PlatformSetIsLooped(bool value)
         {
             _looped = value;
             
-            if (hasSourceId)
-                AL.Source(sourceId, ALSourceb.Looping, _looped);
+            if (HasSourceId)
+                AL.Source(SourceId, ALSourceb.Looping, _looped);
         }
 
         private bool PlatformGetIsLooped()
@@ -216,63 +192,53 @@ namespace Microsoft.Xna.Framework.Audio
 
         private void PlatformSetPan(float value)
         {
-            if (hasSourceId)
-                AL.Source(sourceId, ALSource3f.Position, value, 0.0f, 0.1f);
+            if (HasSourceId)
+                AL.Source(SourceId, ALSource3f.Position, value, 0.0f, 0.1f);
         }
 
         private void PlatformSetPitch(float value)
         {
-            if (hasSourceId)
-                AL.Source (sourceId, ALSourcef.Pitch, XnaPitchToAlPitch(value));
+            if (HasSourceId)
+                AL.Source (SourceId, ALSourcef.Pitch, XnaPitchToAlPitch(value));
         }
 
         private SoundState PlatformGetState()
         {
-            if (!hasSourceId)
+            if (!HasSourceId)
                 return SoundState.Stopped;
             
-            var alState = AL.GetSourceState(sourceId);
+            var alState = AL.GetSourceState(SourceId);
 
             switch (alState)
             {
                 case ALSourceState.Initial:
                 case ALSourceState.Stopped:
-                    soundState = SoundState.Stopped;
+                    SoundState = SoundState.Stopped;
                     break;
 
                 case ALSourceState.Paused:
-                    soundState = SoundState.Paused;
+                    SoundState = SoundState.Paused;
                     break;
 
                 case ALSourceState.Playing:
-                    soundState = SoundState.Playing;
+                    SoundState = SoundState.Playing;
                     break;
             }
 
-            return soundState;
+            return SoundState;
         }
 
         private void PlatformSetVolume(float value)
         {
             _alVolume = value;
 
-            if (hasSourceId)
-                AL.Source(sourceId, ALSourcef.Gain, _alVolume);
+            if (HasSourceId)
+                AL.Source(SourceId, ALSourcef.Gain, _alVolume);
         }
 
         private void PlatformDispose(bool disposing)
         {
-            if (disposing)
-            {
-                if (soundBuffer != null)
-                {
-                    this.Stop(true);
-                    soundBuffer.Reserved -= HandleSoundBufferReserved;
-                    soundBuffer.Recycled -= HandleSoundBufferRecycled;
-                    soundBuffer.Dispose();
-                    soundBuffer = null;
-                }
-            }
+            
         }
     }
 }

--- a/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
@@ -108,10 +108,10 @@ namespace Microsoft.Xna.Framework.Audio
         private void PlatformPlay()
         {
 
-            
-            bool isSourceAvailable = controller.ReserveSource (this);
-            if (!isSourceAvailable)
-                throw new InstancePlayLimitException();
+            SourceId = 0;
+            HasSourceId = false;
+            SourceId = controller.ReserveSource();
+            HasSourceId = true;
 
             int bufferId = _effect.SoundBuffer.OpenALDataBuffer;
             AL.Source(SourceId, ALSourcei.Buffer, bufferId);

--- a/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
@@ -8,34 +8,6 @@ namespace Microsoft.Xna.Framework.Audio
 {
     internal static class SoundEffectInstancePool
     {
-
-#if WINDOWS || (WINRT && !WINDOWS_PHONE) || DESKTOPGL || WEB || ANGLE
-
-        // These platforms are only limited by memory.
-        private const int MAX_PLAYING_INSTANCES = int.MaxValue;
-
-#elif MONOMAC
-
-        // Reference: http://stackoverflow.com/questions/3894044/maximum-number-of-openal-sound-buffers-on-iphone
-        private const int MAX_PLAYING_INSTANCES = 256;
-
-#elif WINDOWS_PHONE
-
-        // Reference: http://msdn.microsoft.com/en-us/library/microsoft.xna.framework.audio.instanceplaylimitexception.aspx
-        private const int MAX_PLAYING_INSTANCES = 64;
-
-#elif IOS
-
-        // Reference: http://stackoverflow.com/questions/3894044/maximum-number-of-openal-sound-buffers-on-iphone
-        private const int MAX_PLAYING_INSTANCES = 32;
-
-#elif ANDROID
-
-        // Set to the same as OpenAL on iOS
-        internal const int MAX_PLAYING_INSTANCES = 32;
-
-#endif
-
         private static readonly List<SoundEffectInstance> _playingInstances;
         private static readonly List<SoundEffectInstance> _pooledInstances;
 

--- a/MonoGame.Framework/Utilities/OggStream.cs
+++ b/MonoGame.Framework/Utilities/OggStream.cs
@@ -59,7 +59,7 @@ namespace MonoGame.Utilities
             BufferCount = bufferCount;
 
             alBufferIds = AL.GenBuffers(bufferCount);
-            alSourceId = AL.GenSource();
+            alSourceId = OpenALSoundController.GetInstance.ReserveSource();
 
             if (ALHelper.XRam.IsInitialized)
             {
@@ -238,9 +238,11 @@ namespace MonoGame.Utilities
                 underlyingStream.Dispose();
             }
 
-            AL.DeleteSource(alSourceId);
+            AL.Source(alSourceId, ALSourcei.Buffer, 0);
+            OpenALSoundController.GetInstance.RecycleSource(alSourceId);
+            ALHelper.Check();
             AL.DeleteBuffers(alBufferIds);
-
+            ALHelper.Check();
             if (ALHelper.Efx.IsInitialized)
                 ALHelper.Efx.DeleteFilter(alFilterId);
             


### PR DESCRIPTION
While investigating #4413, I have noticed that OpenAL buffers were wrongly managed: every ```SoundEffectInstance.Play()``` a new buffer is created without freeing the previous one from the OpenAL context, and buffers are bound to one source at a time (buffer-source relationship is forced to be 1-1, instead of 1-multiple).

There is two problems with this: buffers are not reused, and they are not freed, which is causing #4413 to happen (the buffer limit is reached, and the number of 16 I mentioned is obviously wrong and was pure coincidence).

This PR does the following:
- attaching a buffer to ```SoundEffect``` instead of ```SoundEffectInstance``` so they can be reused and don't depend on one single source (works like XAudio2)
- removing source attachment from ```OALSoundBuffer``` so they are independent and only bound to a playing ```SoundEffectInstance```
- correctly disposing the buffers upon ```SoundEffect.Dispose()```

Fixes #4413
Fixes #4411
Fixes #4403 

While reviewing this PR, #4407 & #4410 should help getting rid of the remaining MacOS problems. (I'll most probably have to rebase them -- @tomspilman would you prefer that I push all these OpenAL changes in this present PR ?)


We've tested that extensively and it seems to work just fine. No leaks or runtime allocations to declare.
Some good testing from other developers would be welcome (inc. on mobile). @dellis1972 @cra0zy @endimilojkoski

UPDATE:

I have updated this PR to make ```OggStream``` use the ```OpenALSoundController``` source pool. This will make sure that there is no conflict between ```Song``` and ```SoundEffectInstance```. The source limit will now correctly be respected and the correct exception will be thrown if need be. This makes ```OpenALSoundController``` to be the one and only place where OpenAL sources are managed.