### PR TITLE
Fix inaccessible GetGuid for OpenTK on Linux / DesktopGL

### DIFF
--- a/MonoGame.Framework/Input/Joystick.OpenTK.cs
+++ b/MonoGame.Framework/Input/Joystick.OpenTK.cs
@@ -26,7 +26,11 @@ namespace Microsoft.Xna.Framework.Input
             return new JoystickCapabilities 
             {
                 IsConnected = true,
+#if DESKTOPGL
+                Id = string.Empty,
+#else
                 Id = OpenTK.Input.Joystick.GetGuid(index).ToString(),
+#endif
                 AxisCount = cap.AxisCount,
                 ButtonCount = cap.ButtonCount,
                 HatCount = cap.HatCount


### PR DESCRIPTION
On Linux / DesktopGL, this method is inaccessible under OpenTK, and results in:

```
Input/Joystick.OpenTK.cs(29,44): error CS0122: `OpenTK.Input.Joystick.GetGuid(int)' is inaccessible due to its protection level
```

when building either the Linux or WindowsGL projects.  On these platforms, default to an empty string instead.