### PR TITLE
Fix exit crash on Windows native desktopGL

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGameWindow.cs
@@ -222,7 +222,7 @@ namespace Microsoft.Xna.Framework
         private void OnResize(object sender, EventArgs e)
         {
             // Ignore resize events until intialization is complete
-            if (Game == null)
+            if (Game == null || Game.GraphicsDevice == null)
                 return;
 
             lock (window)


### PR DESCRIPTION
When DesktopGL uses the native backend on Windows, ```OpenTKGameWindow.OnResize()``` may be called with a null ```GraphicsDevice``` upon exit.

Just a little null check so that it doesn't crash.