### PR TITLE
Adding OpenAL error checking everywhere with more verbosity

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -271,6 +271,9 @@
     <Compile Include="Audio\OALSoundBuffer.cs">
       <Services>OpenALAudio</Services>
     </Compile>
+	<Compile Include="Audio\OggStream.cs">
+      <Platforms>WindowsGL,Linux</Platforms>
+    </Compile>
     <Compile Include="Audio\OpenALSoundController.cs">
       <Services>OpenALAudio</Services>
     </Compile>
@@ -1011,9 +1014,6 @@
       <Platforms>WindowsGL,Linux</Platforms>
     </Compile>
     <Compile Include="Utilities\Hash.cs" />
-    <Compile Include="Audio\OggStream.cs">
-      <Platforms>WindowsGL,Linux</Platforms>
-    </Compile>
     <Compile Include="Utilities\FileHelpers.cs" />
     <Compile Include="Utilities\ReflectionHelpers.cs" />
     <Compile Include="Utilities\Lz4Stream\Lz4DecoderStream.cs" />

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -1011,7 +1011,7 @@
       <Platforms>WindowsGL,Linux</Platforms>
     </Compile>
     <Compile Include="Utilities\Hash.cs" />
-    <Compile Include="Utilities\OggStream.cs">
+    <Compile Include="Audio\OggStream.cs">
       <Platforms>WindowsGL,Linux</Platforms>
     </Compile>
     <Compile Include="Utilities\FileHelpers.cs" />

--- a/MonoGame.Framework/Audio/OALSoundBuffer.cs
+++ b/MonoGame.Framework/Audio/OALSoundBuffer.cs
@@ -24,13 +24,8 @@ namespace Microsoft.Xna.Framework.Audio
 		{
             try
             {
-                var alError = AL.GetError();
                 AL.GenBuffers(1, out openALDataBuffer);
-                alError = AL.GetError();
-                if (alError != ALError.NoError)
-                {
-                    Console.WriteLine("Failed to generate OpenAL data buffer: ", AL.GetErrorString(alError));
-                }
+                ALHelper.CheckError("Failed to generate OpenAL data buffer.");
             }
             catch (DllNotFoundException e)
             {
@@ -60,6 +55,7 @@ namespace Microsoft.Xna.Framework.Audio
             dataSize = size;
             this.sampleRate = sampleRate;
             AL.BufferData(openALDataBuffer, openALFormat, dataBuffer, dataSize, this.sampleRate);
+            ALHelper.CheckError("Failed to fill buffer.");
 
             int bits, channels;
 
@@ -106,7 +102,9 @@ namespace Microsoft.Xna.Framework.Audio
                 // Release unmanaged resources
                 if (AL.IsBuffer(openALDataBuffer))
                 {
+                    ALHelper.CheckError("Failed to fetch buffer state.");
                     AL.DeleteBuffers(1, ref openALDataBuffer);
+                    ALHelper.CheckError("Failed to delete buffer.");
                 }
 
                 _isDisposed = true;

--- a/MonoGame.Framework/Audio/OggStream.cs
+++ b/MonoGame.Framework/Audio/OggStream.cs
@@ -47,21 +47,21 @@ namespace Microsoft.Xna.Framework.Audio
             ALHelper.CheckError("Failed to generate buffers.");
             alSourceId = OpenALSoundController.GetInstance.ReserveSource();
 
-            if (ALHelper.XRam.IsInitialized)
+            if (OggStreamer.Instance.XRam.IsInitialized)
             {
-                ALHelper.XRam.SetBufferMode(BufferCount, ref alBufferIds[0], XRamExtension.XRamStorage.Hardware);
+                OggStreamer.Instance.XRam.SetBufferMode(BufferCount, ref alBufferIds[0], XRamExtension.XRamStorage.Hardware);
                 ALHelper.CheckError("Failed to activate Xram.");
             }
 
             Volume = 1;
 
-            if (ALHelper.Efx.IsInitialized)
+            if (OggStreamer.Instance.Efx.IsInitialized)
             {
-                alFilterId = ALHelper.Efx.GenFilter();
+                alFilterId = OggStreamer.Instance.Efx.GenFilter();
                 ALHelper.CheckError("Failed to generate Efx filter.");
-                ALHelper.Efx.Filter(alFilterId, EfxFilteri.FilterType, (int)EfxFilterType.Lowpass);
+                OggStreamer.Instance.Efx.Filter(alFilterId, EfxFilteri.FilterType, (int)EfxFilterType.Lowpass);
                 ALHelper.CheckError("Failed to set Efx filter type.");
-                ALHelper.Efx.Filter(alFilterId, EfxFilterf.LowpassGain, 1);
+                OggStreamer.Instance.Efx.Filter(alFilterId, EfxFilterf.LowpassGain, 1);
                 ALHelper.CheckError("Failed to set Efx filter value.");
                 LowPassHFGain = 1;
             }
@@ -193,11 +193,11 @@ namespace Microsoft.Xna.Framework.Audio
             get { return lowPassHfGain; }
             set
             {
-                if (ALHelper.Efx.IsInitialized)
+                if (OggStreamer.Instance.Efx.IsInitialized)
                 {
-                    ALHelper.Efx.Filter(alFilterId, EfxFilterf.LowpassGainHF, lowPassHfGain = value);
+                    OggStreamer.Instance.Efx.Filter(alFilterId, EfxFilterf.LowpassGainHF, lowPassHfGain = value);
                     ALHelper.CheckError("Failed to set Efx filter.");
-                    ALHelper.Efx.BindFilterToSource(alSourceId, alFilterId);
+                    OggStreamer.Instance.Efx.BindFilterToSource(alSourceId, alFilterId);
                     ALHelper.CheckError("Failed to bind Efx filter to source.");
                 }
             }
@@ -238,9 +238,9 @@ namespace Microsoft.Xna.Framework.Audio
             OpenALSoundController.GetInstance.RecycleSource(alSourceId);
             AL.DeleteBuffers(alBufferIds);
             ALHelper.CheckError("Failed to delete buffer.");
-            if (ALHelper.Efx.IsInitialized)
+            if (OggStreamer.Instance.Efx.IsInitialized)
             {
-                ALHelper.Efx.DeleteFilter(alFilterId);
+                OggStreamer.Instance.Efx.DeleteFilter(alFilterId);
                 ALHelper.CheckError("Failed to delete EFX filter.");
             }
             
@@ -316,6 +316,9 @@ namespace Microsoft.Xna.Framework.Audio
 
     internal class OggStreamer : IDisposable
     {
+        public readonly XRamExtension XRam = new XRamExtension();
+        public readonly EffectsExtension Efx = new EffectsExtension();
+
         const float DefaultUpdateRate = 10;
         const int DefaultBufferSize = 44100;
 

--- a/MonoGame.Framework/Audio/OggStream.cs
+++ b/MonoGame.Framework/Audio/OggStream.cs
@@ -413,7 +413,7 @@ namespace Microsoft.Xna.Framework.Audio
             {
                 AL.BufferData(bufferId, stream.Reader.Channels == 1 ? ALFormat.Mono16 : ALFormat.Stereo16, castBuffer,
                     readSamples * sizeof(short), stream.Reader.SampleRate);
-                ALHelper.CheckError("Failed to fill buffer, readSamples = {0}, SampleRate = {1}, buffer.Length = {3}.", readSamples, stream.Reader.SampleRate, castBuffer.Length);
+                ALHelper.CheckError("Failed to fill buffer, readSamples = {0}, SampleRate = {1}, buffer.Length = {2}.", readSamples, stream.Reader.SampleRate, castBuffer.Length);
             }
             else
             {

--- a/MonoGame.Framework/Audio/OggStream.cs
+++ b/MonoGame.Framework/Audio/OggStream.cs
@@ -15,23 +15,8 @@ using System.Threading;
 using NVorbis;
 using OpenTK.Audio.OpenAL;
 
-using Microsoft.Xna.Framework.Audio;
-
-namespace MonoGame.Utilities
+namespace Microsoft.Xna.Framework.Audio
 {
-    internal static class ALHelper
-    {
-        public static readonly XRamExtension XRam = new XRamExtension();
-        public static readonly EffectsExtension Efx = new EffectsExtension();
-
-        public static void Check()
-        {
-            ALError error;
-            if ((error = AL.GetError()) != ALError.NoError)
-                throw new InvalidOperationException(AL.GetErrorString(error));
-        }
-    }
-
     internal class OggStream : IDisposable
     {
         const int DefaultBufferCount = 3;
@@ -59,12 +44,13 @@ namespace MonoGame.Utilities
             BufferCount = bufferCount;
 
             alBufferIds = AL.GenBuffers(bufferCount);
+            ALHelper.CheckError("Failed to generate buffers.");
             alSourceId = OpenALSoundController.GetInstance.ReserveSource();
 
             if (ALHelper.XRam.IsInitialized)
             {
                 ALHelper.XRam.SetBufferMode(BufferCount, ref alBufferIds[0], XRamExtension.XRamStorage.Hardware);
-                ALHelper.Check();
+                ALHelper.CheckError("Failed to activate Xram.");
             }
 
             Volume = 1;
@@ -72,8 +58,11 @@ namespace MonoGame.Utilities
             if (ALHelper.Efx.IsInitialized)
             {
                 alFilterId = ALHelper.Efx.GenFilter();
+                ALHelper.CheckError("Failed to generate Efx filter.");
                 ALHelper.Efx.Filter(alFilterId, EfxFilteri.FilterType, (int)EfxFilterType.Lowpass);
+                ALHelper.CheckError("Failed to set Efx filter type.");
                 ALHelper.Efx.Filter(alFilterId, EfxFilterf.LowpassGain, 1);
+                ALHelper.CheckError("Failed to set Efx filter value.");
                 LowPassHFGain = 1;
             }
         }
@@ -83,6 +72,7 @@ namespace MonoGame.Utilities
             if (Preparing) return;
 
             var state = AL.GetSourceState(alSourceId);
+            ALHelper.CheckError("Failed to get source state.");
 
             lock (stopMutex)
             {
@@ -115,6 +105,7 @@ namespace MonoGame.Utilities
         public void Play()
         {
             var state = AL.GetSourceState(alSourceId);
+            ALHelper.CheckError("Failed to get source state.");
 
             switch (state)
             {
@@ -127,7 +118,7 @@ namespace MonoGame.Utilities
             Prepare();
 
             AL.SourcePlay(alSourceId);
-            ALHelper.Check();
+            ALHelper.CheckError("Failed to play source.");
 
             Preparing = false;
 
@@ -136,27 +127,32 @@ namespace MonoGame.Utilities
 
         public void Pause()
         {
-            if (AL.GetSourceState(alSourceId) != ALSourceState.Playing)
+            var state = AL.GetSourceState(alSourceId);
+            ALHelper.CheckError("Failed to get source state.");
+            if (state != ALSourceState.Playing)
                 return;
 
             OggStreamer.Instance.RemoveStream(this);
             AL.SourcePause(alSourceId);
-            ALHelper.Check();
+            ALHelper.CheckError("Failed to pause source.");
         }
 
         public void Resume()
         {
-            if (AL.GetSourceState(alSourceId) != ALSourceState.Paused)
+            var state = AL.GetSourceState(alSourceId);
+            ALHelper.CheckError("Failed to get source state.");
+            if (state != ALSourceState.Paused)
                 return;
 
             OggStreamer.Instance.AddStream(this);
             AL.SourcePlay(alSourceId);
-            ALHelper.Check();
+            ALHelper.CheckError("Failed to play source.");
         }
 
         public void Stop()
         {
             var state = AL.GetSourceState(alSourceId);
+            ALHelper.CheckError("Failed to get source state.");
             if (state == ALSourceState.Playing || state == ALSourceState.Paused)
                 StopPlayback();
 
@@ -168,17 +164,14 @@ namespace MonoGame.Utilities
                     Empty(); // force the queued buffers to be unqueued to avoid issues on Mac
             }
             AL.Source(alSourceId, ALSourcei.Buffer, 0);
-        }
-
-        public ALSourceState GetState()
-        {
-            return AL.GetSourceState(alSourceId);
+            ALHelper.CheckError("Failed to free source from buffers.");
         }
 
         public void SeekToPosition(TimeSpan pos)
         {
             Reader.DecodedTime = pos;
             AL.SourceStop(alSourceId);
+            ALHelper.CheckError("Failed to stop source.");
         }
 
         public TimeSpan GetPosition()
@@ -203,8 +196,9 @@ namespace MonoGame.Utilities
                 if (ALHelper.Efx.IsInitialized)
                 {
                     ALHelper.Efx.Filter(alFilterId, EfxFilterf.LowpassGainHF, lowPassHfGain = value);
+                    ALHelper.CheckError("Failed to set Efx filter.");
                     ALHelper.Efx.BindFilterToSource(alSourceId, alFilterId);
-                    ALHelper.Check();
+                    ALHelper.CheckError("Failed to bind Efx filter to source.");
                 }
             }
         }
@@ -216,7 +210,7 @@ namespace MonoGame.Utilities
             set
             {
                 AL.Source(alSourceId, ALSourcef.Gain, volume = value);
-                ALHelper.Check();
+                ALHelper.CheckError("Failed to set volume.");
             }
         }
 
@@ -225,6 +219,7 @@ namespace MonoGame.Utilities
         public void Dispose()
         {
             var state = AL.GetSourceState(alSourceId);
+            ALHelper.CheckError("Failed to get the source state.");
             if (state == ALSourceState.Playing || state == ALSourceState.Paused)
                 StopPlayback();
 
@@ -239,32 +234,36 @@ namespace MonoGame.Utilities
             }
 
             AL.Source(alSourceId, ALSourcei.Buffer, 0);
+            ALHelper.CheckError("Failed to free source from buffers.");
             OpenALSoundController.GetInstance.RecycleSource(alSourceId);
-            ALHelper.Check();
             AL.DeleteBuffers(alBufferIds);
-            ALHelper.Check();
+            ALHelper.CheckError("Failed to delete buffer.");
             if (ALHelper.Efx.IsInitialized)
+            {
                 ALHelper.Efx.DeleteFilter(alFilterId);
+                ALHelper.CheckError("Failed to delete EFX filter.");
+            }
             
-            ALHelper.Check();
+            
         }
 
         void StopPlayback()
         {
             AL.SourceStop(alSourceId);
-            ALHelper.Check();
+            ALHelper.CheckError("Failed to stop source.");
         }
 
         void Empty()
         {
             int queued;
             AL.GetSource(alSourceId, ALGetSourcei.BuffersQueued, out queued);
+            ALHelper.CheckError("Failed to fetch queued buffers.");
             if (queued > 0)
             {
                 try
                 {
                     AL.SourceUnqueueBuffers(alSourceId, queued);
-                    ALHelper.Check();
+                    ALHelper.CheckError("Failed to unqueue buffers (first attempt).");
                 }
                 catch (InvalidOperationException)
                 {
@@ -272,16 +271,17 @@ namespace MonoGame.Utilities
                     // Salvage what we can
                     int processed;
                     AL.GetSource(alSourceId, ALGetSourcei.BuffersProcessed, out processed);
+                    ALHelper.CheckError("Failed to fetch processed buffers.");
                     var salvaged = new int[processed];
                     if (processed > 0)
                     {
                         AL.SourceUnqueueBuffers(alSourceId, processed, salvaged);
-                        ALHelper.Check();
+                        ALHelper.CheckError("Failed to unqueue buffers (second attempt).");
                     }
 
                     // Try turning it off again?
                     AL.SourceStop(alSourceId);
-                    ALHelper.Check();
+                    ALHelper.CheckError("Failed to stop source.");
 
                     Empty();
                 }
@@ -297,7 +297,7 @@ namespace MonoGame.Utilities
                 // Fill first buffer synchronously
                 OggStreamer.Instance.FillBuffer(this, alBufferIds[0]);
                 AL.SourceQueueBuffer(alSourceId, alBufferIds[0]);
-                ALHelper.Check();
+                ALHelper.CheckError("Failed to queue buffer.");
             }
 
             Ready = true;
@@ -410,7 +410,7 @@ namespace MonoGame.Utilities
             {
                 AL.BufferData(bufferId, stream.Reader.Channels == 1 ? ALFormat.Mono16 : ALFormat.Stereo16, castBuffer,
                     readSamples * sizeof(short), stream.Reader.SampleRate);
-                ALHelper.Check();
+                ALHelper.CheckError("Failed to fill buffer, readSamples = {0}, SampleRate = {1}, buffer.Length = {3}.", readSamples, stream.Reader.SampleRate, castBuffer.Length);
             }
             else
             {
@@ -460,16 +460,19 @@ namespace MonoGame.Utilities
 
                         int queued;
                         AL.GetSource(stream.alSourceId, ALGetSourcei.BuffersQueued, out queued);
-                        ALHelper.Check();
+                        ALHelper.CheckError("Failed to fetch queued buffers.");
                         int processed;
                         AL.GetSource(stream.alSourceId, ALGetSourcei.BuffersProcessed, out processed);
-                        ALHelper.Check();
+                        ALHelper.CheckError("Failed to fetch processed buffers.");
 
                         if (processed == 0 && queued == stream.BufferCount) continue;
 
                         int[] tempBuffers;
                         if (processed > 0)
+                        {
                             tempBuffers = AL.SourceUnqueueBuffers(stream.alSourceId, processed);
+                            ALHelper.CheckError("Failed to unqueue buffers.");
+                        }
                         else
                             tempBuffers = stream.alBufferIds.Skip(queued).ToArray();
 
@@ -505,7 +508,7 @@ namespace MonoGame.Utilities
                         if (finished == 0 && bufferFilled > 0) // queue only successfully filled buffers
                         {
                             AL.SourceQueueBuffers(stream.alSourceId, bufferFilled, tempBuffers);
-                            ALHelper.Check();
+                            ALHelper.CheckError("Failed to queue buffers.");
                         }
                         else if (!stream.IsLooped)
                             continue;
@@ -520,10 +523,11 @@ namespace MonoGame.Utilities
                                 continue;
 
                         var state = AL.GetSourceState(stream.alSourceId);
+                        ALHelper.CheckError("Failed to get source state.");
                         if (state == ALSourceState.Stopped)
                         {
                             AL.SourcePlay(stream.alSourceId);
-                            ALHelper.Check();
+                            ALHelper.CheckError("Failed to play.");
                         }
                     }
                 }

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -27,6 +27,26 @@ using AVFoundation;
 
 namespace Microsoft.Xna.Framework.Audio
 {
+    internal static class ALHelper
+    {
+        public static readonly XRamExtension XRam = new XRamExtension();
+        public static readonly EffectsExtension Efx = new EffectsExtension();
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        [System.Diagnostics.DebuggerHidden]
+        public static void CheckError(string message = "", params object[] args)
+        {
+            ALError error;
+            if ((error = AL.GetError()) != ALError.NoError)
+            {
+                if (args != null && args.Length > 0)
+                    message = String.Format(message, args);
+                
+                throw new InvalidOperationException(message + " (Reason: " + AL.GetErrorString(error) + ")");
+            }
+        }
+    }
+
 	internal sealed class OpenALSoundController : IDisposable
     {
         private static OpenALSoundController _instance = null;
@@ -91,6 +111,7 @@ namespace Microsoft.Xna.Framework.Audio
 
 			allSourcesArray = new int[MAX_NUMBER_OF_SOURCES];
 			AL.GenSources(allSourcesArray);
+            ALHelper.CheckError("Failed to generate sources.");
 
             availableSourcesCollection = new List<int>(allSourcesArray);
 			inUseSourcesCollection = new List<int>();
@@ -347,7 +368,10 @@ namespace Microsoft.Xna.Framework.Audio
                             _oggstreamer.Dispose();
 #endif
                         for (int i = 0; i < allSourcesArray.Length; i++)
+                        {
                             AL.DeleteSource(allSourcesArray[i]);
+                            ALHelper.CheckError("Failed to delete source.");
+                        }
                         
                         CleanUpOpenAL();
                     }
@@ -403,6 +427,7 @@ namespace Microsoft.Xna.Framework.Audio
                 playingSourcesCollection.Add(inst.SourceId);
             }
             AL.SourcePlay(inst.SourceId);
+            ALHelper.CheckError("Failed to play source.");
 		}
 
         public void FreeSource(SoundEffectInstance inst)
@@ -445,6 +470,7 @@ namespace Microsoft.Xna.Framework.Audio
             }
             int pos;
 			AL.GetSource (sourceId, ALGetSourcei.SampleOffset, out pos);
+            ALHelper.CheckError("Failed to set source offset.");
 			return pos;
 		}
 
@@ -468,6 +494,7 @@ namespace Microsoft.Xna.Framework.Audio
                 {
                     int sourceId = playingSourcesCollection[i];
                     state = AL.GetSourceState(sourceId);
+                    ALHelper.CheckError("Failed to get source state.");
                     if (state == ALSourceState.Stopped)
                     {
                         purgeMe.Add(sourceId);
@@ -480,6 +507,7 @@ namespace Microsoft.Xna.Framework.Audio
                 foreach (int sourceId in purgeMe)
                 {
                     AL.Source(sourceId, ALSourcei.Buffer, 0);
+                    ALHelper.CheckError("Failed to free source from buffer.");
                     inUseSourcesCollection.Remove(sourceId);
                     availableSourcesCollection.Add(sourceId);
                 }

--- a/MonoGame.Framework/Audio/OpenALSoundController.cs
+++ b/MonoGame.Framework/Audio/OpenALSoundController.cs
@@ -29,9 +29,6 @@ namespace Microsoft.Xna.Framework.Audio
 {
     internal static class ALHelper
     {
-        public static readonly XRamExtension XRam = new XRamExtension();
-        public static readonly EffectsExtension Efx = new EffectsExtension();
-
         [System.Diagnostics.Conditional("DEBUG")]
         [System.Diagnostics.DebuggerHidden]
         public static void CheckError(string message = "", params object[] args)

--- a/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Xna.Framework.Audio
             // get AL's listener position
             float x, y, z;
             AL.GetListener(ALListener3f.Position, out x, out y, out z);
+            ALHelper.CheckError("Failed to get source position.");
 
             // get the emitter offset from origin
             Vector3 posOffset = emitter.Position - listener.Position;
@@ -86,7 +87,9 @@ namespace Microsoft.Xna.Framework.Audio
 
             // set the position based on relative positon
             AL.Source(SourceId, ALSource3f.Position, finalPos.X, finalPos.Y, finalPos.Z);
+            ALHelper.CheckError("Failed to set source position.");
             AL.Source(SourceId, ALSource3f.Velocity, finalVel.X, finalVel.Y, finalVel.Z);
+            ALHelper.CheckError("Failed to Set source velocity.");
         }
 
         private void PlatformPause()
@@ -100,7 +103,10 @@ namespace Microsoft.Xna.Framework.Audio
             }
 
             if (pauseCount == 0)
+            {
                 AL.SourcePause(SourceId);
+                ALHelper.CheckError("Failed to pause source.");
+            }
             ++pauseCount;
             SoundState = SoundState.Paused;
         }
@@ -115,6 +121,7 @@ namespace Microsoft.Xna.Framework.Audio
 
             int bufferId = _effect.SoundBuffer.OpenALDataBuffer;
             AL.Source(SourceId, ALSourcei.Buffer, bufferId);
+            ALHelper.CheckError("Failed to bind buffer to source.");
 
             // Send the position, gain, looping, pitch, and distance model to the OpenAL driver.
             if (!HasSourceId)
@@ -122,14 +129,19 @@ namespace Microsoft.Xna.Framework.Audio
 
 			// Distance Model
 			AL.DistanceModel (ALDistanceModel.InverseDistanceClamped);
+            ALHelper.CheckError("Failed set source distance.");
 			// Pan
 			AL.Source (SourceId, ALSource3f.Position, _pan, 0, 0.1f);
+            ALHelper.CheckError("Failed to set source pan.");
 			// Volume
 			AL.Source (SourceId, ALSourcef.Gain, _alVolume);
+            ALHelper.CheckError("Failed to set source volume.");
 			// Looping
 			AL.Source (SourceId, ALSourceb.Looping, IsLooped);
+            ALHelper.CheckError("Failed to set source loop state.");
 			// Pitch
 			AL.Source (SourceId, ALSourcef.Pitch, XnaPitchToAlPitch(_pitch));
+            ALHelper.CheckError("Failed to set source pitch.");
 
             controller.PlaySound (this);
             //Console.WriteLine ("playing: " + sourceId + " : " + soundEffect.Name);
@@ -152,7 +164,10 @@ namespace Microsoft.Xna.Framework.Audio
                 }
                 --pauseCount;
                 if (pauseCount == 0)
+                {
                     AL.SourcePlay(SourceId);
+                    ALHelper.CheckError("Failed to play source.");
+                }
             }
             SoundState = SoundState.Playing;
         }
@@ -169,8 +184,10 @@ namespace Microsoft.Xna.Framework.Audio
                     return;
                 }
                 AL.SourceStop(SourceId);
+                ALHelper.CheckError("Failed to stop source.");
 
                 AL.Source(SourceId, ALSourcei.Buffer, 0);
+                ALHelper.CheckError("Failed to free source from buffer.");
 
                 controller.FreeSource(this);
             }
@@ -180,9 +197,12 @@ namespace Microsoft.Xna.Framework.Audio
         private void PlatformSetIsLooped(bool value)
         {
             _looped = value;
-            
+
             if (HasSourceId)
+            {
                 AL.Source(SourceId, ALSourceb.Looping, _looped);
+                ALHelper.CheckError("Failed to set source loop state.");
+            }
         }
 
         private bool PlatformGetIsLooped()
@@ -193,13 +213,19 @@ namespace Microsoft.Xna.Framework.Audio
         private void PlatformSetPan(float value)
         {
             if (HasSourceId)
+            {
                 AL.Source(SourceId, ALSource3f.Position, value, 0.0f, 0.1f);
+                ALHelper.CheckError("Failed to set source pan.");
+            }
         }
 
         private void PlatformSetPitch(float value)
         {
             if (HasSourceId)
-                AL.Source (SourceId, ALSourcef.Pitch, XnaPitchToAlPitch(value));
+            {
+                AL.Source(SourceId, ALSourcef.Pitch, XnaPitchToAlPitch(value));
+                ALHelper.CheckError("Failed to set source pitch.");
+            }
         }
 
         private SoundState PlatformGetState()
@@ -208,6 +234,7 @@ namespace Microsoft.Xna.Framework.Audio
                 return SoundState.Stopped;
             
             var alState = AL.GetSourceState(SourceId);
+            ALHelper.CheckError("Failed to get source state.");
 
             switch (alState)
             {
@@ -233,7 +260,10 @@ namespace Microsoft.Xna.Framework.Audio
             _alVolume = value;
 
             if (HasSourceId)
+            {
                 AL.Source(SourceId, ALSourcef.Gain, _alVolume);
+                ALHelper.CheckError("Failed to set source volume.");
+            }
         }
 
         private void PlatformDispose(bool disposing)

--- a/MonoGame.Framework/Media/Song.NVorbis.cs
+++ b/MonoGame.Framework/Media/Song.NVorbis.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.IO;
-using MonoGame.Utilities;
+using Microsoft.Xna.Framework.Audio;
 using OpenTK.Audio;
 
 namespace Microsoft.Xna.Framework.Media


### PR DESCRIPTION
Follow up to #4452

I also moved ```OggStream``` to the ```Audio``` namespace to have every OpenAL bits under the same one.

@tomspilman @KonajuGames 