### PR TITLE
Update MonoMac, XamMac and Xamarin.Mac Support.

### DIFF
--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Android/templates/MonoGameAndroidProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Android/templates/MonoGameAndroidProject.xpt.xml
@@ -50,7 +50,7 @@
 					<File name="AndroidManifest.xml" src="Android/AndroidManifest.xml" />
 				</Directory>
 				<Directory name="Content">
-					<File name="Content.mgcb" src="Common/Content.mgcb"/>
+					<File name="Content.mgcb" src="Common/Content.mgcb" BuildAction="MonoGameContentReference"/>
 				</Directory>
 				<Directory name="Assets">
 					<RawFile name="AboutAssets.txt" src="Android/AboutAssets.txt" />

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Android/templates/MonoGameOUYAProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Android/templates/MonoGameOUYAProject.xpt.xml
@@ -51,7 +51,7 @@
 					<File name="AndroidManifest.xml" src="Android/AndroidManifest.xml" />
 				</Directory>
 				<Directory name="Content">
-					<File name="Content.mgcb" src="Common/Content.mgcb"/>
+					<File name="Content.mgcb" src="Common/Content.mgcb" BuildAction="MonoGameContentReference"/>
 				</Directory>
 				<Directory name="Assets">
 					<RawFile name="AboutAssets.txt" src="Android/AboutAssets.txt" />

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/MonoDevelop.MonoGame.Mac.csproj
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/MonoDevelop.MonoGame.Mac.csproj
@@ -83,5 +83,14 @@
     <Content Include="templates\Mac\MainMenu.xib">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="templates\MonoGameXamMacProject.xpt.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="templates\Mac\XamMac2Program.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="templates\Mac\XamMacProgram.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/Mac/MacInfo.plist
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/Mac/MacInfo.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleIdentifier</key>
-	<string>${AppIdentifier}</string>
+	<string>project.MonoGame.${Namespace}</string>
 	<key>CFBundleName</key>
-	<string>${AppName}</string>
+	<string>${Namespace}</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/Mac/Program.cs
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/Mac/Program.cs
@@ -29,15 +29,8 @@ namespace ${Namespace}
 	{
 		private static Game1 game;
 
-		public override void FinishedLaunching (MonoMac.Foundation.NSObject notification)
+		public override void FinishedLaunching (NSObject notification)
 		{
-			// Handle a Xamarin.Mac Upgrade
-			AppDomain.CurrentDomain.AssemblyResolve += (object sender, ResolveEventArgs a) =>  {
-			if (a.Name.StartsWith("MonoMac")) {
-				return typeof(MonoMac.AppKit.AppKitFramework).Assembly;
-			}
-			return null;
-			};
 			game = new Game1();
 			game.Run();
 		}

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/Mac/XamMac2Program.cs
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/Mac/XamMac2Program.cs
@@ -1,0 +1,26 @@
+﻿#region Using Statements
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using AppKit;
+using Foundation;
+#endregion
+
+namespace ${Namespace}
+{
+	static class Program
+	{
+		/// <summary>
+		/// The main entry point for the application.
+		/// </summary>
+		static void Main(string[] args)
+		{
+			NSApplication.Init ();
+
+			using (var game = new Game1 ()) {
+			game.Run ();
+			}
+		}
+	}
+}

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/Mac/XamMacProgram.cs
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/Mac/XamMacProgram.cs
@@ -1,0 +1,27 @@
+﻿#region Using Statements
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using MonoMac.AppKit;
+using MonoMac.Foundation;
+#endregion
+
+namespace ${Namespace}
+{
+	static class Program
+	{
+		/// <summary>
+		/// The main entry point for the application.
+		/// </summary>
+		static void Main(string[] args)
+		{
+			NSApplication.Init ();
+
+			using (var game = new Game1 ()) {
+				game.Run ();
+			}
+		}
+	}
+}
+

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/MonoGameMacProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/MonoGameMacProject.xpt.xml
@@ -29,17 +29,16 @@
 				<Reference type="Gac" refto="System.Drawing" />
 				<Reference type="Gac" refto="MonoMac" SpecificVersion="false" />
 				<Reference type="Package" refto="MonoGame.Framework" />
+				<Reference type="Package" refto="OpenTK" />
+				<Reference type="Package" refto="Tao.Sdl" />
 			</References>
-			<Packages>
-				<Package ID="MonoGame.Framework.MacOS" Version="3.4.0.459" targetFramework="net40" />
-			</Packages>
 			<Files>
 				<File name="Game1.cs" AddStandardHeader="True" src="Common/Game1.cs" />
 				<File name="Main.cs" AddStandardHeader="True" src="Mac/Program.cs" />
 				<File name="Info.plist" AddStandardHeader="False" src="Mac/MacInfo.plist" />
 				<File name="MainMenu.xib" AddStandardHeader="False" src="Mac/MainMenu.xib" />
 				<Directory name="Content">
-					<File name="Content.mgcb" src="Common/Content.mgcb"/>
+					<File name="Content.mgcb" src="Common/Content.mgcb" BuildAction="MonoGameContentReference"/>
 				</Directory>
 				<Directory name="Properties">
 					<File name="AssemblyInfo.cs" AddStandardHeader="True" src="Common/AssemblyInfo.cs" />

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/MonoGameXamMacProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.Mac/templates/MonoGameXamMacProject.xpt.xml
@@ -1,11 +1,11 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0"?>
 <Template>
 	<TemplateConfiguration>
-		<_Name>MonoGame Mac Application (Xamarin.Mac)</_Name>
+		<_Name>MonoGame Mac Application (Xamarin.Mac Classic)</_Name>
 		<Category>monogame/app/games</Category>
 		<Icon>monogame-project</Icon>
 		<LanguageName>C#</LanguageName>
-		<_Description>Creates a MonoGame Application for Mac OS. This application uses Xamarin.Mac and is suitable for the Apple Store.</_Description>
+		<_Description>Creates a MonoGame Application for Mac OS. This application uses Xamarin.Mac Classic API</_Description>
 	</TemplateConfiguration>
 	
 	<Actions>
@@ -17,24 +17,25 @@
 			<StartupProject>${ProjectName}</StartupProject>
 		</Options>
 		
-		<Project name = "${ProjectName}" directory = "." type = "XamMac2">
-			<Options TargetFrameworkVersion="v4.5" />
+		<Project name = "${ProjectName}" directory = "." type = "XamMac">
+			<Options />
 			<References>
 				<Reference type="Gac" refto="System" />
 				<Reference type="Gac" refto="System.Xml" />
 				<Reference type="Gac" refto="System.Core" />
 				<Reference type="Gac" refto="System.Xml.Linq" />
 				<Reference type="Gac" refto="System.Drawing" />
-				<Reference type="Gac" refto="Xamarin.Mac"/>
+				<Reference type="Gac" refto="XamMac" SpecificVersion="false"/>
 				<Reference type="Package" refto="MonoGame.Framework" />
 				<Reference type="Package" refto="OpenTK, Version=1.1.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4" SpecificVersion="true" />
 				<Reference type="Package" refto="NVorbis" />
 			</References>
 			<Files>
 				<File name="Game1.cs" AddStandardHeader="True" src="Common/Game1.cs" />
-				<File name="Main.cs" AddStandardHeader="True" src="Mac/XamMac2Program.cs" />
-				<File name="Info.plist" AddStandardHeader="False" src="Mac/MacInfo.plist" />
+				<File name="Main.cs" AddStandardHeader="True" src="Mac/XamMacProgram.cs" />
+				<File name="MainMenu.xib" AddStandardHeader="False" src="Mac/MainMenu.xib" />
 				<RawFile name="Icon.ico" src="Common/Icon.ico" BuildAction="EmbeddedResource"/>
+				<File name="Info.plist" AddStandardHeader="False" src="Mac/MacInfo.plist" />
 				<Directory name="Content">
 					<File name="Content.mgcb" src="Common/Content.mgcb" BuildAction="MonoGameContentReference"/>
 				</Directory>
@@ -45,3 +46,4 @@
 		</Project>
 	</Combine>
 </Template>
+

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/MonoGameMobileOnly-PCL.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/MonoGameMobileOnly-PCL.xpt.xml
@@ -43,7 +43,7 @@
 				<RawFile name="Default.png" src="iOS/iOSDefault.png" />
 				<RawFile name="GameThumbnail.png" src="iOS/iOSGameThumbnail.png" />
 				<Directory name="Content">
-					<File name="Content.mgcb" src="Common/Content.mgcb"/>
+					<File name="Content.mgcb" src="Common/Content.mgcb" BuildAction="MonoGameContentReference"/>
 				</Directory>
 				<Directory name="Properties">
 					<File name="AssemblyInfo.cs" AddStandardHeader="True" src="Common/AssemblyInfo.cs" />
@@ -86,7 +86,7 @@
 				<Directory name="Assets">
 					<RawFile name="AboutAssets.txt" src="Android/AboutAssets.txt" />
 					<Directory name="Content">
-						<File name="Content.mgcb" src="Common/Content.mgcb"/>
+						<File name="Content.mgcb" src="Common/Content.mgcb" BuildAction="MonoGameContentReference"/>
 					</Directory>
 				</Directory>
 			</Files>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/MonoGameMobileOnly-SAP.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/MonoGameMobileOnly-SAP.xpt.xml
@@ -39,7 +39,7 @@
 				<RawFile name="Default.png" src="iOS/iOSDefault.png" />
 				<RawFile name="GameThumbnail.png" src="iOS/iOSGameThumbnail.png" />
 				<Directory name="Content">
-					<File name="Content.mgcb" src="Common/Content.mgcb"/>
+					<File name="Content.mgcb" src="Common/Content.mgcb" BuildAction="MonoGameContentReference"/>
 				</Directory>
 				<Directory name="Properties">
 					<File name="AssemblyInfo.cs" AddStandardHeader="True" src="Common/AssemblyInfo.cs" />
@@ -82,7 +82,7 @@
 				<Directory name="Assets">
 					<RawFile name="AboutAssets.txt" src="Android/AboutAssets.txt" />
 					<Directory name="Content">
-						<File name="Content.mgcb" src="Common/Content.mgcb"/>
+						<File name="Content.mgcb" src="Common/Content.mgcb" BuildAction="MonoGameContentReference"/>
 					</Directory>
 				</Directory>
 			</Files>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/MonoGameiOSProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/MonoGameiOSProject.xpt.xml
@@ -34,7 +34,7 @@
 				<RawFile name="Default.png" src="iOS/iOSDefault.png" />
 				<RawFile name="GameThumbnail.png" src="iOS/iOSGameThumbnail.png" />
 				<Directory name="Content">
-					<File name="Content.mgcb" src="Common/Content.mgcb"/>
+					<File name="Content.mgcb" src="Common/Content.mgcb" BuildAction="MonoGameContentReference"/>
 				</Directory>
 				<Directory name="Properties">
 					<File name="AssemblyInfo.cs" AddStandardHeader="True" src="Common/AssemblyInfo.cs" />

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/MonoGametvOSProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame.iOS/templates/MonoGametvOSProject.xpt.xml
@@ -32,7 +32,7 @@
 				<RawFile name="Default.png" src="iOS/iOSDefault.png" />
 				<RawFile name="GameThumbnail.png" src="iOS/iOSGameThumbnail.png" />
 				<Directory name="Content">
-					<File name="Content.mgcb" src="Common/Content.mgcb"/>
+					<File name="Content.mgcb" src="Common/Content.mgcb" BuildAction="MonoGameContentReference"/>
 				</Directory>
 				<Directory name="Properties">
 					<File name="AssemblyInfo.cs" AddStandardHeader="True" src="Common/AssemblyInfo.cs" />

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame.addin.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame.addin.xml
@@ -37,9 +37,12 @@
     <!-- Mac Templates -->
     <Import file="templates/MonoGameMacProject.xpt.xml" />
     <Import file="templates/MonoGameOSXProject.xpt.xml" />
+    <Import file="templates/MonoGameXamMacProject.xpt.xml" />
     <Import file="templates/Mac/MacInfo.plist" />
     <Import file="templates/Mac/MainMenu.xib" />
     <Import file="templates/Mac/Program.cs" />
+    <Import file="templates/Mac/XamMac2Program.cs" />
+    <Import file="templates/Mac/XamMacProgram.cs" />
     <!-- iOS Templates -->
     <Import file="templates/MonoGameiOSProject.xpt.xml" />
     <Import file="templates/iOS/iOSDefault.png" />
@@ -147,12 +150,10 @@
   <Extension path="/MonoDevelop/Ide/DisplayBindings">
     <DisplayBinding id="MonoGamePipeline" insertbefore="DefaultDisplayBinding" class="MonoDevelop.MonoGame.PipelineDisplayBinding" />
   </Extension>
-  <!-- Disabled in favour of MSBuild .targets integration -->
-  <!--
+  <!-- We still need this for MonoMac and Xamarin Mac Classic support -->
   <Extension path="/MonoDevelop/ProjectModel/ProjectServiceExtensions">
     <Class class="MonoDevelop.MonoGame.MonoGameBuildExtension" />
   </Extension>
-  -->
   <Module>
     <Runtime>
       <Import assembly="MonoDevelop.MonoGame.Android.dll" />
@@ -197,7 +198,8 @@
     </Dependencies>
     <Extension path="/MonoDevelop/Ide/ProjectTemplates">
       <ProjectTemplate id="MonoGameForMonoMacProject" file="templates/MonoGameMacProject.xpt.xml" />
-      <ProjectTemplate id="MonoGameForXamMacProject" file="templates/MonoGameOSXProject.xpt.xml" />
+      <ProjectTemplate id="MonoGameForXamMac2Project" file="templates/MonoGameOSXProject.xpt.xml" />
+      <ProjectTemplate id="MonoGameForXamMacProject" file="templates/MonoGameXamMacProject.xpt.xml" />
     </Extension>
   </Module>
 </Addin>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoGameBuildExtension.cs
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoGameBuildExtension.cs
@@ -16,11 +16,10 @@ namespace MonoDevelop.MonoGame
 		/// </summary>
 		static Dictionary<string,string> supportedProjectTypes = new Dictionary<string,string>() { 
 			{"MonoMac", "MacOSX"}, 
-			{"XamMac","MacOSX"}, 
-			{"MonoTouch", "iOS"}, 
-			{"MonoDroid","Android"},
-			{"MonoGame","Windows"}
+			{"XamMac","DesktopGL"}, 
 		};
+
+		string platform;
 
 		protected override BuildResult Build (MonoDevelop.Core.IProgressMonitor monitor, SolutionEntityItem item, ConfigurationSelector configuration)
 		{
@@ -46,12 +45,12 @@ namespace MonoDevelop.MonoGame
 					return base.Build (monitor, item, configuration);
 
 				var files = proj.Items.Where(x => x is ProjectFile).Cast<ProjectFile>();
-				foreach(var file in files.Where(f => f.Name.EndsWith(".mgcb"))) {
+				foreach(var file in files.Where(f => f.BuildAction == "MonoGameContentReference")) {
 					monitor.Log.WriteLine ("Found MonoGame Content Builder Response File : {0}", file.FilePath);
-					var plaform = proj.GetProjectTypes().FirstOrDefault(x => supportedProjectTypes.ContainsKey(x));
-					if (!string.IsNullOrEmpty (plaform)) {
+					platform = proj.GetProjectTypes().FirstOrDefault(x => supportedProjectTypes.ContainsKey(x));
+					if (!string.IsNullOrEmpty (platform)) {
 						try {
-							RunMonoGameContentBuilder(file.FilePath.ToString(), supportedProjectTypes[plaform], monitor);
+							RunMonoGameContentBuilder(file.FilePath.ToString(), supportedProjectTypes[platform], monitor);
 						} catch (Exception ex) {
 							monitor.ReportWarning(ex.ToString());
 						}
@@ -65,6 +64,34 @@ namespace MonoDevelop.MonoGame
 				monitor.Log.WriteLine("MonoGame Extension Build Ended");	
 				#endif				
 			}
+		}
+
+		protected override BuildResult Compile (MonoDevelop.Core.IProgressMonitor monitor, SolutionEntityItem item, BuildData buildData)
+		{
+			var proj = item as Project;
+			if (proj == null)
+				return base.Compile (monitor, item, buildData);
+			if (!proj.GetProjectTypes().Any(x => supportedProjectTypes.ContainsKey(x)))
+				return base.Compile (monitor, item, buildData);
+			var files = buildData.Items.Where(x => x is ProjectFile).Cast<ProjectFile>().ToArray();
+			foreach (var file in files.Where(f => f.BuildAction == "MonoGameContentReference")) {
+				var path = System.IO.Path.Combine (Path.GetDirectoryName (file.FilePath.ToString ()), "bin", supportedProjectTypes[platform]);
+				monitor.Log.WriteLine("Processing {0}", path);	
+				if (!Directory.Exists (path))
+					continue;
+				foreach (var output in Directory.GetFiles (path, "*.*", SearchOption.AllDirectories)) {
+					var link = string.Format ("Content{0}",  output.Replace (path, ""));
+					if (proj.Files.FirstOrDefault (x => Path.GetFileName (x.FilePath.ToString ()) == Path.GetFileName (output)) == null) {
+						monitor.Log.WriteLine ("Auto Including Content {0}", output);
+						proj.Files.Add (new ProjectFile (output, BuildAction.BundleResource) {
+							Link = new MonoDevelop.Core.FilePath (link),
+							Flags = ProjectItemFlags.DontPersist | ProjectItemFlags.Hidden,
+							Visible = false,
+						});
+					}
+				}
+			}
+			return base.Compile (monitor, item, buildData);
 		}
 
 		void RunMonoGameContentBuilder(string responseFile, string platform, MonoDevelop.Core.IProgressMonitor monitor) {
@@ -95,14 +122,14 @@ namespace MonoDevelop.MonoGame
 			process.StartInfo.WorkingDirectory = Path.GetDirectoryName (responseFile);
 			if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
 				process.StartInfo.FileName = location;
-				process.StartInfo.Arguments = string.Format ("/platform:{0} /@:\"{1}\" ", platform, responseFile);
+				process.StartInfo.Arguments = string.Format ("/@:\"{1}\" /platform:{0}", platform, responseFile);
 			} else if (Directory.Exists ("/Applications") &&
 					Directory.Exists ("/Users")) {
 				process.StartInfo.FileName = "mono";
-				process.StartInfo.Arguments = string.Format ("\"{0}\" /platform:{1} /@:\"{2}\"", location, platform, responseFile);
+				process.StartInfo.Arguments = string.Format ("\"{0}\" /@:\"{2}\" /platform:{1}", location, platform, responseFile);
 			} else {
 				process.StartInfo.FileName = location;
-				process.StartInfo.Arguments = string.Format ("/platform:{0} /@:\"{1}\" ", platform, responseFile);
+				process.StartInfo.Arguments = string.Format ("/@:\"{1}\" /platform:{0}", platform, responseFile);
 			}
 			process.StartInfo.CreateNoWindow = true;
 			process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoGameMSBuildImports.cs
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoGameMSBuildImports.cs
@@ -4,6 +4,7 @@ using System.Xml.XPath;
 using System.Linq;
 using MonoDevelop.Projects.Formats.MSBuild;
 using System.Collections.Generic;
+using MonoDevelop.Projects;
 
 namespace MonoDevelop.MonoGame
 {
@@ -11,6 +12,8 @@ namespace MonoDevelop.MonoGame
 	{
 		const string MonoGameContentBuildTargets = "$(MSBuildExtensionsPath)\\MonoGame\\v3.0\\MonoGame.Content.Builder.targets";
 		const string MonoGameCommonProps = "$(MSBuildExtensionsPath)\\MonoGame\\v3.0\\MonoGame.Common.props";
+		const string MonoGameExtensionsPath = @"$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\{0}\{1}";
+		const string MonoGameExtensionsAbsolutePath = @"/Library/Frameworks/MonoGame.framework/v3.0/Assemblies/{0}/{1}";
 
 		static bool UpgradeMonoGameProject (MonoDevelop.Core.IProgressMonitor monitor, MonoDevelop.Projects.SolutionEntityItem item, MSBuildProject project)
 		{
@@ -23,7 +26,9 @@ namespace MonoDevelop.MonoGame
 				project.PropertyGroups.Any (x => x.Properties.Any (p => p.Name == "AndroidApplication" && string.Compare (p.GetValue (), bool.TrueString, true)==0));
 			bool isShared = project.PropertyGroups.Any (x => x.Properties.Any (p => p.Name == "HasSharedItems" && p.GetValue () == "true"));
 			var type = item.GetType ().Name;
+			monitor.Log.WriteLine ("Found {0}", type);
 			var platform = Environment.OSVersion.Platform == PlatformID.Win32NT ? "Windows" : "DesktopGL";
+			var path = MonoGameExtensionsPath;
 			switch (type) {
 			case "XamarinIOSProject":
 				platform = "iOS";
@@ -31,10 +36,26 @@ namespace MonoDevelop.MonoGame
 			case "MonoDroidProject":
 				platform = "Android";
 				break;
+			case "XamMac2Project":
 			case "MonoGameProject":
 				platform = "DesktopGL";
 				break;
+			case "XamMac":
+			case "XamMacProject":
+				platform = "DesktopGL";
+				// Xamarin.Mac Classic does not use MSBuild so we need to absolute path.
+				path = MonoGameExtensionsAbsolutePath;
+				break;
+			case "MonoMac":
+			case "MonoMacProject":
+				platform = "MacOSX";
+				// Xamarin.Mac Classic does not use MSBuild so we need to absolute path.
+				path = MonoGameExtensionsAbsolutePath;
+				break;
 			}
+			monitor.Log.WriteLine ("Platform = {0}", platform);
+			monitor.Log.WriteLine ("Path = {0}", path);
+			monitor.Log.WriteLine ("isMonoGame {0}", isMonoGame);
 			if (isMonoGame) {
 				var ritems = new List<MSBuildItem> ();
 				foreach (var ig in project.ItemGroups) {
@@ -42,7 +63,36 @@ namespace MonoDevelop.MonoGame
 						if (!i.HasMetadata ("HintPath")) {
 							monitor.Log.WriteLine ("Fixing {0} to be MonoGameContentReference", i.Include);
 							var a = ig.AddNewItem ("Reference", i.Include);
-							a.SetMetadata ("HintPath", string.Format (@"$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\{0}\MonoGame.Framework.dll", platform));
+							a.SetMetadata ("HintPath", string.Format (path, platform, "MonoGame.Framework.dll"));
+							ritems.Add (i);
+							needsSave = true;
+						}
+					}
+					foreach (var i in ig.Items.Where (x => x.Name == "Reference" && x.Include == "Tao.Sdl")) {
+						if (!i.HasMetadata ("HintPath")) {
+							monitor.Log.WriteLine ("Fixing {0} to be Tao.Sdl", i.Include);
+							var a = ig.AddNewItem ("Reference", i.Include);
+							a.SetMetadata ("HintPath", string.Format (path, platform, "Tao.Sdl.dll"));
+							ritems.Add (i);
+							needsSave = true;
+						}
+					}
+					foreach (var i in ig.Items.Where (x => x.Name == "Reference" && x.Include.StartsWith ("OpenTK") &&
+							(platform != "iOS" && platform != "Android"))) {
+						if (!i.HasMetadata ("HintPath")) {
+							monitor.Log.WriteLine ("Fixing {0} to be OpenTK", i.Include);
+							var a = ig.AddNewItem ("Reference", i.Include);
+							a.SetMetadata ("HintPath", string.Format (path, platform, "OpenTK.dll"));
+							a.SetMetadata ("SpecificVersion", "true");
+							ritems.Add (i);
+							needsSave = true;
+						}
+					}
+					foreach (var i in ig.Items.Where (x => x.Name == "Reference" && x.Include == "NVorbis")) {
+						if (!i.HasMetadata ("HintPath")) {
+							monitor.Log.WriteLine ("Fixing {0} to be NVorbis", i.Include);
+							var a = ig.AddNewItem ("Reference", i.Include);
+							a.SetMetadata ("HintPath", string.Format (path, platform, "NVorbis.dll"));
 							ritems.Add (i);
 							needsSave = true;
 						}
@@ -50,6 +100,31 @@ namespace MonoDevelop.MonoGame
 				}
 				foreach (var a in ritems) {
 					project.RemoveItem (a);
+				}
+				var dotNetProject = item as DotNetProject;
+				if (dotNetProject != null && (type == "MonoMacProject" || type == "XamMacProject" )) {
+					var items = new List<ProjectReference> ();
+					var newitems = new List<ProjectReference> ();
+					foreach (var reference in dotNetProject.References) {
+						if (reference.Reference == "MonoGame.Framework" && string.IsNullOrEmpty (reference.HintPath)) {
+							items.Add (reference);
+							newitems.Add (new ProjectReference (ReferenceType.Assembly, reference.Reference, string.Format (path, platform, "MonoGame.Framework.dll")));
+						}
+						if (reference.Reference.StartsWith ("OpenTK") && string.IsNullOrEmpty (reference.HintPath)) {
+							items.Add (reference);
+							newitems.Add (new ProjectReference (ReferenceType.Assembly, reference.Reference, string.Format (path, platform, "OpenTK.dll")));
+						}
+						if (reference.Reference == "NVorbis" && string.IsNullOrEmpty (reference.HintPath)) {
+							items.Add (reference);
+							newitems.Add (new ProjectReference (ReferenceType.Assembly, reference.Reference, string.Format (path, platform, "NVorbis.dll")));
+						}
+						if (reference.Reference == "Tao.Sdl" && string.IsNullOrEmpty (reference.HintPath)) {
+							items.Add (reference);
+							newitems.Add (new ProjectReference (ReferenceType.Assembly, reference.Reference, string.Format (path, platform, "Tao.Sdl.dll")));
+						}
+					}
+					dotNetProject.References.RemoveRange (items);
+					dotNetProject.References.AddRange (newitems);
 				}
 			}
 			if (isMonoGame && containsMGCB && (isApplication || isShared)) {
@@ -97,16 +172,20 @@ namespace MonoDevelop.MonoGame
 
 		public override void LoadProject (MonoDevelop.Core.IProgressMonitor monitor, MonoDevelop.Projects.SolutionEntityItem item, MSBuildProject project)
 		{
-			
-			if (UpgradeMonoGameProject (monitor, item, project))
-				project.Save (project.FileName);
+			var changed = (UpgradeMonoGameProject (monitor, item, project));
 			base.LoadProject (monitor, item, project);
+			if (changed) {
+				project.Save (project.FileName);
+			}
 		}
 
 		public override void SaveProject (MonoDevelop.Core.IProgressMonitor monitor, MonoDevelop.Projects.SolutionEntityItem item, MSBuildProject project)
 		{
-			UpgradeMonoGameProject (monitor, item, project);
+			var changed = UpgradeMonoGameProject (monitor, item, project);
 			base.SaveProject (monitor, item, project);
+			if (changed) {
+				this.LoadProject (monitor, item, project);
+			}
 		}
 	}
 }

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/Common/Content.mgcb
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/Common/Content.mgcb
@@ -2,7 +2,6 @@
 
 /outputDir:bin/$(Platform)
 /intermediateDir:obj/$(Platform)
-/platform:Windows
 /config:
 /profile:Reach
 /compress:False

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameContentBuilderTemplate.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameContentBuilderTemplate.xpt.xml
@@ -9,6 +9,6 @@
 	</TemplateConfiguration>
 
 	<TemplateFiles>
-		<File name="${Name}.mgcb" src="Common/Content.mgcb" />
+		<File name="${Name}.mgcb" src="Common/Content.mgcb" BuildAction="MonoGameContentReference" />
 	</TemplateFiles>
 </Template>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameProject.xpt.xml
@@ -24,6 +24,8 @@
 				<Reference type="Gac" refto="System.Xml" />
 				<Reference type="Gac" refto="System.Core" />
 				<Reference type="Package" refto="MonoGame.Framework" />
+				<Reference type="Package" refto="OpenTK" />
+				<Reference type="Package" refto="NVorbis" />
 			</References>
 			<Files>
 				<File name="Game1.cs" src="Common/Game1.cs" />
@@ -34,7 +36,7 @@
 					<File name="AssemblyInfo.cs" src="Common/AssemblyInfo.cs" />
 				</Directory>
 				<Directory name="Content">
-					<File name="Content.mgcb" src="Common/Content.mgcb"/>
+					<File name="Content.mgcb" src="Common/Content.mgcb" BuildAction="MonoGameContentReference" />
 				</Directory>
 				<ContentFile>
 					<File name="OpenTK.dll.config" src="Common/OpenTK.dll.config" CopyToOutputDirectory="PreserveNewest" />

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameWindowsProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameWindowsProject.xpt.xml
@@ -33,7 +33,7 @@
 					<File name="AssemblyInfo.cs" src="Common/AssemblyInfo.cs" />
 				</Directory>
 				<Directory name="Content">
-					<File name="Content.mgcb" src="Common/Content.mgcb"/>
+					<File name="Content.mgcb" src="Common/Content.mgcb" BuildAction="MonoGameContentReference" />
 				</Directory>
 			</Files>
 		</Project>

--- a/MonoGame.Framework/TitleContainer.cs
+++ b/MonoGame.Framework/TitleContainer.cs
@@ -17,6 +17,7 @@ using Foundation;
 #endif
 #endif
 using Microsoft.Xna.Framework.Utilities;
+using MonoGame.Utilities;
 
 namespace Microsoft.Xna.Framework
 {
@@ -25,6 +26,13 @@ namespace Microsoft.Xna.Framework
         static TitleContainer() 
         {
 #if WINDOWS || DESKTOPGL
+#if DESKTOPGL
+            // Check for the package Resources Folder first. This is where the assets
+            // will be bundled.
+            if (CurrentPlatform.OS == OS.MacOSX)
+                Location = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "..", "Resources");
+            if (!Directory.Exists (Location))
+#endif
             Location = AppDomain.CurrentDomain.BaseDirectory;
 #elif WINRT
             Location = Windows.ApplicationModel.Package.Current.InstalledLocation.Path;


### PR DESCRIPTION
This PR fixes a few issues

1. Corrects ALL the .mgcb files in the XS templates to have the correct BuildAction of MonoGameContentReference

2. Upgraded XamMac, Xamarin.Mac to use DeskopGL as it seems a better fit and works!

3. Upgraded the MonoMac + XamMac build to auto include the outputs of the Content compilation
   this will mean users no longer have to link those files manually.
   We had to do it this way because neither of those project types use MSBuild.

4. Alters the Title Container for DesktopGL so that on MacOS it will first look for the ../Resources directory (which is where BundleResource items should be) before falling back to the root directory where the app is.

5. Changes to the Reference HintPath Fixup code to make sure that for MonoMac and XamMac absolute paths are used and specific versions of OpenTK are used.

6. Fixed the MonoMac template to NOT use Nuget just like the others this is a side effect of point 5.

@mrhelmut @KonajuGames This works well on my machine could use some additional testing though. Note this should only really effect new projects.