### PR TITLE
Clean up some code that potentially was reflected.

### DIFF
--- a/MonoGame.Framework/BoundingFrustum.cs
+++ b/MonoGame.Framework/BoundingFrustum.cs
@@ -471,65 +471,7 @@ namespace Microsoft.Xna.Framework
                     result = 0.0f;
                     return;
                 case ContainmentType.Intersects:
-                    
-                    // TODO: Needs additional test for not 0.0 and null results.
-
-                    result = null;
-
-                    float min = float.MinValue;
-                    float max = float.MaxValue;
-                    foreach (Plane plane in this._planes)
-                    {
-                        var normal = plane.Normal;
-
-                        float result2;
-                        Vector3.Dot(ref ray.Direction, ref normal, out result2);
-
-                        float result3;
-                        Vector3.Dot(ref ray.Position, ref normal, out result3);
-
-                        result3 += plane.D;
-
-                        if ((double)Math.Abs(result2) < 9.99999974737875E-06)
-                        {
-                            if ((double)result3 > 0.0)
-                                return;
-                        }
-                        else
-                        {
-                            float result4 = -result3 / result2;
-                            if ((double)result2 < 0.0)
-                            {
-                                if ((double)result4 > (double)max)
-                                    return;
-                                if ((double)result4 > (double)min)
-                                    min = result4;
-                            }
-                            else
-                            {
-                                if ((double)result4 < (double)min)
-                                    return;
-                                if ((double)result4 < (double)max)
-                                    max = result4;
-                            }
-                        }
-
-                        var distance = ray.Intersects(plane);
-                        if (distance.HasValue)
-                        {
-                            min = Math.Min(min, distance.Value);
-                            max = Math.Max(max, distance.Value);
-                        }
-                    }
-
-                    float temp = min >= 0.0 ? min : max;
-                    if (temp < 0.0)
-                    {
-                        return;
-                    }
-                    result = temp;
-
-                    return;
+                    throw new NotImplementedException();
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/MonoGame.Framework/Vector4.cs
+++ b/MonoGame.Framework/Vector4.cs
@@ -941,22 +941,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Transformed <see cref="Vector4"/> as an output parameter.</param>
         public static void Transform(ref Vector2 value, ref Quaternion rotation, out Vector4 result)
         {
-            double xx = rotation.X + rotation.X;
-            double yy = rotation.Y + rotation.Y;
-            double zz = rotation.Z + rotation.Z;
-            double wxx = rotation.W * xx;
-            double wyy = rotation.W * yy;
-            double wzz = rotation.W * zz;
-            double xxx = rotation.X * xx;
-            double xyy = rotation.X * yy;
-            double xzz = rotation.X * zz;
-            double yyy = rotation.Y * yy;
-            double yzz = rotation.Y * zz;
-            double zzz = rotation.Z * zz;
-            result.X = (float)((double)value.X * (1.0 - yyy - zzz) + (double)value.Y * (xyy - wzz));
-            result.Y = (float)((double)value.X * (xyy + wzz) + (double)value.Y * (1.0 - xxx - zzz));
-            result.Z = (float)((double)value.X * (xzz - wyy) + (double)value.Y * (yzz + wxx));
-            result.W = 1f;
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -981,22 +966,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Transformed <see cref="Vector4"/> as an output parameter.</param>
         public static void Transform(ref Vector3 value, ref Quaternion rotation, out Vector4 result)
         {
-            double xx = rotation.X + rotation.X;
-            double yy = rotation.Y + rotation.Y;
-            double zz = rotation.Z + rotation.Z;
-            double wxx = rotation.W * xx;
-            double wyy = rotation.W * yy;
-            double wzz = rotation.W * zz;
-            double xxx = rotation.X * xx;
-            double xyy = rotation.X * yy;
-            double xzz = rotation.X * zz;
-            double yyy = rotation.Y * yy;
-            double yzz = rotation.Y * zz;
-            double zzz = rotation.Z * zz;
-            result.X = (float)((double)value.X * (1.0 - yyy - zzz) + (double)value.Y * (xyy - wzz) + (double)value.Z * (xzz + wyy));
-            result.Y = (float)((double)value.X * (xyy + wzz) + (double)value.Y * (1.0 - xxx - zzz) + (double)value.Z * (yzz - wxx));
-            result.Z = (float)((double)value.X * (xzz - wyy) + (double)value.Y * (yzz + wxx) + (double)value.Z * (1.0 - xxx - yyy));
-            result.W = 1f;
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -1025,22 +995,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="result">Transformed <see cref="Vector4"/> as an output parameter.</param>
         public static void Transform(ref Vector4 value, ref Quaternion rotation, out Vector4 result)
         {
-            double xx = rotation.X + rotation.X;
-            double yy = rotation.Y + rotation.Y;
-            double zz = rotation.Z + rotation.Z;
-            double wxx = rotation.W * xx;
-            double wyy = rotation.W * yy;
-            double wzz = rotation.W * zz;
-            double xxx = rotation.X * xx;
-            double xyy = rotation.X * yy;
-            double xzz = rotation.X * zz;
-            double yyy = rotation.Y * yy;
-            double yzz = rotation.Y * zz;
-            double zzz = rotation.Z * zz;
-            result.X = (float)((double)value.X * (1.0 - yyy - zzz) + (double)value.Y * (xyy - wzz) + (double)value.Z * (xzz + wyy));
-            result.Y = (float)((double)value.X * (xyy + wzz) + (double)value.Y * (1.0 - xxx - zzz) + (double)value.Z * (yzz - wxx));
-            result.Z = (float)((double)value.X * (xzz - wyy) + (double)value.Y * (yzz + wxx) + (double)value.Z * (1.0 - xxx - yyy));
-            result.W = value.W;
+            throw new NotImplementedException();
         }
 
         /// <summary>


### PR DESCRIPTION
After an incident with a contributor and auditing their contributions we
have a strong suspicion that some bits of their code came from either a
copyrighted source or from a reflection tool.

While we do not have definitive proof of this and cannot be certain of
the code's origin, we feel it is just better for the project to remove
those chunks of code.

 The code in question is in the following functions:

   - BoundingFrustum.Intersects(ref Ray ray, out float? result)
   - Vector4.Transform(ref Vector2 value, ref Quaternion rotation, out Vector4 result)
   - Vector4.Transform(ref Vector3 value, ref Quaternion rotation, out Vector4 result)
   - Vector4.Transform(ref Vector4 value, ref Quaternion rotation, out Vector4 result)

We hope that someone in the community can contribute their own implementations
to fix these holes soon (of course without reading or reusing any of the code removed in this PR).

We will also follow up with an update to the existing CONTRIBUTING.md to help further clarify what we require from them.