### PR TITLE
Fixed a typo in the Xamarin Studio Addin

### DIFF
--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoGameMSBuildImports.cs
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoGameMSBuildImports.cs
@@ -66,7 +66,7 @@ namespace MonoDevelop.MonoGame
 					manager.AddNamespace ("tns", schema);
 					var import = project.Document.CreateElement ("Import", schema);
 					import.SetAttribute ("Project", MonoGameCommonProps);
-					import.SetAttribute ("Conditon", string.Format ("Exists('{0}')", MonoGameCommonProps));
+					import.SetAttribute ("Condition", string.Format ("Exists('{0}')", MonoGameCommonProps));
 					project.Document.DocumentElement.InsertBefore (import, project.Document.DocumentElement.FirstChild);
 					needsSave = true;
 				}


### PR DESCRIPTION
The code that was injecting the monogame .props file
had a tyyo in the Codition property. This was causing
the build to fail on Windows.

This commit fixes that issue