### PR TITLE
Fix WindowsUniversal nuspec

### DIFF
--- a/NuGetPackages/MonoGame.Framework.WindowsUniversal.nuspec
+++ b/NuGetPackages/MonoGame.Framework.WindowsUniversal.nuspec
@@ -32,7 +32,6 @@
         <file src="WindowsUniversal\AnyCPU\Release\SharpDX.DXGI.dll" target="lib\netcore\SharpDX.DXGI.dll" />
         <file src="WindowsUniversal\AnyCPU\Release\SharpDX.MediaFoundation.dll" target="lib\netcore\SharpDX.MediaFoundation.dll" />
         <file src="WindowsUniversal\AnyCPU\Release\SharpDX.XAudio2.dll" target="lib\netcore\SharpDX.XAudio2.dll" />
-        <file src="WindowsUniversal\AnyCPU\Release\SharpDX.XInput.dll" target="lib\netcore\SharpDX.XInput.dll" />
         <file src="..\..\NuGetPackages\readme\MonoGame.Framework\readme.txt" target="readme.txt" />
     </files>
 </package>

--- a/NuGetPackages/Readme-Build.txt
+++ b/NuGetPackages/Readme-Build.txt
@@ -1,4 +1,4 @@
-Example commands to build NuGet Packages (requires an output folder called "packages)
+Example commands to build NuGet Packages (requires an output folder called "packages" that exists)
 
 Builds require the -BasePath parameter to point to the MonoGame.Framework\bin directory, as this is where all the NuGet's are based on
 
@@ -13,4 +13,4 @@ NuGet pack MonoGame.Framework.WindowsDX.nuspec -BasePath ..\MonoGame.Framework\b
 NuGet pack MonoGame.Framework.WindowsGL.nuspec -BasePath ..\MonoGame.Framework\bin -OutputDirectory packages
 NuGet pack MonoGame.Framework.WindowsPhone8.nuspec -BasePath ..\MonoGame.Framework\bin -OutputDirectory packages
 NuGet pack MonoGame.Framework.WindowsPhone81.nuspec -BasePath ..\MonoGame.Framework\bin -OutputDirectory packages
-NuGet pack MonoGame.Framework.DesktopGL.nuspec -BasePath ..\MonoGame.Framework\bin -OutputDirectory packages
+NuGet pack MonoGame.Framework.WindowsUniversal.nuspec -BasePath ..\MonoGame.Framework\bin -OutputDirectory packages


### PR DESCRIPTION
As stated in #4515, this pull removes the reference, and also updates the readme
Remove SharpDX.XInput.dll reference from
MonoGame.Framework.WindowsUniversal.nuspec
Update contents of Readme-Build.txt