### PR TITLE
[Pipeline Tool] Optimized opening of .mgcb files a bit

### DIFF
--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -53,6 +53,7 @@
     <Compile Include="Common\PipelineController.MoveAction.cs" />
     <Compile Include="Common\PipelineController.NewAction.cs" />
     <Compile Include="Common\PipelineController.ExcludeAction.cs" />
+    <Compile Include="Common\PipelineController.FileWatcher.cs" />
     <Compile Include="Common\PipelineController.IncludeAction.cs" />
     <Compile Include="Common\PipelineController.UpdateContentItemAction.cs" />
     <Compile Include="Common\PipelineController.UpdateProjectAction.cs" />

--- a/Tools/Pipeline/Common/PipelineController.FileWatcher.cs
+++ b/Tools/Pipeline/Common/PipelineController.FileWatcher.cs
@@ -1,0 +1,76 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.IO;
+using System.Threading;
+
+namespace MonoGame.Tools.Pipeline
+{
+    internal partial class PipelineController
+    {
+        private class FileWatcher : IDisposable
+        {
+            Thread _thread;
+
+            PipelineController _controller;
+            IView _view;
+
+            public FileWatcher(PipelineController controller, IView view)
+            {
+                _controller = controller;
+                _view = view;
+            }
+
+            public void Run()
+            {
+                Stop();
+
+                _thread = new Thread(new ThreadStart(ExistsThread));
+                _thread.Start();
+            }
+
+            public void Stop()
+            {
+                if (_thread == null)
+                    return;
+                
+                _thread.Abort();
+                _thread = null;
+            }
+
+            private void ExistsThread()
+            {
+                while (true)
+                {
+                    // Can't lock without major code modifications
+                    try
+                    {
+                        var items = _controller._project.ContentItems.ToArray();
+
+                        foreach (var item in items)
+                        {
+                            if (item.Exists == File.Exists(_controller.GetFullPath(item.OriginalPath)))
+                                continue;
+
+                            item.Exists = !item.Exists;
+                            _view.ItemExistanceChanged (item);
+
+                            Thread.Sleep(100);
+                        }
+                    }
+                    catch 
+                    {
+                    }
+                }
+            }
+
+            public void Dispose()
+            {
+                Stop();
+            }
+        }
+    }
+}
+

--- a/Tools/Pipeline/Gtk/MainWindow.cs
+++ b/Tools/Pipeline/Gtk/MainWindow.cs
@@ -182,15 +182,6 @@ namespace MonoGame.Tools.Pipeline
         {
             PipelineSettings.Default.Load ();
 
-            if (string.IsNullOrEmpty(OpenProjectPath))
-            {
-                var startupProject = PipelineSettings.Default.StartupProject;
-                if (!string.IsNullOrEmpty(startupProject) && System.IO.File.Exists(startupProject))                
-                    OpenProjectPath = startupProject;                
-            }
-
-            PipelineSettings.Default.StartupProject = null;
-
             if (!String.IsNullOrEmpty(OpenProjectPath)) {
                 _controller.OpenProject(OpenProjectPath);
                 OpenProjectPath = null;
@@ -536,7 +527,11 @@ namespace MonoGame.Tools.Pipeline
 
         public void ItemExistanceChanged(IProjectItem item)
         {
-            projectview1.RefreshItem(projectview1.GetBaseIter(), item.OriginalPath, item.Exists, _controller.GetFullPath(item.OriginalPath));
+            Application.Invoke(
+                delegate {
+                    projectview1.RefreshItem(projectview1.GetBaseIter(), item.OriginalPath, item.Exists, _controller.GetFullPath(item.OriginalPath));
+                }
+            );
         }
 
 


### PR DESCRIPTION
Modifies 2 things:
 - replaces FileSystemWatcher with FileWatcher
   - I set FileWatcher to check ~10 files per second, do say if you want that increased
 - changes the directory it searches for templates from "&lt;mgcb dir&gt;/" to "&lt;mgcb dir&gt;/MGTemplates"
   - this fixes opening files located at for example "C:\" or "/home/"