### PR TITLE
Disabling HiDPI for Retina displays

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -95,6 +95,10 @@ namespace Microsoft.Xna.Framework
 		public OpenTKGamePlatform(Game game)
             : base(game)
         {
+            Toolkit.Init(new ToolkitOptions
+            {
+                EnableHighResolution = false
+            });
             _view = new OpenTKGameWindow(game);
             this.Window = _view;
 


### PR DESCRIPTION
Following discussions in #4431, this PR disables OpenTK HiDPI mode.

Making MonoGame HiDPI-compliant with OpenTK doesn't look to be interesting considering that it will be replaced, so this is a quick and safe workaround.

@dellis1972 @cra0zy what do you think?