### PR TITLE
Implementation of SetTitle for UWP

### DIFF
--- a/MonoGame.Framework/GameWindow.cs
+++ b/MonoGame.Framework/GameWindow.cs
@@ -42,7 +42,14 @@ namespace Microsoft.Xna.Framework {
 		public abstract string ScreenDeviceName { get; }
 
 		private string _title;
-		public string Title {
+        /// <summary>
+        /// Gets or sets the title of the game window.
+        /// </summary>
+        /// <remarks>
+        /// For Windows 8 and Windows 10 UWP this has no effect. For these platforms the title should be
+        /// set by using the DisplayName property found in the app manifest file.
+        /// </remarks>
+        public string Title {
 			get { return _title; }
 			set {
 				if (_title != value) {

--- a/MonoGame.Framework/WindowsUniversal/UAPGameWindow.cs
+++ b/MonoGame.Framework/WindowsUniversal/UAPGameWindow.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 using Windows.UI.Core;
@@ -241,8 +242,7 @@ namespace Microsoft.Xna.Framework
 
         protected override void SetTitle(string title)
         {
-            var appView = ApplicationView.GetForCurrentView();
-            appView.Title = title;
+            Debug.WriteLine("WARNING: GameWindow.Title has no effect under UWP.");
         }
 
         internal void SetCursor(bool visible)

--- a/MonoGame.Framework/WindowsUniversal/UAPGameWindow.cs
+++ b/MonoGame.Framework/WindowsUniversal/UAPGameWindow.cs
@@ -241,8 +241,8 @@ namespace Microsoft.Xna.Framework
 
         protected override void SetTitle(string title)
         {
-            // NOTE: There is no concept of a window 
-            // title in a Metro application.
+            var appView = ApplicationView.GetForCurrentView();
+            appView.Title = title;
         }
 
         internal void SetCursor(bool visible)


### PR DESCRIPTION
Sets the title for the current view for Universal Windows Project apps.
It should be noted that this is meant to be the title for the current
view, and that UWP apps always will append the Display Name from the app
manifest to this title.