### PR TITLE
Implement vertexStride in VertexBuffer.SetData for OpenGL

### DIFF
--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
@@ -157,8 +157,21 @@ namespace Microsoft.Xna.Framework.Graphics
             var dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
             var dataPtr = (IntPtr)(dataHandle.AddrOfPinnedObject().ToInt64() + startIndex * elementSizeInBytes);
 
-            GL.BufferSubData(BufferTarget.ArrayBuffer, (IntPtr)offsetInBytes, (IntPtr)sizeInBytes, dataPtr);
-            GraphicsExtensions.CheckGLError();
+            int dataSize = Marshal.SizeOf(typeof(T));
+            if (dataSize == vertexStride)
+            {
+                GL.BufferSubData(BufferTarget.ArrayBuffer, (IntPtr) offsetInBytes, (IntPtr) sizeInBytes, dataPtr);
+                GraphicsExtensions.CheckGLError();
+            }
+            else
+            {
+                for (int i = 0; i < elementCount; i++)
+                {
+                    GL.BufferSubData(BufferTarget.ArrayBuffer, (IntPtr)offsetInBytes + i * vertexStride, (IntPtr)dataSize, dataPtr);
+                    GraphicsExtensions.CheckGLError();
+                    dataPtr = (IntPtr)(dataPtr.ToInt64() + dataSize);
+                }
+            }
 
             dataHandle.Free();
         }


### PR DESCRIPTION
This does for OpenGL what #3356 did for DirectX.

Previously, it would only have worked when `vertexStride == sizeof(T)`. This code path remains unchanged. The new code is for when `vertexStride != sizeof(T)`.

This change is covered by existing tests in `VertexBufferTest`: `SetPosition` and `SetTextureCoordinate`. These tests previously failed for OpenGL, and they now pass.