### PR TITLE
Fix nullable enum serialization bug

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/NamespaceAliasHelper.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/NamespaceAliasHelper.cs
@@ -75,6 +75,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
                 if (contentTypeSerializer.TargetType == childType)
                     return;
 
+                if (contentTypeSerializer.TargetType.IsGenericType 
+                    && contentTypeSerializer.TargetType.GetGenericTypeDefinition() == typeof(Nullable<>) 
+                    && contentTypeSerializer.TargetType.GetGenericArguments()[0] == childType)
+                    return;
+
                 if (_serializer.HasTypeAlias(childType))
                     return;
 

--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/NullableSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/NullableSerializer.cs
@@ -9,25 +9,26 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
     [ContentTypeSerializer]
     class NullableSerializer<T> : ContentTypeSerializer<T?> where T : struct
     {
-        private ElementSerializer<T> _serializer;
+        private ContentTypeSerializer _serializer;
+        private ContentSerializerAttribute _format;
 
         protected internal override void Initialize(IntermediateSerializer serializer)
         {
-            _serializer = (ElementSerializer<T>)serializer.GetTypeSerializer(typeof(T));
+            _serializer = serializer.GetTypeSerializer(typeof(T));
+            _format = new ContentSerializerAttribute
+            {
+                FlattenContent = true
+            };
         }
 
         protected internal override T? Deserialize(IntermediateReader input, ContentSerializerAttribute format, T? existingInstance)
         {
-            var list = new List<T>();
-            _serializer.Deserialize(input, list);
-            return list.First();            
+            return input.ReadRawObject<T>(_format, _serializer);
         }
 
         protected internal override void Serialize(IntermediateWriter output, T? value, ContentSerializerAttribute format)
         {
-            var results = new List<string>();
-            _serializer.Serialize(value.Value, results);
-            output.Xml.WriteRaw(results.First());
+            output.WriteRawObject<T>(value.Value, _format, _serializer);
         }
     }
 }

--- a/Test/Assets/Xml/07_OptionalElements.xml
+++ b/Test/Assets/Xml/07_OptionalElements.xml
@@ -3,5 +3,8 @@
   <Asset Type="OptionalElements">
     <b Null="true" />
     <c></c>
+    <e>CullClockwiseFace</e>
+    <f>CullCounterClockwiseFace</f>
+    <g>CullClockwiseFace</g>
   </Asset>
 </XnaContent>

--- a/Test/ContentPipeline/AssetTestClasses.cs
+++ b/Test/ContentPipeline/AssetTestClasses.cs
@@ -137,6 +137,16 @@ public class OptionalElements
 
     [ContentSerializer(Optional = true)]
     public string c = "c";
+
+    [ContentSerializer(Optional = true)]
+    public CullMode? d = null;
+
+    [ContentSerializer(Optional = true)]
+    public CullMode? e = CullMode.CullClockwiseFace;
+
+    public CullMode? f = CullMode.CullCounterClockwiseFace;
+
+    public CullMode g = CullMode.CullClockwiseFace;
 }
 #endregion
 

--- a/Test/ContentPipeline/IntermediateDeserializerTest.cs
+++ b/Test/ContentPipeline/IntermediateDeserializerTest.cs
@@ -188,6 +188,10 @@ namespace MonoGame.Tests.ContentPipeline
                 Assert.AreEqual(null, optional.a);
                 Assert.AreEqual(null, optional.b);
                 Assert.AreEqual(string.Empty, optional.c);
+                Assert.AreEqual(null, optional.d);
+                Assert.AreEqual(CullMode.CullClockwiseFace, optional.e);
+                Assert.AreEqual(CullMode.CullCounterClockwiseFace, optional.f);
+                Assert.AreEqual(CullMode.CullClockwiseFace, optional.g);
             });
         }
 

--- a/Test/ContentPipeline/IntermediateSerializerTest.cs
+++ b/Test/ContentPipeline/IntermediateSerializerTest.cs
@@ -175,7 +175,11 @@ namespace MonoGame.Tests.ContentPipeline
             {
                 a = null,
                 b = null,
-                c = string.Empty
+                c = string.Empty,
+                d = null,
+                e = CullMode.CullClockwiseFace,
+                f = CullMode.CullCounterClockwiseFace,
+                g = CullMode.CullClockwiseFace
             });
         }
 

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -671,6 +671,9 @@
     <Content Include="Assets\Xml\26_ChildCollections.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Assets\Xml\27_Colors.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Assets\Xml\19_FontDescription.xml">


### PR DESCRIPTION
Prior to this fix, serializing or deserializing a nullable enum using `IntermediateSerializer` would crash in `NullableSerializer.Initialize` because `EnumSerializer` couldn't be cast to `ElementSerializer<T>`.

This pull request simplifies `NullableSerializer<T>` by using the existing `ReadRawObject` and `WriteRawObject` methods, which remove the need for the `List<T>` workaround.