### PR TITLE
[DesktopGL] Fixed getting mouse position

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -80,6 +80,8 @@ using Microsoft.Xna.Framework.Input;
 using OpenTK;
 using OpenTK.Graphics;
 
+using MonoGame.Utilities;
+
 namespace Microsoft.Xna.Framework
 {
     class OpenTKGamePlatform : GamePlatform
@@ -95,6 +97,9 @@ namespace Microsoft.Xna.Framework
 		public OpenTKGamePlatform(Game game)
             : base(game)
         {
+            if (CurrentPlatform.OS == OS.Linux)
+                Toolkit.Init(new ToolkitOptions { Backend = PlatformBackend.PreferNative });
+
             _view = new OpenTKGameWindow(game);
             this.Window = _view;
 

--- a/MonoGame.Framework/Input/Mouse.cs
+++ b/MonoGame.Framework/Input/Mouse.cs
@@ -140,9 +140,10 @@ namespace Microsoft.Xna.Framework.Input
 #elif DESKTOPGL || ANGLE
 
             var state = OpenTK.Input.Mouse.GetCursorState();
+            var clientBounds = window.ClientBounds;
             
-            window.MouseState.X = state.X;
-            window.MouseState.Y = state.Y;
+            window.MouseState.X = state.X - clientBounds.X;
+            window.MouseState.Y = state.Y - clientBounds.Y;
 
             window.MouseState.LeftButton = (ButtonState)state.LeftButton;
             window.MouseState.RightButton = (ButtonState)state.RightButton;


### PR DESCRIPTION
On Linux we must make sure we are not using SDL because there is a bug with SDL on getting client bounds, it's been fixed in their develop release, but it's not in stable.

CC. @KonajuGames 