### PR TITLE
Clone the Bitmap in ImageEx.RGBToBGR()

### DIFF
--- a/MonoGame.Framework/Graphics/ImageEx.cs
+++ b/MonoGame.Framework/Graphics/ImageEx.cs
@@ -27,7 +27,8 @@ namespace System.Drawing
             }
             else
             {
-                newBmp = bmp;
+                // Need to clone so the call to Clear() below doesn't clear the source before trying to draw it to the target.
+                newBmp = (Image)bmp.Clone();
             }
         
             try


### PR DESCRIPTION
This prevents the call to Clear() from clearing the source when it should only have been clearing the target.

Fixes #1946