### PR TITLE
[DesktopGL] Rewrite OpenTK Game Window and Platform

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -1,107 +1,34 @@
-#region License
-/*
-Microsoft Public License (Ms-PL)
-MonoGame - Copyright © 2009-2011 The MonoGame Team
-
-All rights reserved.
-
-This license governs use of the accompanying software. If you use the software,
-you accept this license. If you do not accept the license, do not use the
-software.
-
-1. Definitions
-
-The terms "reproduce," "reproduction," "derivative works," and "distribution"
-have the same meaning here as under U.S. copyright law.
-
-A "contribution" is the original software, or any additions or changes to the
-software.
-
-A "contributor" is any person that distributes its contribution under this
-license.
-
-"Licensed patents" are a contributor's patent claims that read directly on its
-contribution.
-
-2. Grant of Rights
-
-(A) Copyright Grant- Subject to the terms of this license, including the
-license conditions and limitations in section 3, each contributor grants you a
-non-exclusive, worldwide, royalty-free copyright license to reproduce its
-contribution, prepare derivative works of its contribution, and distribute its
-contribution or any derivative works that you create.
-
-(B) Patent Grant- Subject to the terms of this license, including the license
-conditions and limitations in section 3, each contributor grants you a
-non-exclusive, worldwide, royalty-free license under its licensed patents to
-make, have made, use, sell, offer for sale, import, and/or otherwise dispose of
-its contribution in the software or derivative works of the contribution in the
-software.
-
-3. Conditions and Limitations
-
-(A) No Trademark License- This license does not grant you rights to use any
-contributors' name, logo, or trademarks.
-
-(B) If you bring a patent claim against any contributor over patents that you
-claim are infringed by the software, your patent license from such contributor
-to the software ends automatically.
-
-(C) If you distribute any portion of the software, you must retain all
-copyright, patent, trademark, and attribution notices that are present in the
-software.
-
-(D) If you distribute any portion of the software in source code form, you may
-do so only under this license by including a complete copy of this license with
-your distribution. If you distribute any portion of the software in compiled or
-object code form, you may only do so under a license that complies with this
-license.
-
-(E) The software is licensed "as-is." You bear the risk of using it. The
-contributors give no express warranties, guarantees or conditions. You may have
-additional consumer rights under your local laws which this license cannot
-change. To the extent permitted under your local laws, the contributors exclude
-the implied warranties of merchantability, fitness for a particular purpose and
-non-infringement.
-*/
-#endregion License
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 
 using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input.Touch;
-using Microsoft.Xna.Framework.Input;
 
 using OpenTK;
-using OpenTK.Graphics;
 
 namespace Microsoft.Xna.Framework
 {
     class OpenTKGamePlatform : GamePlatform
     {
         private OpenTKGameWindow _view;
-		private OpenALSoundController soundControllerInstance = null;
-        // stored the current screen state, so we can check if it has changed.
-        private bool isCurrentlyFullScreen = false;
-        private int isExiting; // int, so we can use Interlocked.Increment
+        private OpenALSoundController _soundControllerInstance;
 
-        int windowDelay = 2;
+        private int isExiting;
+
+        //int windowDelay = 2;
         
 		public OpenTKGamePlatform(Game game)
             : base(game)
         {
-            _view = new OpenTKGameWindow(game);
-            this.Window = _view;
+            this.Window = _view = new OpenTKGameWindow(game);
 
-			// Setup our OpenALSoundController to handle our SoundBuffer pools
             try
             {
-                soundControllerInstance = OpenALSoundController.GetInstance;
+                _soundControllerInstance = OpenALSoundController.GetInstance;
             }
             catch (DllNotFoundException ex)
             {
@@ -116,42 +43,19 @@ namespace Microsoft.Xna.Framework
 
         protected override void OnIsMouseVisibleChanged()
         {
-            _view.SetMouseVisible(IsMouseVisible);
+            _view.SetCursorVisible(IsMouseVisible);
         }
 
         public override void RunLoop()
         {
-            ResetWindowBounds();
             while (true)
             {
                 _view.ProcessEvents();
+                Game.Tick();
 
-                // Stop the main loop iff Game.Exit() has been called.
-                // This can happen under the following circumstances:
-                // 1. Game.Exit() is called programmatically.
-                // 2. The GameWindow is closed through the 'X' (close) button
-                // 3. The GameWindow is closed through Alt-F4 or Cmd-Q
-                // Note: once Game.Exit() is called, we must stop raising 
-                // Update or Draw events as the GameWindow and/or OpenGL context
-                // may no longer be available. 
-                // Note 2: Game.Exit() can be called asynchronously from
-                // _view.ProcessEvents() (cases #2 and #3 above), so the
-                // isExiting check must be placed *after* _view.ProcessEvents()
-                // Note 3: We need to continue processing view events until  
-                // everything gets disposed of, otherwise it will close the window
-                // and make the window handle invalid
-                if (isExiting == 0)
-                    Game.Tick();
-                else if (windowDelay == 2)
+                if (isExiting > 0)
                 {
-                    windowDelay--;
-                    Game.ExitEverything();
-                }
-                else if (windowDelay > 0)
-                    windowDelay--;
-                else
-                {
-                    _view.Dispose();
+                    Game.Exit();
                     break;
                 }
             }
@@ -164,20 +68,18 @@ namespace Microsoft.Xna.Framework
 
         public override void Exit()
         {
-            //(SJ) Why is this called here when it's not in any other project
-            //Net.NetworkSession.Exit();
             Interlocked.Increment(ref isExiting);
 
-            OpenTK.DisplayDevice.Default.RestoreResolution();
+            DisplayDevice.Default.RestoreResolution();
         }
 
         public override bool BeforeUpdate(GameTime gameTime)
         {
             IsActive = _view.Window.Focused;
 
-            // Update our OpenAL sound buffer pools
-            if (soundControllerInstance != null)
-                soundControllerInstance.Update();
+            if (_soundControllerInstance != null)
+                _soundControllerInstance.Update();
+            
             return true;
         }
 
@@ -188,96 +90,22 @@ namespace Microsoft.Xna.Framework
 
         public override void EnterFullScreen()
         {
-            ResetWindowBounds();
+            
         }
 
         public override void ExitFullScreen()
-        {
-            ResetWindowBounds();
-        }
-
-        internal void ResetWindowBounds()
-        {
-            Rectangle bounds;
-
-            bounds = Window.ClientBounds;
-
-            //Changing window style forces a redraw. Some games
-            //have fail-logic and toggle fullscreen in their draw function,
-            //so temporarily become inactive so it won't execute.
-
-            bool wasActive = IsActive;
-            IsActive = false;
-
-            var graphicsDeviceManager = (GraphicsDeviceManager)
-                Game.Services.GetService(typeof(IGraphicsDeviceManager));
-
-            if (graphicsDeviceManager.IsFullScreen)
-            {
-                bounds = new Rectangle(0, 0,graphicsDeviceManager.PreferredBackBufferWidth,graphicsDeviceManager.PreferredBackBufferHeight);
-
-                if (OpenTK.DisplayDevice.Default.Width != graphicsDeviceManager.PreferredBackBufferWidth ||
-                    OpenTK.DisplayDevice.Default.Height != graphicsDeviceManager.PreferredBackBufferHeight)
-                {
-                    OpenTK.DisplayDevice.Default.ChangeResolution(graphicsDeviceManager.PreferredBackBufferWidth,
-                            graphicsDeviceManager.PreferredBackBufferHeight,
-                            OpenTK.DisplayDevice.Default.BitsPerPixel,
-                            OpenTK.DisplayDevice.Default.RefreshRate);
-                }
-            }
-            else
-            {
-                
-                // switch back to the normal screen resolution
-                OpenTK.DisplayDevice.Default.RestoreResolution();
-                // now update the bounds 
-                bounds.Width = graphicsDeviceManager.PreferredBackBufferWidth;
-                bounds.Height = graphicsDeviceManager.PreferredBackBufferHeight;
-            }
-            
-
-            // Now we set our Presentation Parameters
-            var device = (GraphicsDevice)graphicsDeviceManager.GraphicsDevice;
-            // FIXME: Eliminate the need for null checks by only calling
-            //        ResetWindowBounds after the device is ready.  Or,
-            //        possibly break this method into smaller methods.
-            if (device != null)
-            {
-                PresentationParameters parms = device.PresentationParameters;
-                parms.BackBufferHeight = (int)bounds.Height;
-                parms.BackBufferWidth = (int)bounds.Width;
-
-                var viewport = new Viewport(0, 0,
-                            parms.BackBufferWidth,
-                            parms.BackBufferHeight);
-
-                device.Viewport = viewport;
-            }
-
-            if (graphicsDeviceManager.IsFullScreen != isCurrentlyFullScreen)
-            {                
-                _view.ToggleFullScreen();
-            }
-
-            // we only change window bounds if we are not fullscreen
-            // or if fullscreen mode was just entered
-            if (!graphicsDeviceManager.IsFullScreen || (graphicsDeviceManager.IsFullScreen != isCurrentlyFullScreen))
-                _view.ChangeClientBounds(bounds);
-
-            // store the current fullscreen state
-            isCurrentlyFullScreen = graphicsDeviceManager.IsFullScreen;
-
-            IsActive = wasActive;
-        }
-
-        public override void EndScreenDeviceChange(string screenDeviceName, int clientWidth, int clientHeight)
         {
             
         }
 
         public override void BeginScreenDeviceChange(bool willBeFullScreen)
         {
-            
+            _view.BeginScreenDeviceChange(willBeFullScreen);
+        }
+
+        public override void EndScreenDeviceChange(string screenDeviceName, int clientWidth, int clientHeight)
+        {
+            _view.EndScreenDeviceChange(screenDeviceName, clientWidth, clientHeight);
         }
         
         public override void Log(string Message)

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -395,27 +395,14 @@ namespace Microsoft.Xna.Framework
                 break;
             case GameRunBehavior.Synchronous:
                 Platform.RunLoop();
-#if !DESKTOPGL
                 EndRun();
 				DoExiting();
-#endif
                 break;
             default:
                 throw new ArgumentException(string.Format(
                     "Handling for the run behavior {0} is not implemented.", runBehavior));
             }
         }
-
-#if DESKTOPGL
-        // This code is used so that the Window could stay alive
-        // while all the resources are getting destroyed
-        internal void ExitEverything()
-        {
-            EndRun();
-            DoExiting();
-            this.Dispose();
-        }
-#endif
 
         private TimeSpan _accumulatedElapsedTime;
         private readonly GameTime _gameTime = new GameTime();

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -261,7 +261,12 @@ namespace Microsoft.Xna.Framework
             ((MonoGame.Framework.WinFormsGamePlatform)_game.Platform).ResetWindowBounds();
 
 #elif DESKTOPGL
-            ((OpenTKGamePlatform)_game.Platform).ResetWindowBounds();
+            _graphicsDevice.PresentationParameters.BackBufferFormat = _preferredBackBufferFormat;
+            _graphicsDevice.PresentationParameters.BackBufferWidth = _preferredBackBufferWidth;
+            _graphicsDevice.PresentationParameters.BackBufferHeight = _preferredBackBufferHeight;
+            _graphicsDevice.PresentationParameters.DepthStencilFormat = _preferredDepthStencilFormat;
+            _graphicsDevice.PresentationParameters.PresentationInterval = _synchronizedWithVerticalRetrace ? PresentInterval.Default : PresentInterval.Immediate;
+            _graphicsDevice.PresentationParameters.IsFullScreen = _wantFullScreen;
 
             //Set the swap interval based on if vsync is desired or not.
             //See GetSwapInterval for more details
@@ -271,6 +276,13 @@ namespace Microsoft.Xna.Framework
             else
                 swapInterval = 0;
             _graphicsDevice.Context.SwapInterval = swapInterval;
+
+            _graphicsDevice.ApplyRenderTargets(null);
+
+            _game.Platform.BeginScreenDeviceChange(GraphicsDevice.PresentationParameters.IsFullScreen);
+            _game.Platform.EndScreenDeviceChange("", GraphicsDevice.PresentationParameters.BackBufferWidth, GraphicsDevice.PresentationParameters.BackBufferHeight);
+
+
 #elif MONOMAC
             _graphicsDevice.PresentationParameters.IsFullScreen = _wantFullScreen;
 


### PR DESCRIPTION
This should fix the following things:
 - no more hacking around borders
 - no more hacking the exit loop
 - #4538
 - makes opentk window act more stable
 - simplifies code by a lot

~~Do note that it's missing a resolution change, this is because I am looking into how to make that work correctly with multiple displays, I am just putting this out early so it can be tested and so that people can tell me what they think while I figure out this last problem.~~ Linux resolution bug is present only under X11 backend, this is something that's gonna have to be fixed within OpenTK.

@dellis1972 Can you test this on Mac?