### PR TITLE
Fix casing in MonoGame.Tests project definition

### DIFF
--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -754,7 +754,7 @@
     <Content Include="Assets\Fonts\Lindsey.xnb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Assets\Fonts\MotorWerk.xnb">
+    <Content Include="Assets\Fonts\Motorwerk.xnb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Assets\Fonts\QuartzMS.xnb">
@@ -814,11 +814,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
 
-    <Content Include="Assets\Textures\Logo555.bmp">
+    <Content Include="Assets\Textures\logo555.bmp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
 
-    <Content Include="Assets\Textures\Logo565.bmp">
+    <Content Include="Assets\Textures\logo565.bmp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
 


### PR DESCRIPTION
When building on case sensitive platforms, the build fails because the MonoGame.Tests project has a casing that differs from the filenames on disk, which results in these build errors:

```
/usr/lib/mono/xbuild/12.0/bin/Microsoft.Common.targets: error : Cannot copy /srv/leases/workingcopy-26560/repo/monogame/Test/Assets/Fonts/MotorWerk.xnb to /srv/leases/workingcopy-26560/repo/monogame/Test/bin/Windows/AnyCPU/Release/Assets/Fonts/MotorWerk.xnb, as the source file doesn't exist.
797		/usr/lib/mono/xbuild/12.0/bin/Microsoft.Common.targets: error : Cannot copy /srv/leases/workingcopy-26560/repo/monogame/Test/Assets/Textures/Logo555.bmp to /srv/leases/workingcopy-26560/repo/monogame/Test/bin/Windows/AnyCPU/Release/Assets/Textures/Logo555.bmp, as the source file doesn't exist.
798		/usr/lib/mono/xbuild/12.0/bin/Microsoft.Common.targets: error : Cannot copy /srv/leases/workingcopy-26560/repo/monogame/Test/Assets/Textures/Logo565.bmp to /srv/leases/workingcopy-26560/repo/monogame/Test/bin/Windows/AnyCPU/Release/Assets/Textures/Logo565.bmp, as the source file doesn't exist.
799	
```

Instead, set the casing in the definition to match the name of the files on disk.