### PR TITLE
Change Shared Program.cs back to using a static to fix an issue in iOS.

### DIFF
--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/Common/Program.cs
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/Common/Program.cs
@@ -20,13 +20,16 @@ namespace ${Namespace}
     static class Program
     #endif
     {
-        internal static void RunGame() 
-        {
-            using (var game = new Game1())
-            {
-                game.Run();
-            }
-        }
+		private static Game1 game;
+
+		internal static void RunGame() 
+		{
+			game = new Game1();
+			game.Run();
+			#if !__IOS__  && !__TVOS__
+			game.Dispose ();
+			#endif
+		}
             
         /// <summary>
         /// The main entry point for the application.


### PR DESCRIPTION
For MonoGame 3.6 we should revisit this kind of code to have platform
specific source files rather than this mess of #if statements. Generally
speaking developers do not share startup code.