### PR TITLE
Fix mouse coordinate for DesktopGL and windowed mode

### DIFF
--- a/MonoGame.Framework/Input/Mouse.cs
+++ b/MonoGame.Framework/Input/Mouse.cs
@@ -140,9 +140,9 @@ namespace Microsoft.Xna.Framework.Input
 #elif DESKTOPGL || ANGLE
 
             var state = OpenTK.Input.Mouse.GetCursorState();
-            var pc = ((OpenTKGameWindow)window).Window.PointToClient(new System.Drawing.Point(state.X, state.Y));
-            window.MouseState.X = pc.X;
-            window.MouseState.Y = pc.Y;
+            
+            window.MouseState.X = state.X;
+            window.MouseState.Y = state.Y;
 
             window.MouseState.LeftButton = (ButtonState)state.LeftButton;
             window.MouseState.RightButton = (ButtonState)state.RightButton;


### PR DESCRIPTION
```OpenTK.Input.Mouse.GetCursorState()``` and ```OpenTK.Input.Mouse.GetState()``` both return coordinates relatively to the drawing surface. The current mouse code assume them to be relative to the display, and not the drawing surface, and tries to adjust them with the window's position. This was causing mouse coordinates to be wrong when using windowed.

This PR fixes this behavior.

However, OpenTK doesn't provide methods to get the mouse position relatively to the display, and therefore ```Microsoft.Xna.Framework.Input.Mouse.GetState(GameWindow window)``` can't return coordinates specific to a ```GameWindow``` and will always return them relatively to the active OpenTK surface.

@cra0zy @dellis1972 