### PR TITLE
ContentReader, use Lz4DecoderStream directly

### DIFF
--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -498,17 +498,10 @@ namespace Microsoft.Xna.Framework.Content
                 }
                 else if (compressedLz4)
                 {
-                    // Decompress to a byte[] because Windows 8 doesn't support MemoryStream.GetBuffer()
-                    var buffer = new byte[decompressedSize];
-                    using (var decoderStream = new Lz4DecoderStream(stream))
-                    {
-                        if (decoderStream.Read(buffer, 0, buffer.Length) != decompressedSize)
-                        {
-                            throw new ContentLoadException("Decompression of " + originalAssetName + " failed. ");
-                        }
-                    }
-                    // Creating the MemoryStream with a byte[] shares the buffer so it doesn't allocate any more memory
-                    decompressedStream = new MemoryStream(buffer);
+                    var lz4Stream = new Lz4DecoderStream(stream);
+                    reader = new ContentReader(this, lz4Stream, this.graphicsDeviceService.GraphicsDevice,
+                                                            originalAssetName, version, recordDisposableObject);
+                    return reader;
                 }
 
                 reader = new ContentReader(this, decompressedStream, this.graphicsDeviceService.GraphicsDevice,

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -432,12 +432,11 @@ namespace Microsoft.Xna.Framework.Content
             // The next int32 is the length of the XNB file
             int xnbLength = xnbReader.ReadInt32();
 
-            ContentReader reader;
+            Stream decompressedStream = null;
             if (compressedLzx || compressedLz4)
             {
                 // Decompress the xnb
                 int decompressedSize = xnbReader.ReadInt32();
-                MemoryStream decompressedStream = null;
 
                 if (compressedLzx)
                 {
@@ -498,20 +497,17 @@ namespace Microsoft.Xna.Framework.Content
                 }
                 else if (compressedLz4)
                 {
-                    var lz4Stream = new Lz4DecoderStream(stream);
-                    reader = new ContentReader(this, lz4Stream, this.graphicsDeviceService.GraphicsDevice,
-                                                            originalAssetName, version, recordDisposableObject);
-                    return reader;
+                    decompressedStream = new Lz4DecoderStream(stream);
                 }
-
-                reader = new ContentReader(this, decompressedStream, this.graphicsDeviceService.GraphicsDevice,
-                                                            originalAssetName, version, recordDisposableObject);
             }
             else
             {
-                reader = new ContentReader(this, stream, this.graphicsDeviceService.GraphicsDevice,
-                                                            originalAssetName, version, recordDisposableObject);
+                decompressedStream = stream;
             }
+
+            var reader = new ContentReader(this, decompressedStream, this.graphicsDeviceService.GraphicsDevice,
+                                                        originalAssetName, version, recordDisposableObject);
+            
             return reader;
         }
 


### PR DESCRIPTION
We pass the Lz4DecoderStream to the ContentReader instead of 2-step decompressing in MemoryStream. Improve performance since we avoid extra memory allocation and memcopy.

The only difference is that we no longer check the decompressedSize but that's something we can check better on the contentPipeline (compress & decompress to check data  integrity). However the Lz4 code has been proven to be fine so far.