### PR TITLE
Make BitmapContent Width and Height setters protected

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/BitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/BitmapContent.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             {
                 return height;
             }
-            set
+            protected set
             {
                 if (value <= 0)
                     throw new ArgumentOutOfRangeException("height");
@@ -41,7 +41,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             {
                 return width;
             }
-            set
+            protected set
             {
                 if (value <= 0)
                     throw new ArgumentOutOfRangeException("width");

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -86,6 +86,7 @@
   <ItemGroup>
     <Compile Include="ContentPipeline\AssetTestClasses.cs" />
     <Compile Include="ContentPipeline\AssetTestUtility.cs" />
+    <Compile Include="ContentPipeline\BitmapContentTests.cs" />
     <Compile Include="ContentPipeline\FontDescriptionTests.cs" />
     <Compile Include="ContentPipeline\IntermediateDeserializerTest.cs" />
     <Compile Include="ContentPipeline\IntermediateSerializerTest.cs" />


### PR DESCRIPTION
Make BitmapContent Width and Height setters protected. Fixes #4560.

Despite what MSDN [says](https://msdn.microsoft.com/en-us/library/microsoft.xna.framework.content.pipeline.graphics.bitmapcontent.width.aspx), XNA's `BitmapContent` does not have public `Width` and `Height` setters.