### PR TITLE
Fix the MonoMac Template so it runs

### DIFF
--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/MonoDevelop.MonoGame.Mac.csproj
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/MonoDevelop.MonoGame.Mac.csproj
@@ -80,5 +80,8 @@
     <Content Include="templates\MonoGameOSXProject.xpt.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="templates\Mac\MainMenu.xib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/Mac/MacInfo.plist
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/Mac/MacInfo.plist
@@ -3,14 +3,16 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleIdentifier</key>
-	<string>com.yourcompany.MonoGame.Samples.Draw2D.MacOS</string>
+	<string>${AppIdentifier}</string>
 	<key>CFBundleName</key>
-	<string>MonoGame.Samples.Draw2D.MacOS</string>
+	<string>${AppName}</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.6</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
 </dict>
 </plist>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/Mac/MainMenu.xib
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/Mac/MainMenu.xib
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9532"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="NSApplication"/>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application"/>
+        <customObject id="371" customClass="NSFontManager"/>
+        <menu title="Main Menu" systemMenu="main" id="29">
+            <items>
+                <menuItem title="NewApplication" id="56">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="NewApplication" systemMenu="apple" id="57">
+                        <items>
+                            <menuItem title="Quit NewApplication" keyEquivalent="q" id="136">
+                                <connections>
+                                    <action selector="terminate:" target="-1" id="369"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+            </items>
+        </menu>
+    </objects>
+</document>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/MonoGameMacProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/MonoGameMacProject.xpt.xml
@@ -30,10 +30,14 @@
 				<Reference type="Gac" refto="MonoMac" SpecificVersion="false" />
 				<Reference type="Package" refto="MonoGame.Framework" />
 			</References>
+			<Packages>
+				<Package ID="MonoGame.Framework" Version="3.4.0.459" f="net40" />
+			</Packages>
 			<Files>
 				<File name="Game1.cs" AddStandardHeader="True" src="Common/Game1.cs" />
 				<File name="Main.cs" AddStandardHeader="True" src="Mac/Program.cs" />
 				<File name="Info.plist" AddStandardHeader="False" src="Mac/MacInfo.plist" />
+				<File name="MainMenu.xib" AddStandardHeader="False" src="Mac/MainMenu.xib" />
 				<Directory name="Content">
 					<File name="Content.mgcb" src="Common/Content.mgcb"/>
 				</Directory>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame.addin.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame.addin.xml
@@ -38,6 +38,7 @@
     <Import file="templates/MonoGameMacProject.xpt.xml" />
     <Import file="templates/MonoGameOSXProject.xpt.xml" />
     <Import file="templates/Mac/MacInfo.plist" />
+    <Import file="templates/Mac/MainMenu.xib" />
     <Import file="templates/Mac/Program.cs" />
     <!-- iOS Templates -->
     <Import file="templates/MonoGameiOSProject.xpt.xml" />
@@ -57,13 +58,13 @@
     <Import file="MonoDevelop.MonoGame.iOS.dll" />
     <Import file="MonoDevelop.MonoGame.Mac.dll" />
     <!-- Nuget Packages -->
-    <Import file="packages/MonoGame.Framework.Android.3.3.0.nupkg" />
-    <Import file="packages/MonoGame.Framework.iOS.3.3.0.nupkg" />
-    <Import file="packages/MonoGame.Framework.Linux.3.3.0.nupkg" />
-    <Import file="packages/MonoGame.Framework.MacOS.3.3.0.nupkg" />
-    <Import file="packages/MonoGame.Framework.Ouya.3.3.0.nupkg" />
-    <Import file="packages/MonoGame.Framework.WindowsDX.3.3.0.nupkg" />
-    <Import file="packages/MonoGame.Framework.WindowsGL.3.3.0.nupkg" />
+    <Import file="packages/MonoGame.Framework.Android.3.4.0.459.nupkg" />
+    <Import file="packages/MonoGame.Framework.iOS.3.4.0.459.nupkg" />
+    <Import file="packages/MonoGame.Framework.Linux.3.4.0.459.nupkg" />
+    <Import file="packages/MonoGame.Framework.MacOS.3.4.0.459.nupkg" />
+    <Import file="packages/MonoGame.Framework.Ouya.3.4.0.459.nupkg" />
+    <Import file="packages/MonoGame.Framework.WindowsDX.3.4.0.459.nupkg" />
+    <Import file="packages/MonoGame.Framework.WindowsGL.3.4.0.459.nupkg" />
     <Import file="packages/Ouya.Console.Api.1.0.13.1.nupkg" />
     <Import file="packages/MonoGame.Framework.Content.Pipeline.Portable.3.2.99.1-Beta.nupkg" />
     <Import file="packages/MonoGame.Framework.Portable.3.2.99.1-Beta.nupkg" />

--- a/IDE/MonoDevelop/default.build
+++ b/IDE/MonoDevelop/default.build
@@ -35,16 +35,16 @@
 
   <target name="buildaddin" description="Build Xamarin Studio Addin" depends="checkos">
      <mkdir dir="MonoDevelop.MonoGame/packages/"/>
-     <get src="https://www.nuget.org/api/v2/package/MonoGame.Framework.Android/3.3.0" dest="MonoDevelop.MonoGame/packages/MonoGame.Framework.Android.3.3.0.nupkg" />
-     <get src="https://www.nuget.org/api/v2/package/MonoGame.Framework.iOS/3.3.0" dest="MonoDevelop.MonoGame/packages/MonoGame.Framework.iOS.3.3.0.nupkg" />
-     <get src="https://www.nuget.org/api/v2/package/MonoGame.Framework.Linux/3.3.0" dest="MonoDevelop.MonoGame/packages/MonoGame.Framework.Linux.3.3.0.nupkg" />
-     <get src="https://www.nuget.org/api/v2/package/MonoGame.Framework.MacOS/3.3.0" dest="MonoDevelop.MonoGame/packages/MonoGame.Framework.MacOS.3.3.0.nupkg" />
+     <get src="https://www.nuget.org/api/v2/package/MonoGame.Framework.Android/3.4.0.459" dest="MonoDevelop.MonoGame/packages/MonoGame.Framework.Android.3.4.0.459.nupkg" />
+     <get src="https://www.nuget.org/api/v2/package/MonoGame.Framework.iOS/3.4.0.459" dest="MonoDevelop.MonoGame/packages/MonoGame.Framework.iOS.3.4.0.459.nupkg" />
+     <get src="https://www.nuget.org/api/v2/package/MonoGame.Framework.Linux/3.4.0.459" dest="MonoDevelop.MonoGame/packages/MonoGame.Framework.Linux.3.4.0.459.nupkg" />
+     <get src="https://www.nuget.org/api/v2/package/MonoGame.Framework.MacOS/3.4.0.459" dest="MonoDevelop.MonoGame/packages/MonoGame.Framework.MacOS.3.4.0.459.nupkg" />
       <!--
      <get src="https://www.nuget.org/api/v2/package/MonoGame.Framework.MonoMac/3.2.99-Beta" dest="MonoDevelop.MonoGame/packages/MonoGame.Framework.MonoMac.3.3.0.nupkg" />
      -->
-     <get src="https://www.nuget.org/api/v2/package/MonoGame.Framework.Ouya/3.3.0" dest="MonoDevelop.MonoGame/packages/MonoGame.Framework.Ouya.3.3.0.nupkg" />
-     <get src="https://www.nuget.org/api/v2/package/MonoGame.Framework.WindowsDX/3.3.0" dest="MonoDevelop.MonoGame/packages/MonoGame.Framework.WindowsDX.3.3.0.nupkg" />
-     <get src="https://www.nuget.org/api/v2/package/MonoGame.Framework.WindowsGL/3.3.0" dest="MonoDevelop.MonoGame/packages/MonoGame.Framework.WindowsGL.3.3.0.nupkg" />
+     <get src="https://www.nuget.org/api/v2/package/MonoGame.Framework.Ouya/3.4.0.459" dest="MonoDevelop.MonoGame/packages/MonoGame.Framework.Ouya.3.4.0.459.nupkg" />
+     <get src="https://www.nuget.org/api/v2/package/MonoGame.Framework.WindowsDX/3.4.0.459" dest="MonoDevelop.MonoGame/packages/MonoGame.Framework.WindowsDX.3.4.0.459.nupkg" />
+     <get src="https://www.nuget.org/api/v2/package/MonoGame.Framework.WindowsGL/3.4.0.459" dest="MonoDevelop.MonoGame/packages/MonoGame.Framework.WindowsGL.3.4.0.459.nupkg" />
      <get src="https://www.nuget.org/api/v2/package/MonoGame.Framework.Portable/3.2.99.1-Beta" dest="MonoDevelop.MonoGame/packages/MonoGame.Framework.Portable.3.2.99.1-Beta.nupkg" />
      <get src="https://www.nuget.org/api/v2/package/MonoGame.Framework.Content.Pipeline.Portable/3.2.99.1-Beta" dest="MonoDevelop.MonoGame/packages/MonoGame.Framework.Content.Pipeline.Portable.3.2.99.1-Beta.nupkg" />
      <get src="https://www.nuget.org/api/v2/package/Ouya.Console.Api/1.0.13.1" dest="MonoDevelop.MonoGame/packages/Ouya.Console.Api.1.0.13.1.nupkg"/>


### PR DESCRIPTION
The MonoMac project was missing a MainMenu item
which was causing the application to crash.
Has to add back the use of Nuget because MonoMac projects
to NOT use MSBuild/xbuild so it cannot use the new .props
system.