### PR TITLE
[WIP] Implement RenderTargetCube for OpenGL

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -546,6 +546,9 @@
     <Compile Include="Graphics\RenderTargetCube.OpenGL.cs">
       <Services>OpenGLGraphics</Services>
     </Compile>
+    <Compile Include="Graphics\RenderTargetCube.Web.cs">
+      <Services>WebGraphics</Services>
+    </Compile>
     <Compile Include="Graphics\RenderTargetUsage.cs" />
     <Compile Include="Graphics\ResourceCreatedEventArgs.cs" />
     <Compile Include="Graphics\ResourceDestroyedEventArgs.cs" />

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -540,6 +540,12 @@
     </Compile>
     <Compile Include="Graphics\RenderTargetBinding.cs" />
     <Compile Include="Graphics\RenderTargetCube.cs" />
+	<Compile Include="Graphics\RenderTargetCube.DirectX.cs">
+      <Services>DirectXGraphics</Services>
+    </Compile>
+    <Compile Include="Graphics\RenderTargetCube.OpenGL.cs">
+      <Services>OpenGLGraphics</Services>
+    </Compile>
     <Compile Include="Graphics\RenderTargetUsage.cs" />
     <Compile Include="Graphics\ResourceCreatedEventArgs.cs" />
     <Compile Include="Graphics\ResourceDestroyedEventArgs.cs" />

--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -135,6 +135,7 @@
     <Compile Include="Framework\Visual\EffectTest.cs" />
     <Compile Include="Framework\Visual\GraphicsDeviceTest.cs" />
     <Compile Include="Framework\Visual\RasterizerStateTest.cs" />
+    <Compile Include="Framework\Visual\RenderTargetCubeTest.cs" />
     <Compile Include="Framework\Visual\SamplerStateTest.cs" />
     <Compile Include="Framework\Visual\ScissorRectangleTest.cs" />
     <Compile Include="Framework\Visual\Texture2DTest.cs" />

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -472,7 +472,7 @@ namespace Microsoft.Xna.Framework.Graphics
         // FBO cache used to resolve MSAA rendertargets, we create 1 FBO per RenderTargetBinding combination
         private Dictionary<RenderTargetBinding[], int> glResolveFramebuffers = new Dictionary<RenderTargetBinding[], int>(new RenderTargetBindingArrayComparer());
 
-        internal void PlatformCreateRenderTarget(Texture renderTarget, int width, int height, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
+        internal void PlatformCreateRenderTarget(IRenderTarget renderTarget, int width, int height, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
         {
             var color = 0;
             var depth = 0;
@@ -545,37 +545,25 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
             }
 
-            var renderTarget2D = renderTarget as RenderTarget2D;
-            if (renderTarget2D != null)
-            {
-                if (color != 0)
-                    renderTarget2D.glColorBuffer = color;
-                else
-                    renderTarget2D.glColorBuffer = renderTarget2D.glTexture;
-                renderTarget2D.glDepthBuffer = depth;
-                renderTarget2D.glStencilBuffer = stencil;
-            }
+            if (color != 0)
+                renderTarget.GLColorBuffer = color;
             else
-            {
-                throw new NotSupportedException(); 
-            }
+                renderTarget.GLColorBuffer = renderTarget.GLTexture;
+            renderTarget.GLDepthBuffer = depth;
+            renderTarget.GLStencilBuffer = stencil;
         }
 
-        internal void PlatformDeleteRenderTarget(Texture renderTarget)
+        internal void PlatformDeleteRenderTarget(IRenderTarget renderTarget)
         {
             var color = 0;
             var depth = 0;
             var stencil = 0;
             var colorIsRenderbuffer = false;
 
-            var renderTarget2D = renderTarget as RenderTarget2D;
-            if (renderTarget2D != null)
-            {
-                color = renderTarget2D.glColorBuffer;
-                depth = renderTarget2D.glDepthBuffer;
-                stencil = renderTarget2D.glStencilBuffer;
-                colorIsRenderbuffer = color != renderTarget2D.glTexture;
-            }
+            color = renderTarget.GLColorBuffer;
+            depth = renderTarget.GLDepthBuffer;
+            stencil = renderTarget.GLStencilBuffer;
+            colorIsRenderbuffer = color != renderTarget.GLTexture;
 
             if (color != 0)
             {
@@ -622,7 +610,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 return;
 
             var renderTargetBinding = this._currentRenderTargetBindings[0];
-            var renderTarget = renderTargetBinding.RenderTarget as RenderTarget2D;
+            var renderTarget = renderTargetBinding.RenderTarget as IRenderTarget;
             if (renderTarget.MultiSampleCount > 0 && this.framebufferHelper.SupportsBlitFramebuffer)
             {
                 var glResolveFramebuffer = 0;
@@ -632,7 +620,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     this.framebufferHelper.BindFramebuffer(glResolveFramebuffer);
                     for (var i = 0; i < this._currentRenderTargetCount; ++i)
                     {
-                        this.framebufferHelper.FramebufferTexture2D((int)(FramebufferAttachment.ColorAttachment0 + i), (int)renderTarget.glTarget, renderTarget.glTexture);
+                        this.framebufferHelper.FramebufferTexture2D((int)(FramebufferAttachment.ColorAttachment0 + i), (int) renderTarget.GetFramebufferTarget(renderTargetBinding), renderTarget.GLTexture);
                     }
                     this.glResolveFramebuffers.Add(this._currentRenderTargetBindings, glResolveFramebuffer);
                 }
@@ -648,7 +636,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 for (var i = 0; i < this._currentRenderTargetCount; ++i)
                 {
                     renderTargetBinding = this._currentRenderTargetBindings[i];
-                    renderTarget = renderTargetBinding.RenderTarget as RenderTarget2D;
+                    renderTarget = renderTargetBinding.RenderTarget as IRenderTarget;
                     this.framebufferHelper.BlitFramebuffer(i, renderTarget.Width, renderTarget.Height);
                 }
                 if (renderTarget.RenderTargetUsage == RenderTargetUsage.DiscardContents && this.framebufferHelper.SupportsInvalidateFramebuffer)
@@ -658,12 +646,12 @@ namespace Microsoft.Xna.Framework.Graphics
             for (var i = 0; i < this._currentRenderTargetCount; ++i)
             {
                 renderTargetBinding = this._currentRenderTargetBindings[i];
-                renderTarget = renderTargetBinding.RenderTarget as RenderTarget2D;
+                renderTarget = renderTargetBinding.RenderTarget as IRenderTarget;
                 if (renderTarget.LevelCount > 1)
                 {
-                    GL.BindTexture((TextureTarget)renderTarget.glTarget, renderTarget.glTexture);
+                    GL.BindTexture((TextureTarget)renderTarget.GLTarget, renderTarget.GLTexture);
                     GraphicsExtensions.CheckGLError();
-                    this.framebufferHelper.GenerateMipmap((int)renderTarget.glTarget);
+                    this.framebufferHelper.GenerateMipmap((int)renderTarget.GLTarget);
                 }
             }
         }
@@ -676,18 +664,18 @@ namespace Microsoft.Xna.Framework.Graphics
                 this.framebufferHelper.GenFramebuffer(out glFramebuffer);
                 this.framebufferHelper.BindFramebuffer(glFramebuffer);
                 var renderTargetBinding = this._currentRenderTargetBindings[0];
-                var renderTarget = renderTargetBinding.RenderTarget as RenderTarget2D;
-                this.framebufferHelper.FramebufferRenderbuffer((int)FramebufferAttachment.DepthAttachment, renderTarget.glDepthBuffer, 0);
-                this.framebufferHelper.FramebufferRenderbuffer((int)FramebufferAttachment.StencilAttachment, renderTarget.glStencilBuffer, 0);
+                var renderTarget = renderTargetBinding.RenderTarget as IRenderTarget;
+                this.framebufferHelper.FramebufferRenderbuffer((int)FramebufferAttachment.DepthAttachment, renderTarget.GLDepthBuffer, 0);
+                this.framebufferHelper.FramebufferRenderbuffer((int)FramebufferAttachment.StencilAttachment, renderTarget.GLStencilBuffer, 0);
                 for (var i = 0; i < this._currentRenderTargetCount; ++i)
                 {
                     renderTargetBinding = this._currentRenderTargetBindings[i];
-                    renderTarget = renderTargetBinding.RenderTarget as RenderTarget2D;
+                    renderTarget = renderTargetBinding.RenderTarget as IRenderTarget;
                     var attachement = (int)(FramebufferAttachment.ColorAttachment0 + i);
-                    if (renderTarget.glColorBuffer != renderTarget.glTexture)
-                        this.framebufferHelper.FramebufferRenderbuffer(attachement, renderTarget.glColorBuffer, 0);
+                    if (renderTarget.GLColorBuffer != renderTarget.GLTexture)
+                        this.framebufferHelper.FramebufferRenderbuffer(attachement, renderTarget.GLColorBuffer, 0);
                     else
-                        this.framebufferHelper.FramebufferTexture2D(attachement, (int)renderTarget.glTarget, renderTarget.glTexture, 0, renderTarget.MultiSampleCount);
+                        this.framebufferHelper.FramebufferTexture2D(attachement, (int)renderTarget.GetFramebufferTarget(renderTargetBinding), renderTarget.GLTexture, 0, renderTarget.MultiSampleCount);
                 }
 
 #if DEBUG

--- a/MonoGame.Framework/Graphics/IRenderTarget.cs
+++ b/MonoGame.Framework/Graphics/IRenderTarget.cs
@@ -40,6 +40,20 @@
 using SharpDX.Direct3D11;
 #endif
 
+#if MONOMAC
+#if PLATFORM_MACOS_LEGACY
+using MonoMac.OpenGL;
+#else
+using OpenGL;
+#endif
+#elif DESKTOPGL
+using OpenTK.Graphics.OpenGL;
+using System;
+using System.Collections.Generic;
+#elif GLES
+using OpenTK.Graphics.ES20;
+#endif
+
 namespace Microsoft.Xna.Framework.Graphics
 {
     /// <summary>
@@ -81,6 +95,18 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         /// <returns>The <see cref="DepthStencilView"/>. Can be <see langword="null"/>.</returns>
         DepthStencilView GetDepthStencilView();
+#endif
+
+#if OPENGL
+        int GLTexture { get; }
+        TextureTarget GLTarget { get; }
+        int GLColorBuffer { get; set; }
+        int GLDepthBuffer { get; set; }
+        int GLStencilBuffer { get; set; }
+        int MultiSampleCount { get; }
+        int LevelCount { get; }
+
+        TextureTarget GetFramebufferTarget(RenderTargetBinding renderTargetBinding);
 #endif
     }
 }

--- a/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/RenderTarget2D.OpenGL.cs
@@ -20,9 +20,24 @@ namespace Microsoft.Xna.Framework.Graphics
 {
     public partial class RenderTarget2D
     {
-        internal int glColorBuffer;
-        internal int glDepthBuffer;
-        internal int glStencilBuffer;
+        int IRenderTarget.GLTexture
+        {
+            get { return glTexture; }
+        }
+
+        TextureTarget IRenderTarget.GLTarget
+        {
+            get { return glTarget; }
+        }
+
+        int IRenderTarget.GLColorBuffer { get; set; }
+        int IRenderTarget.GLDepthBuffer { get; set; }
+        int IRenderTarget.GLStencilBuffer { get; set; }
+
+        TextureTarget IRenderTarget.GetFramebufferTarget(RenderTargetBinding renderTargetBinding)
+        {
+            return glTarget;
+        }
 
         private void PlatformConstruct(GraphicsDevice graphicsDevice, int width, int height, bool mipMap,
             SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage, bool shared)

--- a/MonoGame.Framework/Graphics/RenderTargetCube.DirectX.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.DirectX.cs
@@ -1,0 +1,101 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using SharpDX.DXGI;
+using SharpDX.Direct3D11;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    public partial class RenderTargetCube
+    {
+        private RenderTargetView[] _renderTargetViews;
+        private DepthStencilView _depthStencilView;
+
+        private void PlatformConstruct(GraphicsDevice graphicsDevice, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount)
+        {
+            // Create one render target view per cube map face.
+            _renderTargetViews = new RenderTargetView[6];
+            for (int i = 0; i < _renderTargetViews.Length; i++)
+            {
+                var renderTargetViewDescription = new RenderTargetViewDescription
+                {
+                    Dimension = RenderTargetViewDimension.Texture2DArray,
+                    Format = SharpDXHelper.ToFormat(preferredFormat),
+                    Texture2DArray =
+                    {
+                        ArraySize = 1,
+                        FirstArraySlice = i,
+                        MipSlice = 0
+                    }
+                };
+
+                _renderTargetViews[i] = new RenderTargetView(graphicsDevice._d3dDevice, GetTexture(), renderTargetViewDescription);
+            }
+
+            // If we don't need a depth buffer then we're done.
+            if (preferredDepthFormat == DepthFormat.None)
+                return;
+
+            var sampleDescription = new SampleDescription(1, 0);
+            if (preferredMultiSampleCount > 1)
+            {
+                sampleDescription.Count = preferredMultiSampleCount;
+                sampleDescription.Quality = (int)StandardMultisampleQualityLevels.StandardMultisamplePattern;
+            }
+
+            var depthStencilDescription = new Texture2DDescription
+            {
+                Format = SharpDXHelper.ToFormat(preferredDepthFormat),
+                ArraySize = 1,
+                MipLevels = 1,
+                Width = size,
+                Height = size,
+                SampleDescription = sampleDescription,
+                BindFlags = BindFlags.DepthStencil,
+            };
+
+            using (var depthBuffer = new SharpDX.Direct3D11.Texture2D(graphicsDevice._d3dDevice, depthStencilDescription))
+            {
+                var depthStencilViewDescription = new DepthStencilViewDescription
+                {
+                    Dimension = DepthStencilViewDimension.Texture2D,
+                    Format = SharpDXHelper.ToFormat(preferredDepthFormat),
+                };
+                _depthStencilView = new DepthStencilView(graphicsDevice._d3dDevice, depthBuffer, depthStencilViewDescription);
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (_renderTargetViews != null)
+                {
+                    for (var i = 0; i < _renderTargetViews.Length; i++)
+                        _renderTargetViews[i].Dispose();
+
+                    _renderTargetViews = null;
+                    SharpDX.Utilities.Dispose(ref _depthStencilView);
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+
+        /// <inheritdoc/>
+        [CLSCompliant(false)]
+        public RenderTargetView GetRenderTargetView(int arraySlice)
+        {
+            return _renderTargetViews[arraySlice];
+        }
+
+        /// <inheritdoc/>
+        [CLSCompliant(false)]
+        public DepthStencilView GetDepthStencilView()
+        {
+            return _depthStencilView;
+        }
+    }
+}

--- a/MonoGame.Framework/Graphics/RenderTargetCube.DirectX.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.DirectX.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Xna.Framework.Graphics
         private RenderTargetView[] _renderTargetViews;
         private DepthStencilView _depthStencilView;
 
-        private void PlatformConstruct(GraphicsDevice graphicsDevice, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount)
+        private void PlatformConstruct(GraphicsDevice graphicsDevice, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
         {
             // Create one render target view per cube map face.
             _renderTargetViews = new RenderTargetView[6];

--- a/MonoGame.Framework/Graphics/RenderTargetCube.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.OpenGL.cs
@@ -2,15 +2,62 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#if MONOMAC
+#if PLATFORM_MACOS_LEGACY
+using MonoMac.OpenGL;
+#else
+using OpenGL;
+#endif
+#elif DESKTOPGL
+using OpenTK.Graphics.OpenGL;
 using System;
+using System.Collections.Generic;
+#elif GLES
+using OpenTK.Graphics.ES20;
+#endif
 
 namespace Microsoft.Xna.Framework.Graphics
 {
     public partial class RenderTargetCube
     {
-        private void PlatformConstruct(GraphicsDevice graphicsDevice, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount)
+        int IRenderTarget.GLTexture
         {
-            throw new NotImplementedException();
+            get { return glTexture; }
+        }
+
+        TextureTarget IRenderTarget.GLTarget
+        {
+            get { return glTarget; }
+        }
+
+        int IRenderTarget.GLColorBuffer { get; set; }
+        int IRenderTarget.GLDepthBuffer { get; set; }
+        int IRenderTarget.GLStencilBuffer { get; set; }
+
+        TextureTarget IRenderTarget.GetFramebufferTarget(RenderTargetBinding renderTargetBinding)
+        {
+            return TextureTarget.TextureCubeMapPositiveX + renderTargetBinding.ArraySlice;
+        }
+
+        private void PlatformConstruct(GraphicsDevice graphicsDevice, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
+        {
+            Threading.BlockOnUIThread(() =>
+            {
+                graphicsDevice.PlatformCreateRenderTarget(this, size, size, mipMap, preferredFormat, preferredDepthFormat, preferredMultiSampleCount, usage);
+            });
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!IsDisposed)
+            {
+                Threading.BlockOnUIThread(() =>
+                {
+                    this.GraphicsDevice.PlatformDeleteRenderTarget(this);
+                });
+            }
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/MonoGame.Framework/Graphics/RenderTargetCube.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.OpenGL.cs
@@ -1,0 +1,16 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    public partial class RenderTargetCube
+    {
+        private void PlatformConstruct(GraphicsDevice graphicsDevice, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MonoGame.Framework/Graphics/RenderTargetCube.Web.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.Web.cs
@@ -1,0 +1,23 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    public partial class RenderTargetCube
+    {
+        private void PlatformConstruct(GraphicsDevice graphicsDevice, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int preferredMultiSampleCount, RenderTargetUsage usage)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            throw new NotImplementedException();
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/MonoGame.Framework/Graphics/RenderTargetCube.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.cs
@@ -1,60 +1,14 @@
-﻿#region License
-// Microsoft Public License (Ms-PL)
-// MonoGame - Copyright © 2009 The MonoGame Team
-// 
-// All rights reserved.
-// 
-// This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
-// accept the license, do not use the software.
-// 
-// 1. Definitions
-// The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
-// U.S. copyright law.
-// 
-// A "contribution" is the original software, or any additions or changes to the software.
-// A "contributor" is any person that distributes its contribution under this license.
-// "Licensed patents" are a contributor's patent claims that read directly on its contribution.
-// 
-// 2. Grant of Rights
-// (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-// each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-// (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-// each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-// 
-// 3. Conditions and Limitations
-// (A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-// (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
-// your patent license from such contributor to the software ends automatically.
-// (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
-// notices that are present in the software.
-// (D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
-// a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
-// code form, you may only do so under a license that complies with this license.
-// (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
-// or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
-// permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
-// purpose and non-infringement.
-#endregion License
-
-using System;
-#if DIRECTX
-using SharpDX.DXGI;
-using SharpDX.Direct3D11;
-#endif
-
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
 
 namespace Microsoft.Xna.Framework.Graphics
 {
     /// <summary>
     /// Represents a texture cube that can be used as a render target.
     /// </summary>
-    public class RenderTargetCube : TextureCube, IRenderTarget
+    public partial class RenderTargetCube : TextureCube, IRenderTarget
     {
-#if DIRECTX
-        private RenderTargetView[] _renderTargetViews;
-        private DepthStencilView _depthStencilView;
-#endif
-
         /// <summary>
         /// Gets the depth-stencil buffer format of this render target.
         /// </summary>
@@ -115,95 +69,7 @@ namespace Microsoft.Xna.Framework.Graphics
             MultiSampleCount = preferredMultiSampleCount;
             RenderTargetUsage = usage;
 
-#if DIRECTX
-            // Create one render target view per cube map face.
-            _renderTargetViews = new RenderTargetView[6];
-            for (int i = 0; i < _renderTargetViews.Length; i++)
-            {
-                var renderTargetViewDescription = new RenderTargetViewDescription
-                {
-                    Dimension = RenderTargetViewDimension.Texture2DArray,
-                    Format = SharpDXHelper.ToFormat(preferredFormat),
-                    Texture2DArray =
-                    {
-                        ArraySize = 1,
-                        FirstArraySlice = i,
-                        MipSlice = 0
-                    }
-                };
-
-                _renderTargetViews[i] = new RenderTargetView(graphicsDevice._d3dDevice, GetTexture(), renderTargetViewDescription);
-            }
-
-            // If we don't need a depth buffer then we're done.
-            if (preferredDepthFormat == DepthFormat.None)
-                return;
-
-            var sampleDescription = new SampleDescription(1, 0);
-            if (preferredMultiSampleCount > 1)
-            {
-                sampleDescription.Count = preferredMultiSampleCount;
-                sampleDescription.Quality = (int)StandardMultisampleQualityLevels.StandardMultisamplePattern;
-            }
-
-            var depthStencilDescription = new Texture2DDescription
-            {
-                Format = SharpDXHelper.ToFormat(preferredDepthFormat),
-                ArraySize = 1,
-                MipLevels = 1,
-                Width = size,
-                Height = size,
-                SampleDescription = sampleDescription,
-                BindFlags = BindFlags.DepthStencil,
-            };
-
-            using (var depthBuffer = new SharpDX.Direct3D11.Texture2D(graphicsDevice._d3dDevice, depthStencilDescription))
-            {
-                var depthStencilViewDescription = new DepthStencilViewDescription
-                {
-                    Dimension = DepthStencilViewDimension.Texture2D,
-                    Format = SharpDXHelper.ToFormat(preferredDepthFormat),
-                };
-                _depthStencilView = new DepthStencilView(graphicsDevice._d3dDevice, depthBuffer, depthStencilViewDescription);
-            }
-#else
-            throw new NotImplementedException();
-#endif            
+            PlatformConstruct(graphicsDevice, preferredFormat, preferredDepthFormat, preferredMultiSampleCount);
         }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-#if DIRECTX
-                if (_renderTargetViews != null)
-                {
-                    for (var i = 0; i < _renderTargetViews.Length; i++)
-                        _renderTargetViews[i].Dispose();
-
-                    _renderTargetViews = null;
-                    SharpDX.Utilities.Dispose(ref _depthStencilView);
-                }
-#endif
-            }
-
-            base.Dispose(disposing);
-        }
-
-#if DIRECTX
-        /// <inheritdoc/>
-        [CLSCompliant(false)]
-        public RenderTargetView GetRenderTargetView(int arraySlice)
-        {
-            return _renderTargetViews[arraySlice];
-        }
-
-        /// <inheritdoc/>
-        [CLSCompliant(false)]
-        public DepthStencilView GetDepthStencilView()
-        {
-            return _depthStencilView;
-        }
-#endif
     }
 }

--- a/MonoGame.Framework/Graphics/RenderTargetCube.cs
+++ b/MonoGame.Framework/Graphics/RenderTargetCube.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Xna.Framework.Graphics
             MultiSampleCount = preferredMultiSampleCount;
             RenderTargetUsage = usage;
 
-            PlatformConstruct(graphicsDevice, preferredFormat, preferredDepthFormat, preferredMultiSampleCount);
+            PlatformConstruct(graphicsDevice, mipMap, preferredFormat, preferredDepthFormat, preferredMultiSampleCount, usage);
         }
     }
 }

--- a/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
@@ -73,8 +73,10 @@ namespace Microsoft.Xna.Framework.Graphics
         {
 #if OPENGL && (MONOMAC || DESKTOPGL)
             TextureTarget target = GetGLCubeFace(cubeMapFace);
-            GL.BindTexture(target, this.glTexture);
+            GL.BindTexture(TextureTarget.TextureCubeMap, this.glTexture);
+            GraphicsExtensions.CheckGLError();
             GL.GetTexImage<T>(target, 0, glFormat, glType, data);
+            GraphicsExtensions.CheckGLError();
 #else
             throw new NotImplementedException();
 #endif

--- a/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
@@ -71,15 +71,10 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformGetData<T>(CubeMapFace cubeMapFace, T[] data) where T : struct
         {
-#if OPENGL && MONOMAC
+#if OPENGL && (MONOMAC || DESKTOPGL)
             TextureTarget target = GetGLCubeFace(cubeMapFace);
             GL.BindTexture(target, this.glTexture);
-            // 4 bytes per pixel
-            if (data.Length < size * size * 4)
-                throw new ArgumentException("data");
-
-            GL.GetTexImage<T>(target, 0, PixelFormat.Bgra,
-                PixelType.UnsignedByte, data);
+            GL.GetTexImage<T>(target, 0, glFormat, glType, data);
 #else
             throw new NotImplementedException();
 #endif

--- a/Test/Framework/Visual/RenderTargetCubeTest.cs
+++ b/Test/Framework/Visual/RenderTargetCubeTest.cs
@@ -1,0 +1,42 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using NUnit.Framework;
+
+namespace MonoGame.Tests.Visual
+{
+    [TestFixture]
+    class RenderTargetCubeTest : VisualTestFixtureBase
+    {
+        [TestCase(1)]
+        [TestCase(8)]
+        [TestCase(31)]
+        public void ShouldClearRenderTargetAndGetData(int size)
+        {
+            Game.DrawWith += (sender, e) =>
+            {
+                var dataSize = size * size;
+                var renderTargetCube = new RenderTargetCube(Game.GraphicsDevice, size, false, SurfaceFormat.Color, DepthFormat.Depth16);
+
+                for (var i = 0; i < 6; i++)
+                {
+                    var cubeMapFace = (CubeMapFace) i;
+
+                    Game.GraphicsDevice.SetRenderTarget(renderTargetCube, cubeMapFace);
+                    Game.GraphicsDevice.Clear(ClearOptions.Target | ClearOptions.DepthBuffer, Color.BlanchedAlmond, 1.0f, 0);
+                    Game.GraphicsDevice.SetRenderTarget(null, cubeMapFace);
+
+                    var readData = new Color[dataSize];
+                    renderTargetCube.GetData(cubeMapFace, readData);
+
+                    for (var j = 0; j < dataSize; j++)
+                        Assert.AreEqual(Color.BlanchedAlmond, readData[j]);
+                }
+            };
+            Game.Run();
+        }
+    }
+}

--- a/Test/Framework/Visual/RenderTargetCubeTest.cs
+++ b/Test/Framework/Visual/RenderTargetCubeTest.cs
@@ -21,19 +21,30 @@ namespace MonoGame.Tests.Visual
                 var dataSize = size * size;
                 var renderTargetCube = new RenderTargetCube(Game.GraphicsDevice, size, false, SurfaceFormat.Color, DepthFormat.Depth16);
 
+                var colors = new[]
+                {
+                    Color.BlanchedAlmond,
+                    Color.BlueViolet,
+                    Color.DarkSeaGreen,
+                    Color.ForestGreen,
+                    Color.IndianRed,
+                    Color.LightGoldenrodYellow
+                };
+
                 for (var i = 0; i < 6; i++)
                 {
-                    var cubeMapFace = (CubeMapFace) i;
+                    Game.GraphicsDevice.SetRenderTarget(renderTargetCube, (CubeMapFace) i);
+                    Game.GraphicsDevice.Clear(ClearOptions.Target | ClearOptions.DepthBuffer, colors[i], 1.0f, 0);
+                    Game.GraphicsDevice.SetRenderTarget(null, (CubeMapFace) i);
+                }
 
-                    Game.GraphicsDevice.SetRenderTarget(renderTargetCube, cubeMapFace);
-                    Game.GraphicsDevice.Clear(ClearOptions.Target | ClearOptions.DepthBuffer, Color.BlanchedAlmond, 1.0f, 0);
-                    Game.GraphicsDevice.SetRenderTarget(null, cubeMapFace);
-
+                for (var i = 0; i < 6; i++)
+                {
                     var readData = new Color[dataSize];
-                    renderTargetCube.GetData(cubeMapFace, readData);
+                    renderTargetCube.GetData((CubeMapFace) i, readData);
 
                     for (var j = 0; j < dataSize; j++)
-                        Assert.AreEqual(Color.BlanchedAlmond, readData[j]);
+                        Assert.AreEqual(colors[i], readData[j]);
                 }
             };
             Game.Run();

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Framework\Visual\GraphicsDeviceTest.cs" />
     <Compile Include="Framework\Visual\IndexBufferTest.cs" />
     <Compile Include="Framework\Visual\RasterizerStateTest.cs" />
+    <Compile Include="Framework\Visual\RenderTargetCubeTest.cs" />
     <Compile Include="Framework\Visual\SamplerStateTest.cs" />
     <Compile Include="Framework\Visual\TextureCubeTest.cs" />
     <Compile Include="Framework\Visual\VertexBufferTest.cs" />


### PR DESCRIPTION
Fixes #2411.

This PR adds support for RenderTargetCube on OpenGL, with a test.

A couple of notes:

* Unfortunately the [new] test doesn't pass on OpenGL :( However, the specific part of the test that renders to a `RenderTargetCube` and then extracts the data and compares it with known-good data, passes. The part that fails is when `PlatformPresent` is subsequently called. That part is not really related to the test. It obviously should pass, but I have no idea why it doesn't. Here's the stack trace; does anyone have any ideas?

``` csharp
Microsoft.Xna.Framework.Graphics.MonoGameGLException : GL.GetError() returned InvalidEnum

   at Microsoft.Xna.Framework.Graphics.GraphicsExtensions.CheckGLError() in C:\Users\Tim Jones\Documents\GitHub\MonoGame\MonoGame.Framework\Graphics\GraphicsExtensions.cs:line 919
   at Microsoft.Xna.Framework.Graphics.GraphicsDevice.PlatformPresent() in C:\Users\Tim Jones\Documents\GitHub\MonoGame\MonoGame.Framework\Graphics\GraphicsDevice.OpenGL.cs:line 380
   at Microsoft.Xna.Framework.Graphics.GraphicsDevice.Present() in C:\Users\Tim Jones\Documents\GitHub\MonoGame\MonoGame.Framework\Graphics\GraphicsDevice.cs:line 509
   at Microsoft.Xna.Framework.OpenTKGamePlatform.Present() in C:\Users\Tim Jones\Documents\GitHub\MonoGame\MonoGame.Framework\Desktop\OpenTKGamePlatform.cs:line 292
   at Microsoft.Xna.Framework.Game.EndDraw() in C:\Users\Tim Jones\Documents\GitHub\MonoGame\MonoGame.Framework\Game.cs:line 526
   at Microsoft.Xna.Framework.Game.DoDraw(GameTime gameTime) in C:\Users\Tim Jones\Documents\GitHub\MonoGame\MonoGame.Framework\Game.cs:line 684
   at Microsoft.Xna.Framework.Game.Tick() in C:\Users\Tim Jones\Documents\GitHub\MonoGame\MonoGame.Framework\Game.cs:line 515
   at Microsoft.Xna.Framework.OpenTKGamePlatform.RunLoop() in C:\Users\Tim Jones\Documents\GitHub\MonoGame\MonoGame.Framework\Desktop\OpenTKGamePlatform.cs:line 144
   at Microsoft.Xna.Framework.Game.Run(GameRunBehavior runBehavior) in C:\Users\Tim Jones\Documents\GitHub\MonoGame\MonoGame.Framework\Game.cs:line 397
   at MonoGame.Tests.TestGameBase.Run(Predicate`1 until) in C:\Users\Tim Jones\Documents\GitHub\MonoGame\Test\Framework\TestGameBase.cs:line 185
   at MonoGame.Tests.Visual.RenderTargetCubeTest.ShouldClearRenderTargetAndGetData(Int32 size) in C:\Users\Tim Jones\Documents\GitHub\MonoGame\Test\Framework\Visual\RenderTargetCubeTest.cs:line 50
```

* In order to avoid duplicating loads of render target-related code (for `RenderTarget2D` and `RenderTargetCube`) in `GraphicsDevice.OpenGL.cs`, I have added some properties and a method to `IRenderTarget`.