### PR TITLE
Removed state check to force stop playing instances

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Xna.Framework.Audio
             for (var x = 0; x < _playingInstances.Count;)
             {
                 inst = _playingInstances[x];
-                if (inst.State != SoundState.Stopped && inst._effect == effect)
+                if (inst._effect == effect)
                 {
                     inst.Stop(true); // stop immediatly
                     Add(inst);


### PR DESCRIPTION
This PR removes the ```SoundEffectInstance.State``` check from the disposing mechanism of the ```SoundEffectInstancePool```. This was causing problem to the OpenAL implementation because its ```SoundEffectInstance.PlatformGetState()``` was internally updating the state, which was making the pool to think that some instances were wrongly stopped, preventing them from freeing their OpenAL source.
This rare scenario ended up in an AL crash in ```SoundEffect.Dispose()``` because the sound buffer was still bound to a ```SoundEffectInstance```.

This change doesn't affect other implementations.

Ping @dellis1972 :)