### PR TITLE
Add exception to PixelBitmapContent constructor

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/PixelBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/PixelBitmapContent.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
         public PixelBitmapContent(int width, int height)
         {
+            if (!TryGetFormat(out _format))
+                throw new InvalidOperationException(string.Format("Color format \"{0}\" is not supported",typeof(T).ToString()));
             Height = height;
             Width = width;
 
@@ -27,7 +29,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             for (int y = 0; y < height; y++)
                 _pixelData[y] = new T[width];
 
-            TryGetFormat(out _format);
         }
 
         public override byte[] GetPixelData()


### PR DESCRIPTION
If the call to TryGetFormat returns false inside the constructor, throw
an InvalidOperationException instead of continuing with the wrong
SurfaceFormat.
This bug was detected in #4595: If for the T parameter of `PixelBitmapContent` there is no matching `SurfaceFormat` the constructor defaults to `SurfaceFormat.Color` and continues like nothing has happened, leading to problems when using this instance