### PR TITLE
Fixed Minimum framework version for iOS

### DIFF
--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/iOS/iOSInfo.plist
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/iOS/iOSInfo.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>project.MonoGame.${Namespace}</string>
 	<key>MinimumOSVersion</key>
-	<string>4.2</string>
+	<string>7.0</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
The Minumum framework version needs to be 5.1.1 in order to
compile the iOS app. It also needs to be that version to publish
to the maximum number of devices.