### PR TITLE
[Linux Installer] Disable copying of nvtt libs

### DIFF
--- a/Installers/Linux/RUN/postinstall.sh
+++ b/Installers/Linux/RUN/postinstall.sh
@@ -31,23 +31,6 @@ echo "rm -rf $IDIR" >> $IDIR/uninstall.sh
 #automatic dependency installer
 ./Dependencies/dependencies.sh
 
-#setup nvtt libraries
-if [ ! -f /lib/libnvcore.so ]; then
-	ln $IDIR/libnvcore.so /lib/libnvcore.so
-fi
-
-if [ ! -f /lib/libnvimage.so ]; then
-	ln $IDIR/libnvimage.so /lib/libnvimage.so
-fi
-
-if [ ! -f /lib/libnvmath.so ]; then
-	ln $IDIR/libnvmath.so /lib/libnvmath.so
-fi
-
-if [ ! -f /lib/libnvtt.so ]; then
-	ln $IDIR/libnvtt.so /lib/libnvtt.so
-fi
-
 #check GLIBCXX_3.4.20 support
 if [ -f /usr/lib/x86_64-linux-gnu/libstdc++.so.6 ]
 then
@@ -57,7 +40,7 @@ then
 	if [ ! $size -gt 0 ] 
 	then
 		echo "Your libstdc++.so.6 does not support GLIBCXX_3.4.20. Want to copy newer version of it?"
-		echo "Old version will be copied renamed to libstdc++.so.6.old"
+		echo "Old version will be renamed to libstdc++.so.6.old"
 		read -p "(Y, n): " choice
 	
 		case "$choice" in 

--- a/Installers/default.build
+++ b/Installers/default.build
@@ -157,10 +157,6 @@ fi
       <copy file="Linux/Main/monogame-pipeline" tofile="Linux/tmp_deb/bin/monogame-pipeline"/>
       <copy file="Linux/Main/monogame.svg" tofile="Linux/tmp_deb/usr/share/icons/gnome/scalable/mimetypes/monogame.svg"/>
       <copy file="../MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets" tofile="Linux/tmp_deb/usr/lib/mono/xbuild/MonoGame/v3.0/MonoGame.Content.Builder.targets"/>
-      <copy file="Linux/tmp_deb/opt/monogame-pipeline/libnvcore.so" tofile="Linux/tmp_deb/lib/libnvcore.so"/>
-      <copy file="Linux/tmp_deb/opt/monogame-pipeline/libnvimage.so" tofile="Linux/tmp_deb/lib/libnvimage.so"/>
-      <copy file="Linux/tmp_deb/opt/monogame-pipeline/libnvmath.so" tofile="Linux/tmp_deb/lib/libnvmath.so"/>
-      <copy file="Linux/tmp_deb/opt/monogame-pipeline/libnvtt.so" tofile="Linux/tmp_deb/lib/libnvtt.so"/>
       <echo file="Linux/tmp_deb/DEBIAN/control" append="true">version: ${buildNumber}&#xa;</echo>
       <copy todir="Linux/tmp_deb/usr/lib/mono/xbuild/MonoGame/v3.0/Assemblies/DesktopGL">
          <fileset basedir="../MonoGame.Framework/bin/Linux/AnyCPU/Release">


### PR DESCRIPTION
This was needed because when I compiled nvtt libs, I didn't know about rpath, and left it to default(which was my home path), @KonajuGames recompiled them so this is no longer needed.