### PR TITLE
Fix Content Building on Mac

### DIFF
--- a/Tools/2MGFX/Program.cs
+++ b/Tools/2MGFX/Program.cs
@@ -7,7 +7,7 @@ namespace TwoMGFX
     {
         public static int Main(string[] args)
         {
-            if (!Environment.Is64BitProcess)
+            if (!Environment.Is64BitProcess && Environment.OSVersion.Platform != PlatformID.Unix)
             {
                 Console.Error.WriteLine("The MonoGame content tools only work on a 64bit OS.");
                 return -1;

--- a/Tools/MGCB/Program.cs
+++ b/Tools/MGCB/Program.cs
@@ -17,7 +17,7 @@ namespace MGCB
             // to avoid any out of order console output.
             Console.SetError(Console.Out);
 
-            if (!Environment.Is64BitProcess)
+            if (!Environment.Is64BitProcess && Environment.OSVersion.Platform != PlatformID.Unix)
             {
                 Console.Error.WriteLine("The MonoGame content tools only work on a 64bit OS.");
                 return -1;


### PR DESCRIPTION
At the moment 64 bit mono is not really available,
it is still in preview. So we need to disable this
64Bit check for Mac (and Linux) until its in stable.