### PR TITLE
WinDX: Fixed GDI leak in GraphicsAdapter.CurrentDisplayMode

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsAdapter.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.cs
@@ -96,7 +96,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 using (var graphics = System.Drawing.Graphics.FromHwnd(IntPtr.Zero))
                 {
                     var dc = graphics.GetHdc();
-                    return new DisplayMode(GetDeviceCaps(dc, HORZRES), GetDeviceCaps(dc, VERTRES), SurfaceFormat.Color);
+                    int width = GetDeviceCaps(dc, HORZRES);
+                    int height = GetDeviceCaps(dc, VERTRES);
+                    graphics.ReleaseHdc(dc);
+                    return new DisplayMode(width, height, SurfaceFormat.Color);
                 }
 #else
                 return new DisplayMode(800, 600, SurfaceFormat.Color);

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.cs
@@ -93,8 +93,11 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 return new DisplayMode(OpenTK.DisplayDevice.Default.Width, OpenTK.DisplayDevice.Default.Height, SurfaceFormat.Color);
 #elif WINDOWS
-                var dc = System.Drawing.Graphics.FromHwnd(IntPtr.Zero).GetHdc();
-                return new DisplayMode(GetDeviceCaps(dc, HORZRES), GetDeviceCaps(dc, VERTRES), SurfaceFormat.Color);
+                using (var graphics = System.Drawing.Graphics.FromHwnd(IntPtr.Zero))
+                {
+                    var dc = graphics.GetHdc();
+                    return new DisplayMode(GetDeviceCaps(dc, HORZRES), GetDeviceCaps(dc, VERTRES), SurfaceFormat.Color);
+                }
 #else
                 return new DisplayMode(800, 600, SurfaceFormat.Color);
 #endif


### PR DESCRIPTION
Today I got a crash report with the following exception:
```
Type: System.ArgumentException
Message: Parameter is not valid.
Source: System.Drawing
Stack Trace:
at System.Drawing.Graphics.GetHdc()
at Microsoft.Xna.Framework.Graphics.GraphicsAdapter.get_CurrentDisplayMode()
...
```
Turns out there was a bit of a GDI leak in `GraphicsAdapter.CurrentDisplayMode`. The main problem was that a `Graphics` object was being created (via `Graphics.FromHwnd(IntPtr.Zero)`) but wasn't being disposed. This meant that the resources weren't being released until the garbage collector kicked in. So calling `CurrentDisplayMode` a lot could eventually lead to the above crash.

The fix was as simple as wrapping the `Graphics` object in a `using` so that it got disposed.