### PR TITLE
Prevent OpenAL calls with 0 buffers or empty buffers

### DIFF
--- a/MonoGame.Framework/Utilities/OggStream.cs
+++ b/MonoGame.Framework/Utilities/OggStream.cs
@@ -408,8 +408,9 @@ namespace MonoGame.Utilities
                 readSamples = stream.Reader.ReadSamples(readSampleBuffer, 0, BufferSize);
                 CastBuffer(readSampleBuffer, castBuffer, readSamples);
             }
-            AL.BufferData(bufferId, stream.Reader.Channels == 1 ? ALFormat.Mono16 : ALFormat.Stereo16, castBuffer,
-                readSamples * sizeof (short), stream.Reader.SampleRate);
+            if (readSamples > 0)
+                AL.BufferData(bufferId, stream.Reader.Channels == 1 ? ALFormat.Mono16 : ALFormat.Stereo16, castBuffer,
+                    readSamples * sizeof (short), stream.Reader.SampleRate);
             ALHelper.Check();
 
             return readSamples != BufferSize;
@@ -482,7 +483,7 @@ namespace MonoGame.Utilities
                             }
                         }
 
-                        if (!finished)
+                        if (!finished && tempBuffers.Length > 0)
                         {
                             AL.SourceQueueBuffers(stream.alSourceId, tempBuffers.Length, tempBuffers);
                             ALHelper.Check();


### PR DESCRIPTION
This fixes an error related to differences across OpenAL implementations.
>```AL.BufferData()``` generates an "invalid value" error if the ```size``` parameter is ```0``` on OS X, while it does nothing on Windows. Same applies to ```AL.SourceQueueBuffers()```.

I've simply added checks so that it doesn't crash ```Song``` anymore.

Fixes #4440

This however raises another issue: this shouldn't be happening. The original cause is ```VorbisReader.ReadSamples()``` occasionally failing to read the ogg stream by returning ```0``` and skipping a few samples or simply reset the stream (it loses track of the stream position). Which means that there is a bug in NVorbis, or something that Mono don't like in NVorbis.

This means that, even though it doesn't crash anymore, it may occasionally skip a few seconds of a ```Song```, replay a previous buffer, or reset it at worse. It also seems to break the stream initial position, make ```Song``` to start at random position after the first occurrence of this issue.

@dellis1972 Do you find acceptable to merge this until I can figure out what's wrong with NVorbis?

Even though the original ```OggStreamer``` may be a couple years old now, maybe @renaudbedard could have some thoughts about this (did you experienced similar NVorbis issues on Mono?).