### PR TITLE
Revert "Fix mouse coordinate for DesktopGL and windowed mode"

### DIFF
--- a/MonoGame.Framework/Input/Mouse.cs
+++ b/MonoGame.Framework/Input/Mouse.cs
@@ -140,9 +140,9 @@ namespace Microsoft.Xna.Framework.Input
 #elif DESKTOPGL || ANGLE
 
             var state = OpenTK.Input.Mouse.GetCursorState();
-            
-            window.MouseState.X = state.X;
-            window.MouseState.Y = state.Y;
+            var pc = ((OpenTKGameWindow)window).Window.PointToClient(new System.Drawing.Point(state.X, state.Y));
+            window.MouseState.X = pc.X;
+            window.MouseState.Y = pc.Y;
 
             window.MouseState.LeftButton = (ButtonState)state.LeftButton;
             window.MouseState.RightButton = (ButtonState)state.RightButton;


### PR DESCRIPTION
Reverts mono/MonoGame#4501

Side note, we should also get OpenTK updated, now MonoGame/opentk needs https://github.com/TD25/opentk/commit/e5ab1ae791ef07750971bc8a88e250c50cace268 from opentk/opentk.