### PR TITLE
[android] Fix Accelerometer state.

### DIFF
--- a/MonoGame.Framework/Android/Devices/Sensors/Accelerometer.cs
+++ b/MonoGame.Framework/Android/Devices/Sensors/Accelerometer.cs
@@ -45,7 +45,10 @@ namespace Microsoft.Devices.Sensors
                 if (IsDisposed)
                     throw new ObjectDisposedException(GetType().Name);
                 if (sensorManager == null)
+                {
                     Initialize();
+                    state = sensor != null ? SensorState.Initializing : SensorState.NotSupported;
+                }
                 return state;
             }
         }


### PR DESCRIPTION
The state valiable is NOT updated after the accelerometer has
been created so it always returns NotSupported..