### PR TITLE
Linux Installers Upgrades

### DIFF
--- a/Installers/Linux/DEBIAN/postinst
+++ b/Installers/Linux/DEBIAN/postinst
@@ -1,16 +1,12 @@
 #!/bin/sh
+
 xdg-mime install /tmp/mgcb.xml --novendor
 xdg-mime default "Monogame Pipeline.desktop" text/mgcb
 sudo -H -u $SUDO_USER bash -c 'mdtool setup install -y /tmp/MonoDevelop.MonoGame.mpack'
 
-if [ -L /usr/lib/mono/xbuild/MonoGame/v3.0/Tools ]; then
-	rm -rf /usr/lib/mono/xbuild/MonoGame/v3.0/Tools
-fi
+rm -rf /usr/lib/mono/xbuild/MonoGame/v3.0/Tools
 ln -s /opt/monogame-pipeline /usr/lib/mono/xbuild/MonoGame/v3.0/Tools
 
-if [ -f /usr/share/applications/Monogame\ Pipeline.desktop ]
-then
-	rm /usr/share/applications/Monogame\ Pipeline.desktop
-fi
+rm -f /usr/share/applications/Monogame\ Pipeline.desktop
 echo "[Desktop Entry]\nVersion=1.0\nEncoding=UTF-8\nName=MonoGame Pipeline\nGenericName=MonoGame Pipeline\nComment=Used to create platform specific .xnb files\nExec=monogame-pipeline %F\nTryExec=monogame-pipeline\nIcon=monogame\nStartupNotify=true\nTerminal=false\nType=Application\nMimeType=text/mgcb;\nCategories=Development;" >> /usr/share/applications/Monogame\ Pipeline.desktop
 

--- a/Installers/Linux/DEBIAN/postinst
+++ b/Installers/Linux/DEBIAN/postinst
@@ -4,8 +4,8 @@ xdg-mime install /tmp/mgcb.xml --novendor
 xdg-mime default "Monogame Pipeline.desktop" text/mgcb
 sudo -H -u $SUDO_USER bash -c 'mdtool setup install -y /tmp/MonoDevelop.MonoGame.mpack'
 
-rm -rf /usr/lib/mono/xbuild/MonoGame/v3.0/Tools
-ln -s /opt/monogame-pipeline /usr/lib/mono/xbuild/MonoGame/v3.0/Tools
+rm -rf /opt/MonoGameSDK
+ln -s /usr/lib/mono/xbuild/MonoGame/v3.0/Tools /opt/MonoGameSDK
 
 rm -f /usr/share/applications/Monogame\ Pipeline.desktop
 echo "[Desktop Entry]\nVersion=1.0\nEncoding=UTF-8\nName=MonoGame Pipeline\nGenericName=MonoGame Pipeline\nComment=Used to create platform specific .xnb files\nExec=monogame-pipeline %F\nTryExec=monogame-pipeline\nIcon=monogame\nStartupNotify=true\nTerminal=false\nType=Application\nMimeType=text/mgcb;\nCategories=Development;" >> /usr/share/applications/Monogame\ Pipeline.desktop

--- a/Installers/Linux/Main/mgcb
+++ b/Installers/Linux/Main/mgcb
@@ -1,2 +1,2 @@
 #!/bin/bash
-mono /opt/monogame-pipeline/MGCB.exe "$@"
+mono /usr/lib/mono/xbuild/MonoGame/v3.0/Tools/MGCB.exe "$@"

--- a/Installers/Linux/Main/monogame-pipeline
+++ b/Installers/Linux/Main/monogame-pipeline
@@ -1,2 +1,2 @@
 #!/bin/bash
-mono /opt/monogame-pipeline/Pipeline.exe "$@"
+mono /usr/lib/mono/xbuild/MonoGame/v3.0/Tools/Pipeline.exe "$@"

--- a/Installers/Linux/RUN/postinstall.sh
+++ b/Installers/Linux/RUN/postinstall.sh
@@ -7,7 +7,7 @@ if [ "$(id -u)" != "0" ]; then
 fi
 
 # Check previous versions
-if [ -f /bin/mgcb ]
+if type "mgcb" > /dev/null 2>&1
 then
 	echo "Please uninstall any previous versions of MonoGame SDK" 1>&2
 	exit 1
@@ -28,7 +28,7 @@ case "$choice2" in
 esac
 
 # MonoGame SDK installation
-echo "Installing SDK..."
+echo "Installing MonoGame SDK..."
 
 rm -rf "$IDIR"
 mkdir -p "$IDIR"
@@ -36,16 +36,14 @@ cp -rf "$DIR/MonoGameSDK/." "$IDIR" -R
 rm -rf "/opt/MonoGameSDK"
 ln -s "$IDIR" "/opt/MonoGameSDK"
 
+# Monogame Pipeline terminal commands
 echo "Creating launcher items..."
 
-# Monogame Pipeline terminal commands
-rm -f /bin/monogame-pipeline
-cp $DIR/Main/monogame-pipeline /bin/monogame-pipeline
-chmod +x /bin/monogame-pipeline
+cp $DIR/Main/monogame-pipeline /usr/bin/monogame-pipeline
+chmod +x /usr/bin/monogame-pipeline
 
-rm -f /bin/mgcb
-cp $DIR/Main/mgcb /bin/mgcb
-chmod +x /bin/mgcb
+cp $DIR/Main/mgcb /usr/bin/mgcb
+chmod +x /usr/bin/mgcb
 
 # MonoGame icon
 mkdir -p /usr/share/icons/hicolor/scalable/mimetypes

--- a/Installers/Linux/RUN/postinstall.sh
+++ b/Installers/Linux/RUN/postinstall.sh
@@ -1,33 +1,25 @@
 #!/bin/sh
 
-#check installation priviledge
+# Check installation priviledge
 if [ "$(id -u)" != "0" ]; then
 	echo "Please make sure you are running this installer with sudo or as root." 1>&2
 	exit 1
 fi
 
-#check previous versions
+# Check previous versions
 if [ -f /bin/mgcb ]
 then
 	echo "Please uninstall any previous versions of MonoGame SDK" 1>&2
 	exit 1
 fi
 
-#pipeline installation
 DIR=$(pwd)
-IDIR="/opt/monogame-pipeline"
+IDIR="/usr/lib/mono/xbuild/MonoGame/v3.0"
 
-rm -rf "$IDIR"
-
-mkdir "$IDIR"
-echo "Copying files..."
-
-cp "$DIR/Pipeline/." "$IDIR/" -R
-
-#automatic dependency installer
+# Automatic dependency installer
 ./Dependencies/dependencies.sh
 
-#monodevelop addin
+# MonoDevelop addin
 read -p "Install monodevelop addin(Y, n): " choice2
 case "$choice2" in 
 	n|N ) ;;
@@ -35,28 +27,27 @@ case "$choice2" in
 	sudo -H -u $SUDO_USER bash -c "mdtool setup install -y $DIR/Main/MonoDevelop.MonoGame.mpack"
 esac
 
-#MonoGame.xbuild data
-rm -rf /usr/lib/mono/xbuild/MonoGame
+# Pipeline Tool installation
+echo "Installing SDK..."
 
-mkdir -p /usr/lib/mono/xbuild/MonoGame/v3.0/Assemblies/
-cp "$DIR/Assemblies/." /usr/lib/mono/xbuild/MonoGame/v3.0/Assemblies/ -R
-
-sudo ln -s /opt/monogame-pipeline /usr/lib/mono/xbuild/MonoGame/v3.0/Tools
-sudo cp $DIR/Main/MonoGame.Content.Builder.targets /usr/lib/mono/xbuild/MonoGame/v3.0/
+rm -rf "$IDIR"
+mkdir -p "$IDIR"
+cp -rf "$DIR/MonoGameSDK/." "$IDIR" -R
+rm -rf "/opt/MonoGameSDK"
+ln -s "$IDIR" "/opt/MonoGameSDK"
 
 echo "Creating launcher items..."
 
-#monogame pipeline terminal command
+# Monogame Pipeline terminal commands
 rm -f /bin/monogame-pipeline
 cp $DIR/Main/monogame-pipeline /bin/monogame-pipeline
 chmod +x /bin/monogame-pipeline
 
-#mgcb terminal command
 rm -f /bin/mgcb
 cp $DIR/Main/mgcb /bin/mgcb
 chmod +x /bin/mgcb
 
-#application/mimetype icon
+# MonoGame icon
 mkdir -p /usr/share/icons/gnome/scalable/mimetypes
 
 cp $DIR/Main/monogame.svg /usr/share/icons/gnome/scalable/mimetypes/monogame.svg
@@ -68,16 +59,16 @@ else
 	sudo gtk-update-icon-cache /usr/share/icons/gnome/ -f
 fi
 
-#application launcher
+# Application launcher
 rm -f /usr/share/applications/Monogame\ Pipeline.desktop
 echo -e "[Desktop Entry]\nVersion=1.0\nEncoding=UTF-8\nName=MonoGame Pipeline\nGenericName=MonoGame Pipeline\nComment=Used to create platform specific .xnb files\nExec=monogame-pipeline %F\nTryExec=monogame-pipeline\nIcon=monogame\nStartupNotify=true\nTerminal=false\nType=Application\nMimeType=text/mgcb;\nCategories=Development;" | sudo tee --append /usr/share/applications/Monogame\ Pipeline.desktop > /dev/null
 
-#mimetype
+# Mimetype
 echo "Adding mimetype..."
 xdg-mime install $DIR/Main/mgcb.xml --novendor
 xdg-mime default "Monogame Pipeline.desktop" text/mgcb
 
-#uninstall script
+# Uninstall script
 chmod +x $IDIR/uninstall.sh
 echo "To uninstall the pipeline please run $IDIR/uninstall.sh"
 

--- a/Installers/Linux/RUN/postinstall.sh
+++ b/Installers/Linux/RUN/postinstall.sh
@@ -27,7 +27,7 @@ case "$choice2" in
 	sudo -H -u $SUDO_USER bash -c "mdtool setup install -y $DIR/Main/MonoDevelop.MonoGame.mpack"
 esac
 
-# Pipeline Tool installation
+# MonoGame SDK installation
 echo "Installing SDK..."
 
 rm -rf "$IDIR"
@@ -48,16 +48,9 @@ cp $DIR/Main/mgcb /bin/mgcb
 chmod +x /bin/mgcb
 
 # MonoGame icon
-mkdir -p /usr/share/icons/gnome/scalable/mimetypes
-
-cp $DIR/Main/monogame.svg /usr/share/icons/gnome/scalable/mimetypes/monogame.svg
-
-if [ -f /usr/share/icons/default/index.theme ]
-then
-	sudo gtk-update-icon-cache /usr/share/icons/default/ -f
-else
-	sudo gtk-update-icon-cache /usr/share/icons/gnome/ -f
-fi
+mkdir -p /usr/share/icons/hicolor/scalable/mimetypes
+cp $DIR/Main/monogame.svg /usr/share/icons/hicolor/scalable/mimetypes/monogame.svg
+gtk-update-icon-cache /usr/share/icons/hicolor/ -f
 
 # Application launcher
 rm -f /usr/share/applications/Monogame\ Pipeline.desktop

--- a/Installers/Linux/RUN/postinstall.sh
+++ b/Installers/Linux/RUN/postinstall.sh
@@ -17,40 +17,15 @@ fi
 DIR=$(pwd)
 IDIR="/opt/monogame-pipeline"
 
-if [ -d "$IDIR" ]
-then
-	rm -rf "$IDIR"
-fi
+rm -rf "$IDIR"
 
 mkdir "$IDIR"
 echo "Copying files..."
 
 cp "$DIR/Pipeline/." "$IDIR/" -R
-echo "rm -rf $IDIR" >> $IDIR/uninstall.sh
 
 #automatic dependency installer
 ./Dependencies/dependencies.sh
-
-#check GLIBCXX_3.4.20 support
-if [ -f /usr/lib/x86_64-linux-gnu/libstdc++.so.6 ]
-then
-	GREP=$(strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX_3.4.20)
-	size=${#GREP} 
-
-	if [ ! $size -gt 0 ] 
-	then
-		echo "Your libstdc++.so.6 does not support GLIBCXX_3.4.20. Want to copy newer version of it?"
-		echo "Old version will be renamed to libstdc++.so.6.old"
-		read -p "(Y, n): " choice
-	
-		case "$choice" in 
-			n|N ) ;;
-			*)
-			sudo mv /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.old
-			sudo cp $DIR/Main/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libstdc++.so.6
-		esac
-	fi
-fi
 
 #monodevelop addin
 read -p "Install monodevelop addin(Y, n): " choice2
@@ -61,50 +36,28 @@ case "$choice2" in
 esac
 
 #MonoGame.xbuild data
-if [ -d /usr/lib/mono/xbuild/MonoGame ]; then
-	rm -rf /usr/lib/mono/xbuild/MonoGame
-fi
+rm -rf /usr/lib/mono/xbuild/MonoGame
 
-mkdir /usr/lib/mono/xbuild/MonoGame
-mkdir /usr/lib/mono/xbuild/MonoGame/v3.0
-
-mkdir /usr/lib/mono/xbuild/MonoGame/v3.0/Assemblies/
+mkdir -p /usr/lib/mono/xbuild/MonoGame/v3.0/Assemblies/
 cp "$DIR/Assemblies/." /usr/lib/mono/xbuild/MonoGame/v3.0/Assemblies/ -R
 
 sudo ln -s /opt/monogame-pipeline /usr/lib/mono/xbuild/MonoGame/v3.0/Tools
-
 sudo cp $DIR/Main/MonoGame.Content.Builder.targets /usr/lib/mono/xbuild/MonoGame/v3.0/
-
-#fix permissions
-usr="$SUDO_USER"
-if [ -z "$usr" -a "$usr"==" " ]; then
-	usr="$USERNAME"
-fi
-sudo chown -R "$usr" "$IDIR/"
 
 echo "Creating launcher items..."
 
 #monogame pipeline terminal command
-if [ -f /bin/monogame-pipeline ]
-then
-	rm /bin/monogame-pipeline
-fi
+rm -f /bin/monogame-pipeline
 cp $DIR/Main/monogame-pipeline /bin/monogame-pipeline
 chmod +x /bin/monogame-pipeline
 
 #mgcb terminal command
-if [ -f /bin/mgcb ]
-then
-	rm /bin/mgcb
-fi
+rm -f /bin/mgcb
 cp $DIR/Main/mgcb /bin/mgcb
 chmod +x /bin/mgcb
 
 #application/mimetype icon
-if [ ! -d /usr/share/icons/gnome/scalable/mimetypes ]
-then
-	mkdir /usr/share/icons/gnome/scalable/mimetypes
-fi
+mkdir -p /usr/share/icons/gnome/scalable/mimetypes
 
 cp $DIR/Main/monogame.svg /usr/share/icons/gnome/scalable/mimetypes/monogame.svg
 
@@ -116,10 +69,7 @@ else
 fi
 
 #application launcher
-if [ -f /usr/share/applications/Monogame\ Pipeline.desktop ]
-then
-	rm /usr/share/applications/Monogame\ Pipeline.desktop
-fi
+rm -f /usr/share/applications/Monogame\ Pipeline.desktop
 echo -e "[Desktop Entry]\nVersion=1.0\nEncoding=UTF-8\nName=MonoGame Pipeline\nGenericName=MonoGame Pipeline\nComment=Used to create platform specific .xnb files\nExec=monogame-pipeline %F\nTryExec=monogame-pipeline\nIcon=monogame\nStartupNotify=true\nTerminal=false\nType=Application\nMimeType=text/mgcb;\nCategories=Development;" | sudo tee --append /usr/share/applications/Monogame\ Pipeline.desktop > /dev/null
 
 #mimetype
@@ -130,3 +80,4 @@ xdg-mime default "Monogame Pipeline.desktop" text/mgcb
 #uninstall script
 chmod +x $IDIR/uninstall.sh
 echo "To uninstall the pipeline please run $IDIR/uninstall.sh"
+

--- a/Installers/Linux/RUN/uninstall.sh
+++ b/Installers/Linux/RUN/uninstall.sh
@@ -16,9 +16,7 @@ rm -rf /usr/share/icons/gnome/scalable/mimetypes/monogame.svg
 #remove pipeline tool application launcher
 rm -rf /usr/share/applications/Monogame\ Pipeline.desktop
 
-#remove MonoGame xbuild data
+#remove MonoGame SDK
 rm -rf /usr/lib/mono/xbuild/MonoGame
-
-#remove pipeline tool
-rm -rf /opt/monogame-pipeline
+rm -rf /opt/MonoGameSDK
 

--- a/Installers/Linux/RUN/uninstall.sh
+++ b/Installers/Linux/RUN/uninstall.sh
@@ -1,32 +1,24 @@
 #!/bin/sh
 
-#remove terminal commands for mgcb and pipeline tool
-if [ -f /bin/monogame-pipeline ]
-then
-	rm /bin/monogame-pipeline
+#check removale priviledge
+if [ "$(id -u)" != "0" ]; then
+	echo "Please make sure you are running this uninstaller with sudo or as root." 1>&2
+	exit 1
 fi
 
-if [ -f /bin/mgcb ]
-then
-	rm /bin/mgcb
-fi
+#remove terminal commands for mgcb and pipeline tool
+rm -f /bin/monogame-pipeline
+rm -f /bin/mgcb
 
 #remove application icon
-if [ -f /usr/share/icons/gnome/scalable/mimetypes/monogame.svg ]
-then
-	rm -rf /usr/share/icons/gnome/scalable/mimetypes/monogame.svg
-fi
+rm -rf /usr/share/icons/gnome/scalable/mimetypes/monogame.svg
 
 #remove pipeline tool application launcher
-if [ -f /usr/share/applications/Monogame\ Pipeline.desktop ]
-then
-	rm /usr/share/applications/Monogame\ Pipeline.desktop
-fi
+rm -rf /usr/share/applications/Monogame\ Pipeline.desktop
 
 #remove MonoGame xbuild data
-if [ -d /usr/lib/mono/xbuild/MonoGame ]
-then
-	rm -rf /usr/lib/mono/xbuild/MonoGame
-fi
+rm -rf /usr/lib/mono/xbuild/MonoGame
 
-#remove pipeline tool and self, the command for it is added by postinstall.sh
+#remove pipeline tool
+rm -rf /opt/monogame-pipeline
+

--- a/Installers/Linux/RUN/uninstall.sh
+++ b/Installers/Linux/RUN/uninstall.sh
@@ -7,8 +7,8 @@ if [ "$(id -u)" != "0" ]; then
 fi
 
 #remove terminal commands for mgcb and pipeline tool
-rm -f /bin/monogame-pipeline
-rm -f /bin/mgcb
+rm -f /usr/bin/monogame-pipeline
+rm -f /usr/bin/mgcb
 
 #remove application icon
 rm -rf /usr/share/icons/gnome/scalable/mimetypes/monogame.svg

--- a/Installers/default.build
+++ b/Installers/default.build
@@ -143,6 +143,7 @@ fi
     <!-- Linux Installer -->
     <if test="${(os == 'Unix' or os == 'MacOS') and directory::exists('../Tools/Pipeline/bin/Linux/AnyCPU/Release')}">
       
+      <!-- .deb installer -->
       <delete dir="Linux/tmp_deb" failonerror="false"/>
       <mkdir dir="Linux/tmp_deb"/>
       <copy todir="Linux/tmp_deb/DEBIAN/">
@@ -164,6 +165,7 @@ fi
          </fileset>
       </copy>
 
+      <!-- .run installer -->
       <delete dir="Linux/tmp_run" failonerror="false"/>
       <mkdir dir="Linux/tmp_run"/>
       <copy todir="Linux/tmp_run/Main/">
@@ -171,7 +173,6 @@ fi
       </copy>
       <copy file="../IDE/MonoDevelop/MonoDevelop.MonoGame_${buildNumber}.mpack" tofile="Linux/tmp_run/Main/MonoDevelop.MonoGame.mpack" overwrite="true"/>
       <copy file="../MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets" tofile="Linux/tmp_run/Main/MonoGame.Content.Builder.targets"/>
-      <copy file="../ThirdParty/Dependencies/assimp/libstdc++.so.6" tofile="Linux/tmp_run/Main/libstdc++.so.6" />
       <copy todir="Linux/tmp_run/Pipeline">
         <fileset basedir="../Tools/Pipeline/bin/Linux/AnyCPU/Release"/>
       </copy>

--- a/Installers/default.build
+++ b/Installers/default.build
@@ -156,7 +156,7 @@ fi
       <copy file="Linux/Main/mgcb.xml" tofile="Linux/tmp_deb/tmp/mgcb.xml"/>
       <copy file="Linux/Main/mgcb" tofile="Linux/tmp_deb/bin/mgcb"/>
       <copy file="Linux/Main/monogame-pipeline" tofile="Linux/tmp_deb/bin/monogame-pipeline"/>
-      <copy file="Linux/Main/monogame.svg" tofile="Linux/tmp_deb/usr/share/icons/gnome/scalable/mimetypes/monogame.svg"/>
+      <copy file="Linux/Main/monogame.svg" tofile="Linux/tmp_deb/usr/share/icons/hicolor/scalable/mimetypes/monogame.svg"/>
       <copy file="../MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets" tofile="Linux/tmp_deb/usr/lib/mono/xbuild/MonoGame/v3.0/MonoGame.Content.Builder.targets"/>
       <echo file="Linux/tmp_deb/DEBIAN/control" append="true">version: ${buildNumber}&#xa;</echo>
       <copy todir="Linux/tmp_deb/usr/lib/mono/xbuild/MonoGame/v3.0/Assemblies/DesktopGL">

--- a/Installers/default.build
+++ b/Installers/default.build
@@ -154,8 +154,8 @@ fi
       </copy>
       <copy file="../IDE/MonoDevelop/MonoDevelop.MonoGame_${buildNumber}.mpack" tofile="Linux/tmp_deb/tmp/MonoDevelop.MonoGame.mpack" overwrite="true"/>
       <copy file="Linux/Main/mgcb.xml" tofile="Linux/tmp_deb/tmp/mgcb.xml"/>
-      <copy file="Linux/Main/mgcb" tofile="Linux/tmp_deb/bin/mgcb"/>
-      <copy file="Linux/Main/monogame-pipeline" tofile="Linux/tmp_deb/bin/monogame-pipeline"/>
+      <copy file="Linux/Main/mgcb" tofile="Linux/tmp_deb/usr/bin/mgcb"/>
+      <copy file="Linux/Main/monogame-pipeline" tofile="Linux/tmp_deb/usr/bin/monogame-pipeline"/>
       <copy file="Linux/Main/monogame.svg" tofile="Linux/tmp_deb/usr/share/icons/hicolor/scalable/mimetypes/monogame.svg"/>
       <copy file="../MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets" tofile="Linux/tmp_deb/usr/lib/mono/xbuild/MonoGame/v3.0/MonoGame.Content.Builder.targets"/>
       <echo file="Linux/tmp_deb/DEBIAN/control" append="true">version: ${buildNumber}&#xa;</echo>

--- a/Installers/default.build
+++ b/Installers/default.build
@@ -149,7 +149,7 @@ fi
       <copy todir="Linux/tmp_deb/DEBIAN/">
         <fileset basedir="Linux/DEBIAN"/>
       </copy>
-      <copy todir="Linux/tmp_deb/opt/monogame-pipeline">
+      <copy todir="Linux/tmp_deb/usr/lib/mono/xbuild/MonoGame/v3.0/Tools">
         <fileset basedir="../Tools/Pipeline/bin/Linux/AnyCPU/Release"/>
       </copy>
       <copy file="../IDE/MonoDevelop/MonoDevelop.MonoGame_${buildNumber}.mpack" tofile="Linux/tmp_deb/tmp/MonoDevelop.MonoGame.mpack" overwrite="true"/>
@@ -172,11 +172,11 @@ fi
         <fileset basedir="Linux/Main"/>
       </copy>
       <copy file="../IDE/MonoDevelop/MonoDevelop.MonoGame_${buildNumber}.mpack" tofile="Linux/tmp_run/Main/MonoDevelop.MonoGame.mpack" overwrite="true"/>
-      <copy file="../MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets" tofile="Linux/tmp_run/Main/MonoGame.Content.Builder.targets"/>
-      <copy todir="Linux/tmp_run/Pipeline">
+      <copy file="../MonoGame.Framework.Content.Pipeline/MonoGame.Content.Builder.targets" tofile="Linux/tmp_run/MonoGameSDK/MonoGame.Content.Builder.targets"/>
+      <copy todir="Linux/tmp_run/MonoGameSDK/Tools">
         <fileset basedir="../Tools/Pipeline/bin/Linux/AnyCPU/Release"/>
       </copy>
-      <copy todir="Linux/tmp_run/Assemblies/DesktopGL">
+      <copy todir="Linux/tmp_run/MonoGameSDK/Assemblies/DesktopGL">
          <fileset basedir="../MonoGame.Framework/bin/Linux/AnyCPU/Release">
                 <include name="*.*"/>
          </fileset>
@@ -184,7 +184,7 @@ fi
       <copy todir="Linux/tmp_run">
         <fileset basedir="Linux/RUN"/>
       </copy>
-      <move file="Linux/tmp_run/uninstall.sh" tofile="Linux/tmp_run/Pipeline/uninstall.sh" />
+      <move file="Linux/tmp_run/uninstall.sh" tofile="Linux/tmp_run/MonoGameSDK/uninstall.sh" />
       
       <exec program="Linux/compile.sh" workingdir="Linux/"/>
       <delete dir="Linux/tmp_deb" failonerror="false"/>


### PR DESCRIPTION
Stuff done:
 - removed redundant code / simplified code
 - installer now installs Pipeline Tool in the xbuild folder
   - symlink is created to /opt/MonoGameSDK
 - fixed icon location
 - moved terminal commands to /usr/bin