### PR TITLE
Fixed Window.ClientBounds crashing on secondary thread

### DIFF
--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -93,9 +93,9 @@ namespace MonoGame.Framework
         {
             get
             {
+                var clientRectangle = _form.ClientRectangle;
                 var position = _form.PointToScreen(Point.Empty);
-                var size = _form.ClientSize;
-                return new Rectangle(position.X, position.Y, size.Width, size.Height);
+                return new Rectangle(position.X, position.Y, clientRectangle.Width, clientRectangle.Height);
             }
         }
 


### PR DESCRIPTION
See issue #4654.
Fixes commit e74c7e5.

Cross thread operations accessing the Window.ClientBounds property caused an InvalidOperationException.