### PR TITLE
[Pipeline] Output filename before error msg for missing files

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
@@ -555,7 +555,10 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         private void BuildContent(PipelineBuildEvent pipelineEvent, PipelineBuildEvent cachedEvent, string eventFilepath)
         {
             if (!File.Exists(pipelineEvent.SourceFile))
+            {
+                Logger.LogMessage("{0}", pipelineEvent.SourceFile);
                 throw new PipelineException("The source file '{0}' does not exist!", pipelineEvent.SourceFile);
+            }
 
             Logger.PushFile(pipelineEvent.SourceFile);
 


### PR DESCRIPTION
fix a problem with FilterOutput view (#4272)

new output:
```
Build started 21/1/2016 8:07:39 πμ

P:/TestPipeline/A.fbx
	P:/TestPipeline/obj.png
P:/TestPipeline/C.fbx
P:/TestPipeline/C.fbx: error: The source file 'P:/TestPipeline/C.fbx' does not exist!

Build 1 succeeded, 1 failed.

Time elapsed 00:00:02.30.
```

before:
```
Build started 21/1/2016 8:07:39 πμ

P:/TestPipeline/A.fbx
	P:/TestPipeline/obj.png
P:/TestPipeline/C.fbx: error: The source file 'P:/TestPipeline/C.fbx' does not exist!

Build 1 succeeded, 1 failed.

Time elapsed 00:00:02.30.
```