### PR TITLE
Enable the "Save" button after a new item is added to a project, so t…

### DIFF
--- a/Tools/Pipeline/Windows/MainView.cs
+++ b/Tools/Pipeline/Windows/MainView.cs
@@ -858,6 +858,11 @@ namespace MonoGame.Tools.Pipeline
 
                 // Ensure name is unique among files at this location?
                 _controller.NewItem(dlg.NameGiven, location, template);
+
+                if (_controller.ProjectDirty)
+                {
+                    _toolSave.Enabled = true;
+                }
             }
         }
 

--- a/Tools/Pipeline/Windows/MainView.cs
+++ b/Tools/Pipeline/Windows/MainView.cs
@@ -859,10 +859,7 @@ namespace MonoGame.Tools.Pipeline
                 // Ensure name is unique among files at this location?
                 _controller.NewItem(dlg.NameGiven, location, template);
 
-                if (_controller.ProjectDirty)
-                {
-                    _toolSave.Enabled = true;
-                }
+                UpdateMenus();
             }
         }
 


### PR DESCRIPTION
…hat the user knows that the project needs to be saved [due to the newly-added item].

This should fix Issue #4624.

One problem is that the Save button isn't disabled after it's clicked, but I think that was an already-existing issue. To explain further:
* Add -> New Item
* Fill out details
* Save button is now enabled
* Click Save button
* Save button is not disabled, where it should be at this point, I think

Anyhow, that's probably a problem for a separate Issue.