### PR TITLE
Mouse coords in OpenTK again.

### DIFF
--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// The preferred backend for OpenTK to use.
         /// </summary>
-        public static Backend PreferredBackend = Backend.Default;
+        public static Backend PreferredBackend = MonoGame.Utilities.CurrentPlatform.OS == OS.Linux ? Backend.Native : Backend.Default;
     }
 
     class OpenTKGamePlatform : GamePlatform

--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -84,6 +84,33 @@ using MonoGame.Utilities;
 
 namespace Microsoft.Xna.Framework
 {
+    /// <summary>
+    /// The backend options for OpenTK.
+    /// </summary>
+    public enum Backend
+    {
+        /// <summary>
+        /// Use the default backend for the current OS. If SDL2 is found, it will be used.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Use the native backend. SDL2 is not considered.
+        /// </summary>
+        Native
+    }
+
+    /// <summary>
+    /// Parameters that are used in configuring the platform.
+    /// </summary>
+    public static class PlatformParameters
+    {
+        /// <summary>
+        /// The preferred backend for OpenTK to use.
+        /// </summary>
+        public static Backend PreferredBackend = Backend.Default;
+    }
+
     class OpenTKGamePlatform : GamePlatform
     {
         private OpenTKGameWindow _view;
@@ -97,7 +124,7 @@ namespace Microsoft.Xna.Framework
 		public OpenTKGamePlatform(Game game)
             : base(game)
         {
-            if (CurrentPlatform.OS == OS.Linux)
+            if (PlatformParameters.PreferredBackend != Backend.Default)
                 Toolkit.Init(new ToolkitOptions { Backend = PlatformBackend.PreferNative });
 
             _view = new OpenTKGameWindow(game);

--- a/MonoGame.Framework/Input/Mouse.cs
+++ b/MonoGame.Framework/Input/Mouse.cs
@@ -141,19 +141,9 @@ namespace Microsoft.Xna.Framework.Input
 
             var state = OpenTK.Input.Mouse.GetCursorState();
 
-            // SDL2 backend doesn't support mouse coordinates outside the window, but GetCursorState uses the window client top/left as the origin.
-            // Native backend does support mouse coordinates outside the window, but GetCursorState uses the screen top/left as the origin.
-            if (OpenTK.Configuration.RunningOnSdl2)
-            {
-                window.MouseState.X = state.X;
-                window.MouseState.Y = state.Y;
-            }
-            else
-            {
-                var clientBounds = window.ClientBounds;
-                window.MouseState.X = state.X - clientBounds.X;
-                window.MouseState.Y = state.Y - clientBounds.Y;
-            }
+            var clientBounds = window.ClientBounds;
+            window.MouseState.X = state.X - clientBounds.X;
+            window.MouseState.Y = state.Y - clientBounds.Y;
 
             window.MouseState.LeftButton = (ButtonState)state.LeftButton;
             window.MouseState.RightButton = (ButtonState)state.RightButton;

--- a/MonoGame.Framework/Input/Mouse.cs
+++ b/MonoGame.Framework/Input/Mouse.cs
@@ -140,10 +140,20 @@ namespace Microsoft.Xna.Framework.Input
 #elif DESKTOPGL || ANGLE
 
             var state = OpenTK.Input.Mouse.GetCursorState();
-            var clientBounds = window.ClientBounds;
-            
-            window.MouseState.X = state.X - clientBounds.X;
-            window.MouseState.Y = state.Y - clientBounds.Y;
+
+            // SDL2 backend doesn't support mouse coordinates outside the window, but GetCursorState uses the window client top/left as the origin.
+            // Native backend does support mouse coordinates outside the window, but GetCursorState uses the screen top/left as the origin.
+            if (OpenTK.Configuration.RunningOnSdl2)
+            {
+                window.MouseState.X = state.X;
+                window.MouseState.Y = state.Y;
+            }
+            else
+            {
+                var clientBounds = window.ClientBounds;
+                window.MouseState.X = state.X - clientBounds.X;
+                window.MouseState.Y = state.Y - clientBounds.Y;
+            }
 
             window.MouseState.LeftButton = (ButtonState)state.LeftButton;
             window.MouseState.RightButton = (ButtonState)state.RightButton;


### PR DESCRIPTION
Do not do the client bounds offset if SDL2 is being used.
Added PlatformParameters to DesktopGL platforms where the preferred OpenTK backend can be specified.  Must be set prior to construction of the Game object.

Ref: #4631