### PR TITLE
Rgba64 support in PixelBitmapContent

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/PixelBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/PixelBitmapContent.cs
@@ -95,6 +95,24 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 format = SurfaceFormat.Single;
             else if (typeof(T) == typeof(byte))
                 format = SurfaceFormat.Alpha8;
+            else if (typeof(T) == typeof(Rgba64))
+                format = SurfaceFormat.Rgba64;
+            else if (typeof(T) == typeof(Rgba1010102))
+                format = SurfaceFormat.Rgba1010102;
+            else if (typeof(T) == typeof(Rg32))
+                format = SurfaceFormat.Rg32;
+            else if (typeof(T) == typeof(Byte4))
+                format = SurfaceFormat.Color;
+            else if (typeof(T) == typeof(NormalizedByte2))
+                format = SurfaceFormat.NormalizedByte2;
+            else if (typeof(T) == typeof(NormalizedByte4))
+                format = SurfaceFormat.NormalizedByte4;
+            else if (typeof(T) == typeof(HalfSingle))
+                format = SurfaceFormat.HalfSingle;
+            else if (typeof(T) == typeof(HalfVector2))
+                format = SurfaceFormat.HalfVector2;
+            else if (typeof(T) == typeof(HalfVector4))
+                format = SurfaceFormat.HalfVector4;
             else
             {
                 format = SurfaceFormat.Color;

--- a/MonoGame.Framework.Content.Pipeline/TextureImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/TextureImporter.cs
@@ -133,35 +133,31 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             FIBITMAP bgra;
             switch(imageType)
             {
-                //Bitmap files are expanded to 32 bits before switching channels
-                case FREE_IMAGE_TYPE.FIT_BITMAP:
-                    bgra = FreeImage.ConvertTo32Bits(fBitmap);
+                // RGBF are switched before adding an alpha channel.
+                case FREE_IMAGE_TYPE.FIT_RGBF:
+                    // Swap R and B channels to make it BGR, then add an alpha channel
+                    SwitchRedAndBlueChannels(fBitmap);
+                    bgra = FreeImage.ConvertToType(fBitmap, FREE_IMAGE_TYPE.FIT_RGBAF, true);
                     FreeImage.UnloadEx(ref fBitmap);
                     fBitmap = bgra;
-                    SwitchRedAndBlueChannels(fBitmap);
                     break;
 
-                //RGBF are switched before adding an alpha channel.
-                case FREE_IMAGE_TYPE.FIT_RGBF:
-                    {
-                        // Swap R and B channels to make it BGR, then add an alpha channel
-                        SwitchRedAndBlueChannels(fBitmap);
-                        bgra = FreeImage.ConvertToType(fBitmap, FREE_IMAGE_TYPE.FIT_RGBAF, true);
-                        FreeImage.UnloadEx(ref fBitmap);
-                        fBitmap = bgra;
-                    }
+                case FREE_IMAGE_TYPE.FIT_RGB16:
+                    // Swap R and B channels to make it BGR, then add an alpha channel
+                    SwitchRedAndBlueChannels(fBitmap);
+                    bgra = FreeImage.ConvertToType(fBitmap, FREE_IMAGE_TYPE.FIT_RGBA16, true);
+                    FreeImage.UnloadEx(ref fBitmap);
+                    fBitmap = bgra;
                     break;
 
                 case FREE_IMAGE_TYPE.FIT_RGBAF:
-                    {
-                        // Swap R and B channels to make it BGRA
-                        SwitchRedAndBlueChannels(fBitmap);
-                    }
+                case FREE_IMAGE_TYPE.FIT_RGBA16:
+                    // Swap R and B channels to make it BGRA
+                    SwitchRedAndBlueChannels(fBitmap);
                     break;
-                //case FREE_IMAGE_TYPE.FIT_RGBA16:
-                //    SwitchRedAndBlueChannels(fBitmap);
-                //    break;
+
                 default:
+                    // Bitmap and other formats are converted to 32-bit by default
                     bgra = FreeImage.ConvertTo32Bits(fBitmap);
                     SwitchRedAndBlueChannels(bgra);
                     FreeImage.UnloadEx(ref fBitmap);

--- a/Test/ContentPipeline/TextureImporterTests.cs
+++ b/Test/ContentPipeline/TextureImporterTests.cs
@@ -122,7 +122,7 @@ namespace MonoGame.Tests.ContentPipeline
             Assert.AreEqual(content.Faces[0][0].Height, 240);
             SurfaceFormat format;
             Assert.True(content.Faces[0][0].TryGetFormat(out format));
-            Assert.AreEqual(SurfaceFormat.Color, format);
+            Assert.AreEqual(SurfaceFormat.Rgba64, format);
             // Clean-up the directories it may have produced, ignoring DirectoryNotFound exceptions
             try
             {


### PR DESCRIPTION
- Added other packed vector types that had been omitted, though I'm not sure how to support NormalizedShort2 and 4 as there does not appear to be corresponding SurfaceFormat types.
- Updated Rgba64 importer test to expect SurfaceFormat.Rgba64.