### PR TITLE
Split out Title Container into partial classes

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -248,6 +248,21 @@
       <Platforms>Android,Angle,iOS,Linux,MacOS,Ouya,WindowsGL,WindowsPhone,tvOS</Platforms>
     </Compile>
     <Compile Include="TitleContainer.cs" />
+    <Compile Include="TitleContainer.Android.cs">
+      <Platforms>Android,Ouya</Platforms>
+    </Compile>
+    <Compile Include="TitleContainer.Desktop.cs">
+      <Platforms>Linux,WindowsGL,Angle</Platforms>
+    </Compile>
+    <Compile Include="TitleContainer.iOS.cs">
+      <Platforms>iOS</Platforms>
+    </Compile>
+    <Compile Include="TitleContainer.MacOS.cs">
+      <Platforms>MacOS</Platforms>
+    </Compile>
+    <Compile Include="TitleContainer.WinRT.cs">
+      <Platforms>WindowsPhone,WindowsUniversal,Windows8,WindowsPhone81</Platforms>
+    </Compile>
     <Compile Include="Vector2.cs" />
     <Compile Include="Vector3.cs" />
     <Compile Include="Vector4.cs" />

--- a/MonoGame.Framework/Content/ContentManager.cs
+++ b/MonoGame.Framework/Content/ContentManager.cs
@@ -191,6 +191,16 @@ namespace Microsoft.Xna.Framework.Content
 			}
 		}
 
+        public virtual IEnumerable<string> ListAssets(string directory)
+        {
+            var files = TitleContainer.GetFiles(Path.Combine(RootDirectory, directory), "*.xnb");
+            for (int i = 0; i < files.Count; i++)
+            {
+                files[i] = files[i].Replace(RootDirectory + Path.DirectorySeparatorChar, "");
+            }
+            return files;
+        }
+
 		public virtual T Load<T>(string assetName)
 		{
             if (string.IsNullOrEmpty(assetName))

--- a/MonoGame.Framework/TitleContainer.Android.cs
+++ b/MonoGame.Framework/TitleContainer.Android.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.IO;
+using Microsoft.Xna.Framework.Utilities;
+using System.Collections.Generic;
+
+namespace Microsoft.Xna.Framework
+{
+    public static partial class TitleContainer
+    {
+        static TitleContainer() 
+        {
+            Location = String.Empty;
+        }
+
+        internal static Stream PlatformOpenStream (string safeName)
+        {
+            return Android.App.Application.Context.Assets.Open(safeName);
+        }
+
+        internal static List<string> PlatformGetFiles (string directory, string filter)
+        {
+            var results = new List<string>();
+            var files = Game.Activity.Assets.List (directory);
+            for (int i=files.Length; i > 0; i--)
+            {
+                var ext = Path.GetExtension (files[i]);
+                if (filter.EndsWith ( filter.EndsWith ("*") ? filter : ext))
+                {
+                    results.Add(files[i]);
+                }
+            }
+            return results;
+        }
+    }
+}
+

--- a/MonoGame.Framework/TitleContainer.Desktop.cs
+++ b/MonoGame.Framework/TitleContainer.Desktop.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+
+namespace Microsoft.Xna.Framework
+{
+    public static partial class TitleContainer
+    {
+        static TitleContainer() 
+        {
+            Location = AppDomain.CurrentDomain.BaseDirectory;
+        }
+
+        internal static Stream PlatformOpenStream (string safeName)
+        {
+            var absolutePath = Path.Combine(Location, safeName);
+            return File.OpenRead(absolutePath);
+        }
+
+        internal static List<string> PlatformGetFiles (string directory, string filter)
+        {
+            return new List<string> (Directory.GetFiles(directory, filter));
+        }
+    }
+}
+

--- a/MonoGame.Framework/TitleContainer.MacOS.cs
+++ b/MonoGame.Framework/TitleContainer.MacOS.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+#if PLATFORM_MACOS_LEGACY
+using MonoMac.Foundation;
+#else
+using Foundation;
+#endif
+
+namespace Microsoft.Xna.Framework
+{
+    public static partial class TitleContainer
+    {
+        static TitleContainer() 
+        {
+            Location = NSBundle.MainBundle.ResourcePath;
+        }
+
+        internal static Stream PlatformOpenStream (string safeName)
+        {
+            var absolutePath = Path.Combine(Location, safeName);
+            return File.OpenRead(absolutePath);
+        }
+
+        internal static List<string> PlatformGetFiles (string directory, string filter)
+        {
+            return new List<string> (Directory.GetFiles(directory, filter));
+        }
+    }
+}

--- a/MonoGame.Framework/TitleContainer.WinRT.cs
+++ b/MonoGame.Framework/TitleContainer.WinRT.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Xna.Framework.Utilities;
+using System.IO;
+using System.Collections.Generic;
+
+namespace Microsoft.Xna.Framework
+{
+    public static partial class TitleContainer
+    {
+        static TitleContainer() 
+        {
+            Location = Windows.ApplicationModel.Package.Current.InstalledLocation.Path;
+        }
+
+        internal static Stream PlatformOpenStream (string safeName)
+        {
+            var stream = Task.Run( () => OpenStreamAsync(safeName).Result ).Result;
+            if (stream == null)
+                throw new FileNotFoundException(safeName);
+
+            return stream;
+        }
+
+        internal static List<string> PlatformGetFiles (string directory, string filter)
+        {
+            return Task.Run(() => GetFilesAsync(directory).Result).Result;
+        }
+
+        private static async Task<List<string>> GetFilesAsync(string directory)
+        {
+            var package = Windows.ApplicationModel.Package.Current;
+            var results = new List<string>();
+            try {
+                var folder = await package.InstalledLocation.GetFolderAsync(directory);
+                if (folder != null)
+                {
+                    var files = await folder.GetFilesAsync(Windows.Storage.Search.CommonFileQuery.DefaultQuery);
+                    foreach (var f in files)
+                    {
+                        results.Add(Path.Combine (directory, f.Name));
+                    }
+                }
+                return results;
+            }
+            catch (IOException)
+            {
+                // The file must not exist... return a null stream.
+                return results;
+            }
+        }
+
+        private static async Task<Stream> OpenStreamAsync(string name)
+        {
+            var package = Windows.ApplicationModel.Package.Current;
+
+            try
+            {
+                var storageFile = await package.InstalledLocation.GetFileAsync(name);
+                var randomAccessStream = await storageFile.OpenReadAsync();
+                return randomAccessStream.AsStreamForRead();
+            }
+            catch (IOException)
+            {
+                // The file must not exist... return a null stream.
+                return null;
+            }
+        }
+    }
+}
+

--- a/MonoGame.Framework/TitleContainer.cs
+++ b/MonoGame.Framework/TitleContainer.cs
@@ -4,68 +4,15 @@
 
 using System;
 using System.IO;
-#if WINRT
-using System.Threading.Tasks;
-#elif IOS
-using Foundation;
-using UIKit;
-#elif MONOMAC
-#if PLATFORM_MACOS_LEGACY
-using MonoMac.Foundation;
-#else
-using Foundation;
-#endif
-#endif
 using Microsoft.Xna.Framework.Utilities;
+using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework
 {
-    public static class TitleContainer
+    public static partial class TitleContainer
     {
-        static TitleContainer() 
-        {
-#if WINDOWS || DESKTOPGL
-            Location = AppDomain.CurrentDomain.BaseDirectory;
-#elif WINRT
-            Location = Windows.ApplicationModel.Package.Current.InstalledLocation.Path;
-#elif IOS || MONOMAC
-			Location = NSBundle.MainBundle.ResourcePath;
-#else
-            Location = string.Empty;
-#endif
-
-#if IOS
-            SupportRetina = UIScreen.MainScreen.Scale >= 2.0f;
-            RetinaScale = (int)Math.Round(UIScreen.MainScreen.Scale);
-#endif
-        }
-
         static internal string Location { get; private set; }
-#if IOS
-        static internal bool SupportRetina { get; private set; }
-        static internal int RetinaScale { get; private set; }
-#endif
 
-#if WINRT
-
-        private static async Task<Stream> OpenStreamAsync(string name)
-        {
-            var package = Windows.ApplicationModel.Package.Current;
-
-            try
-            {
-                var storageFile = await package.InstalledLocation.GetFileAsync(name);
-                var randomAccessStream = await storageFile.OpenReadAsync();
-                return randomAccessStream.AsStreamForRead();
-            }
-            catch (IOException)
-            {
-                // The file must not exist... return a null stream.
-                return null;
-            }
-        }
-
-#endif // WINRT
 
         /// <summary>
         /// Returns an open stream to an exsiting file in the title storage area.
@@ -81,34 +28,12 @@ namespace Microsoft.Xna.Framework
             if (Path.IsPathRooted(safeName))
                 throw new ArgumentException("Invalid filename. TitleContainer.OpenStream requires a relative path.");
 
-#if WINRT
-            var stream = Task.Run( () => OpenStreamAsync(safeName).Result ).Result;
-            if (stream == null)
-                throw new FileNotFoundException(name);
+            return PlatformOpenStream(safeName);
+        }
 
-            return stream;
-#elif ANDROID
-            return Android.App.Application.Context.Assets.Open(safeName);
-#elif IOS
-            var absolutePath = Path.Combine(Location, safeName);
-            if (SupportRetina)
-            {
-                for (var scale = RetinaScale; scale >= 2; scale--)
-                {
-                    // Insert the @#x immediately prior to the extension. If this file exists
-                    // and we are on a Retina device, return this file instead.
-                    var absolutePathX = Path.Combine(Path.GetDirectoryName(absolutePath),
-                                                      Path.GetFileNameWithoutExtension(absolutePath)
-                                                      + "@" + scale + "x" + Path.GetExtension(absolutePath));
-                    if (File.Exists(absolutePathX))
-                        return File.OpenRead(absolutePathX);
-                }
-            }
-            return File.OpenRead(absolutePath);
-#else
-            var absolutePath = Path.Combine(Location, safeName);
-            return File.OpenRead(absolutePath);
-#endif
+        public static List<string> GetFiles(string directory, string filter = "*.*")
+        {
+            return PlatformGetFiles(directory, filter);
         }
 
         // TODO: This is just path normalization.  Remove this

--- a/MonoGame.Framework/TitleContainer.iOS.cs
+++ b/MonoGame.Framework/TitleContainer.iOS.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+#if IOS
+using Foundation;
+using UIKit;
+#endif
+
+namespace Microsoft.Xna.Framework
+{
+    public static partial class TitleContainer
+    {
+        static internal bool SupportRetina { get; private set; }
+        static internal int RetinaScale { get; private set; }
+
+         static TitleContainer() 
+        {
+            Location = NSBundle.MainBundle.ResourcePath;
+            SupportRetina = UIScreen.MainScreen.Scale >= 2.0f;
+            RetinaScale = (int)Math.Round(UIScreen.MainScreen.Scale);
+        }
+
+        internal static Stream PlatformOpenStream (string safeName)
+        {
+            var absolutePath = Path.Combine(Location, safeName);
+            if (SupportRetina)
+            {
+                for (var scale = RetinaScale; scale >= 2; scale--)
+                {
+                    // Insert the @#x immediately prior to the extension. If this file exists
+                    // and we are on a Retina device, return this file instead.
+                    var absolutePathX = Path.Combine(Path.GetDirectoryName(absolutePath),
+                        Path.GetFileNameWithoutExtension(absolutePath)
+                        + "@" + scale + "x" + Path.GetExtension(absolutePath));
+                    if (File.Exists(absolutePathX))
+                        return File.OpenRead(absolutePathX);
+                }
+            }
+            return File.OpenRead(absolutePath);
+        }
+
+        internal static List<string> PlatformGetFiles (string directory, string filter)
+        {
+            return new List<string> (Directory.GetFiles(directory, filter));
+        }
+    }
+}
+


### PR DESCRIPTION
This should make porting to other platforms easier.
Also implemented the GetAssets/GetFiles functionality
from #4542