### PR TITLE
Build Script Refactor

### DIFF
--- a/Installers/default.build
+++ b/Installers/default.build
@@ -8,8 +8,8 @@
   <if test="${environment::variable-exists('BUILD_NUMBER')}">
     <property name="buildNumber" value="${environment::get-variable('BUILD_NUMBER')}"/>
   </if>
-  
-  <target name="checkos" description="check the operating system">
+
+  <target name="_checkos">
     <property name="os" value="${operating-system::get-platform(environment::get-operating-system())}"/>
     <if test="${os == 'Unix'}">
       <if test="${directory::exists('/Applications') and directory::exists('/Library')}">
@@ -19,35 +19,28 @@
     <echo message="Detected : ${os}"/>
   </target>
 
-  <target name="download" description="Downloads iOS binaries">
-    <if test="${environment::variable-exists('MACBUILDJOB')}">
-      <property name="macbuildjob" value="${environment::get-variable('MACBUILDJOB')}"/>
-      <property name="latestArtifactUrl" value="http://build.monogame.net/job/${macbuildjob}/lastSuccessfulBuild/artifact/"/>
 
-      <mkdir dir="Windows/iOS" failonerror="false"/>
-      <get src="${latestArtifactUrl}MonoGame.Framework/bin/iOS/iPhoneSimulator/Release/MonoGame.Framework.dll" dest="Windows/iOS/MonoGame.Framework.dll" failonerror="false"/>
-    </if>
-  </target>
+  <target name="build" description="Build Installers" depends="_checkos">
 
 
-  <target name="build" description="Build Installers" depends="checkos">
+    <!-- Windows Installer -->
     <if test="${os == 'Win32NT'}">
       <if test="${file::exists('C:\Program Files (x86)\NSIS\makensis.exe')}">
-
         <echo append="false" file="Windows/header.nsh">
 !define FrameworkPath "${project::get-base-directory()}"
 !define VERSION "3.0"
 !define INSTALLERVERSION "${buildNumber}"
         </echo>
-        <call target="download"/>
-        <exec program="C:\Windows\system32\cmd.exe" commandline='/C rmdir /S /Q WindowsUniversal' workingdir="${project::get-base-directory()}\..\MonoGame.Framework\bin" failonerror='false' />
-		<exec program="C:\Windows\system32\cmd.exe" commandline='/C rename WindowsUAP WindowsUniversal' workingdir="${project::get-base-directory()}\..\MonoGame.Framework\bin" />
         <exec program="makensis" workingdir="Windows" basedir="C:\Program Files (x86)\NSIS">
 		      <arg value="MonoGame.nsi"/>
-		    </exec>
+        </exec>
       </if>
     </if>
+
+
+    <!-- Mac Installers -->
     <if test="${os == 'MacOS'}">
+
       <!-- Build Pipeline.Installer.pkg -->
       <delete failonerror="false">
          <fileset>
@@ -140,6 +133,7 @@ fi
       <delete file="./MacOS/Resources/LICENSE.html"/>
     </if>
 
+
     <!-- Linux Installer -->
     <if test="${(os == 'Unix' or os == 'MacOS') and directory::exists('../Tools/Pipeline/bin/Linux/AnyCPU/Release')}">
       
@@ -192,4 +186,5 @@ fi
     </if>
 
   </target>
+
 </project>

--- a/default.build
+++ b/default.build
@@ -1,15 +1,24 @@
 <?xml version="1.0"?>
-<project name="MonoGame Build Script" default="build_installer" basedir=".">
-  <description>Default MonoGame Automated Build script</description>
+<project name="MonoGame Build Script" default="build" basedir=".">
+
+  <description>The MonoGame automated build script.</description>
+
   <property name="os" value="${operating-system::get-platform(environment::get-operating-system())}" />
   <property name="mdtooldir" value="/Applications/MonoDevelop.app/Contents/MacOS"/>
   <property name="msbuild12dir" value="C:\Program Files (x86)\MSBuild\12.0\Bin" />
   <property name="msbuild14dir" value="C:\Program Files (x86)\MSBuild\14.0\Bin" />
+  
+  <!-- Helper default target. -->
+  <target   name="build" 
+            description="Build, run tests, generate docs, and create installers." 
+            depends="build_code,run_tests,build_docs,build_installer" />
 
-  <!-- Temporary work around so that we don't need to change the targets on the build server -->
-  <target name="build" depends="build_code,run_tests,build_docs,build_installer" />
+  <!-- Some additional helper dependencies. -->
+  <target name="_default" depends="_checkos" />
+  <target name="_prebuild" depends="_default,_clean" />
 
-  <target name="checkos" description="check the operating system">
+  <!-- Do some OS checks required by the other steps. -->
+  <target name="_checkos">
     <property name="os" value="${operating-system::get-platform(environment::get-operating-system())}"/>
     <if test="${os == 'Unix'}">
       <if test="${directory::exists('/Applications') and directory::exists('/Library')}">
@@ -22,13 +31,14 @@
     <echo message="Detected : ${os}"/>
   </target>
 
-  <target name="clean">
+  <!-- Clean the build output directories. -->
+  <target name="_clean">
     <delete dir="${project::get-base-directory()}\MonoGame.Framework\obj" />
     <delete dir="${project::get-base-directory()}\MonoGame.Framework.Content.Pipeline\obj" />
   </target>
-
-  <target name="build_code" description="Build all the projects." depends="checkos">
-
+  
+  <!-- Shortcut for building all valid target platforms -->
+  <target name="build_code" description="Build all the projects.">
     <call target="build_windows"/>
     <call target="build_windows8" />
     <call target="build_windowsphone" />
@@ -39,10 +49,13 @@
     <call target="build_android" />
     <call target="build_mac" />
     <call target="build_ios" />
-
   </target>
+ 
 
-  <target name="build_windows" description="Build Windows" depends="clean">
+
+  <!-- Build targets for the various platforms. -->
+
+  <target name="build_windows" description="Build Windows" depends="_prebuild">
     <if test="${os == 'Win32NT'}">
       <exec program="Protobuild" commandline="-generate Windows" />
       <exec program="msbuild " commandline="MonoGame.Framework.Windows.sln /t:Clean /p:Configuration=Release" />
@@ -61,7 +74,7 @@
     </if>
   </target>
 
-  <target name="build_linux" description="Build Linux" depends="clean">
+  <target name="build_linux" description="Build Linux" depends="_prebuild">
     <if test="${os == 'Win32NT'}">
       <exec program="Protobuild" commandline="-generate Linux" />
       <exec program="msbuild " commandline="MonoGame.Framework.Linux.sln /t:Clean /p:Configuration=Release" />
@@ -79,7 +92,7 @@
     </if>
   </target>
 
-  <target name="build_web" description="Build Web JSIL" depends="clean">
+  <target name="build_web" description="Build Web JSIL" depends="_prebuild">
     <if test="${os == 'Win32NT'}">
       <exec program="Protobuild" commandline="-generate Web">
         <environment>
@@ -96,7 +109,7 @@
     </if>
   </target>
 
-  <target name="build_mac" description="Build MacOS" depends="clean">
+  <target name="build_mac" description="Build MacOS" depends="_prebuild">
     <if test="${os == 'MacOS'}">
       <exec program="mono" commandline="Protobuild.exe -generate MacOS" />
       <exec program="mdtool" basedir="${mdtooldir}" commandline="build -t:Clean -c:Release MonoGame.Framework.MacOS.sln" />
@@ -104,7 +117,7 @@
     </if>
   </target>
 
-  <target name="build_ios" description="Build iOS" depends="clean">
+  <target name="build_ios" description="Build iOS" depends="_prebuild">
     <if test="${os == 'MacOS'}">
       <if test="${file::exists('/Developer/MonoTouch/MSBuild/Xamarin.ObjcBinding.CSharp.targets') or file::exists('/Library/Frameworks/Mono.framework/External/xbuild/Xamarin/Xamarin.ObjcBinding.CSharp.targets')}">
         <exec program="mono" commandline="Protobuild.exe -generate iOS" />
@@ -114,7 +127,7 @@
     </if>
   </target>
 
-  <target name="build_android" description="Build Android" depends="clean">
+  <target name="build_android" description="Build Android" depends="_prebuild">
     <if test="${os == 'Win32NT'}">
       <if test="${file::exists('C:\Program Files (x86)\MSBuild\Novell\Novell.MonoDroid.CSharp.targets')}">
         <exec program="Protobuild" commandline="-generate Android" />
@@ -137,7 +150,7 @@
     </if>
   </target>
 
-  <target name="build_windows8" description="Build Windows 8" depends="clean">
+  <target name="build_windows8" description="Build Windows 8" depends="_prebuild">
     <if test="${os == 'Win32NT'}">
       <exec program="Protobuild" commandline="-generate Windows8" />
       <exec program="msbuild " commandline="MonoGame.Framework.Windows8.sln /t:Clean /p:Configuration=Release" />
@@ -145,7 +158,7 @@
     </if>
   </target>
 
-  <target name="build_windowsphone" description="Build Windows Phone" depends="clean">
+  <target name="build_windowsphone" description="Build Windows Phone" depends="_prebuild">
     <if test="${os == 'Win32NT'}">
       <if test="${file::exists('c:\Program Files (x86)\MSBuild\Microsoft\WindowsPhone\v8.0\Microsoft.Cpp.WindowsPhone.8.0.targets')}">
         <exec program="Protobuild" commandline="-generate WindowsPhone" />
@@ -157,7 +170,7 @@
     </if>
   </target>
 
-  <target name="build_windowsphone81" description="Build Windows Phone 8.1" depends="clean">
+  <target name="build_windowsphone81" description="Build Windows Phone 8.1" depends="_prebuild">
     <if test="${os == 'Win32NT'}">
       <if test="${file::exists('c:\Program Files (x86)\MSBuild\Microsoft\WindowsPhone\v8.1\Microsoft.Cpp.WindowsPhone.8.1.targets')}">
         <exec program="Protobuild" commandline="-generate WindowsPhone81" />
@@ -167,7 +180,7 @@
     </if>
   </target>
 
-  <target name="build_windows10" description="Build Windows 10 UAP" depends="clean">
+  <target name="build_windows10" description="Build Windows 10 UAP" depends="_prebuild">
     <if test="${os == 'Win32NT'}">
       <if test="${file::exists('c:\Program Files (x86)\MSBuild\Microsoft\WindowsXaml\v14.0\Microsoft.Windows.UI.Xaml.CSharp.targets')}">
         <exec program="Protobuild" commandline="-generate WindowsUniversal" />
@@ -181,35 +194,38 @@
 
         <exec program="${msbuild14dir}\msbuild.exe " commandline='MonoGame.Framework.WindowsUniversal.sln /t:Clean /p:Configuration=Release /p:Platform="Any CPU"' />
         <exec program="${msbuild14dir}\msbuild.exe " commandline='MonoGame.Framework.WindowsUniversal.sln /t:Build /p:Configuration=Release /p:Platform="Any CPU"' />
-        <exec program="C:\Windows\system32\cmd.exe" commandline='/C rmdir /S /Q WindowsUAP' workingdir='MonoGame.Framework\bin' failonerror='false' />
-        <exec program="C:\Windows\system32\cmd.exe" commandline='/C rename WindowsUniversal WindowsUAP' workingdir='MonoGame.Framework\bin' />
+
       </if>
     </if>
   </target>
 
-  <target name="run_tests" description="Run all the tests" depends="build_code">
+
+  <!-- Run the unit tests... will fail if the code hasn't been built. -->
+  <target name="run_tests" description="Run all the tests" depends="_default">
     <nunit2 if="${os == 'Win32NT'}">
       <formatter type="Xml" usefile="true" extension=".xml" outputdir="Test\bin\Windows\AnyCPU\Release" />
       <test assemblyname="Test\bin\Windows\AnyCPU\Release\MonoGameTests.exe" />
     </nunit2>
   </target>
 
-  <target name="build_docs" description="Build the documentation." depends="build_code,run_tests">
+
+  <!-- Generate the docs... will fail if the code hasn't been built. -->
+  <target name="build_docs" description="Build the documentation." depends="_default">
     <if test="${os == 'Win32NT'}">
       <delete dir="${project::get-base-directory()}\Documentation\Output" />
       <exec program="SharpDoc.exe" basedir="ThirdParty\Dependencies\SharpDoc" commandline="-config Documentation\config.xml" />
     </if>
   </target>
 
-  <target name="build_installer" description="Build the installers." depends="build_code,build_docs,run_tests">
 
+  <!-- Create the installers... will fail if the code hasn't been built. -->
+  <target name="build_installer" description="Build the installers." depends="_default">
     <nant buildfile="ProjectTemplates/VisualStudio2010/default.build" target="build" />
     <nant buildfile="ProjectTemplates/VisualStudio2012/default.build" target="build" />
     <nant buildfile="ProjectTemplates/VisualStudio2013/default.build" target="build" />
     <nant buildfile="ProjectTemplates/VisualStudio2015/default.build" target="build" />
     <nant buildfile="IDE/MonoDevelop/default.build" target="build" />
     <nant buildfile="Installers/default.build" target="build" />
-
   </target>
 
 </project>


### PR DESCRIPTION
This PR refactors the main build script to allow tests, docs, and installers to run without target dependencies.  This will allow us to do some restructuring of the build server into more parallel steps.