### PR TITLE
Fix for OpenTK messing with the window size when both fullscreen and …

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
@@ -292,16 +292,6 @@ namespace Microsoft.Xna.Framework
                     window.WindowBorder = WindowBorder.Resizable;
                 
                 updateClientBounds = false;
-
-                // when we resize, we also have to move the window to center of the screen here again
-                // to do this, we simply compare the old size to the target size
-                int centerOffsetX = -(targetBounds.Width - window.ClientRectangle.Width) / 2;
-                int centerOffsetY = -(targetBounds.Height - window.ClientRectangle.Height) / 2;
-                window.X = Math.Max(0, centerOffsetX + window.X);
-                window.Y = Math.Max(0, centerOffsetY + window.Y);
-
-                window.ClientRectangle = new System.Drawing.Rectangle(targetBounds.X,
-                                     targetBounds.Y, targetBounds.Width, targetBounds.Height);
                 
                 // if the window-state is set from the outside (maximized button pressed) we have to update it here.
                 // if it was set from the inside (.IsFullScreen changed), we have to change the window.
@@ -312,6 +302,16 @@ namespace Microsoft.Xna.Framework
                     windowState = window.WindowState; // maximize->normal and normal->maximize are usually set from the outside
                 else
                     window.WindowState = windowState; // usually fullscreen-stuff is set from the code
+
+                // when we resize, we also have to move the window to center of the screen here again
+                // to do this, we simply compare the old size to the target size
+                int centerOffsetX = -(targetBounds.Width - window.ClientRectangle.Width) / 2;
+                int centerOffsetY = -(targetBounds.Height - window.ClientRectangle.Height) / 2;
+                window.X = Math.Max(0, centerOffsetX + window.X);
+                window.Y = Math.Max(0, centerOffsetY + window.Y);
+
+                window.ClientRectangle = new System.Drawing.Rectangle(targetBounds.X,
+                     targetBounds.Y, targetBounds.Width, targetBounds.Height);
 
                 // we need to create a small delay between resizing the window
                 // and changing the border to avoid OpenTK Linux bug


### PR DESCRIPTION
…resolution are changed.

I have noticed that if one tries to change ```GraphicsDeviceManager.IsFullscreen``` AND ```GraphicsDeviceManager.PreferredBackBufferWidth``` / Height through ```GraphicsDeviceManager.ApplyChanges()``` outside of the ```Game``` constructor, the new window size is totally wrong (the new size is basically ignored and OpenTK use a default value instead).

I have identified the cause to be OpenTK ```NativeWindow.WindowState``` to recalculate the window size when its state changes from ```Hidden``` to anything else. This overrides the setting of ```NativeWindow.ClientBounds```.

This PR simply invert the order in which ```NativeWindow.ClientBounds``` and ```NativeWindow.WindowState``` are set so that ```NativeWindow.ClientBounds``` keeps its intended value.

@cra0zy @dellis1972 