### PR TITLE
Fixed SoundEffect.Play does nothing on Android #4452

### DIFF
--- a/MonoGame.Framework/Android/AndroidGamePlatform.cs
+++ b/MonoGame.Framework/Android/AndroidGamePlatform.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Xna.Framework
 {
     class AndroidGamePlatform : GamePlatform
     {
+        OpenALSoundController soundControllerInstance = null;
+
         public AndroidGamePlatform(Game game)
             : base(game)
         {
@@ -23,6 +25,14 @@ namespace Microsoft.Xna.Framework
             Window = _gameWindow;
 
             MediaLibrary.Context = Game.Activity;
+            try
+            {
+                soundControllerInstance = OpenALSoundController.GetInstance;
+            }
+            catch (DllNotFoundException ex)
+            {
+                throw (new NoAudioHardwareException("Failed to init OpenALSoundController", ex));
+            }
         }
 
         protected override void Dispose(bool disposing)

--- a/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.OpenAL.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         internal OALSoundBuffer SoundBuffer;
 
-		internal float Rate { get; set; }
+        internal float Rate { get; set; }
 
         internal int Size { get; set; }
 
@@ -151,7 +151,6 @@ namespace Microsoft.Xna.Framework.Audio
             _data = buffer;
 
 #endif
-
             // bind buffer
             SoundBuffer = new OALSoundBuffer();
             SoundBuffer.BindDataBuffer(_data, Format, Size, (int)Rate);


### PR DESCRIPTION
The OpenALSoundController was not being initialized before
the SoundEffects were trying to load.

Tested on Android and MacOS (DesktopGL) works fine