### PR TITLE
Fix XAudio PlatformSetPan sound quality degradation

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffectInstance.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.XAudio.cs
@@ -141,6 +141,10 @@ namespace Microsoft.Xna.Framework.Audio
             var srcChannelCount = _effect._format.Channels;
             var dstChannelCount = SoundEffect.MasterVoice.VoiceDetails.InputChannelCount;
 
+            // Do no panning if destination is mono
+            if (dstChannelCount < 2)
+                return;
+
             if (_panMatrix == null || _panMatrix.Length < dstChannelCount)
                 _panMatrix = new float[srcChannelCount * dstChannelCount];
 
@@ -183,9 +187,18 @@ namespace Microsoft.Xna.Framework.Audio
 
             // For now, only the front channels are routed,
             // as handling all the possible combinations of channel counts is out of scope of this fix.
-
-            _panMatrix[0] = lVal;
-            _panMatrix[srcChannelCount + 1] = rVal;
+            
+            if (srcChannelCount == 1)
+            {
+                // For mono sources, send a copy of the channel to front-right
+                _panMatrix[0] = lVal;
+                _panMatrix[srcChannelCount] = rVal;
+            }
+            else
+            {
+                _panMatrix[0] = lVal;
+                _panMatrix[srcChannelCount + 1] = rVal;
+            }
 
             _voice.SetOutputMatrix(srcChannelCount, dstChannelCount, _panMatrix);
         }

--- a/MonoGame.Framework/Audio/SoundEffectInstance.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.XAudio.cs
@@ -142,11 +142,11 @@ namespace Microsoft.Xna.Framework.Audio
             var dstChannelCount = SoundEffect.MasterVoice.VoiceDetails.InputChannelCount;
 
             if (_panMatrix == null || _panMatrix.Length < dstChannelCount)
-                _panMatrix = new float[Math.Max(dstChannelCount, 8)];
+                _panMatrix = new float[srcChannelCount * dstChannelCount];
 
-            // Default to full volume for all channels/destinations   
+            // Default to zero volume for all channels/destinations   
             for (var i = 0; i < _panMatrix.Length; i++)
-                _panMatrix[i] = 1.0f;
+                _panMatrix[i] = 0.0f;
 
             // From X3DAudio documentation:
             /*
@@ -175,45 +175,17 @@ namespace Microsoft.Xna.Framework.Audio
             //
             // Assuming it is correct to pan all channels which have a left/right component.
 
-            var lVal = 1.0f - _pan;
-            var rVal = 1.0f + _pan;
+            // This implements the so-called equal-power panning,
+            // dropping the volume at center so that it stays consistent across the range.
 
-            switch (SoundEffect.Speakers)
-            {
-                case Speakers.Stereo:
-                case Speakers.TwoPointOne:
-                case Speakers.Surround:
-                    _panMatrix[0] = lVal;
-                    _panMatrix[1] = rVal;
-                    break;
+            var lVal = (float)Math.Sin((1 - _pan) * MathHelper.PiOver4);
+            var rVal = (float)Math.Sin((1 + _pan) * MathHelper.PiOver4);
 
-                case Speakers.Quad:
-                    _panMatrix[0] = _panMatrix[2] = lVal;
-                    _panMatrix[1] = _panMatrix[3] = rVal;
-                    break;
+            // For now, only the front channels are routed,
+            // as handling all the possible combinations of channel counts is out of scope of this fix.
 
-                case Speakers.FourPointOne:
-                    _panMatrix[0] = _panMatrix[3] = lVal;
-                    _panMatrix[1] = _panMatrix[4] = rVal;
-                    break;
-
-                case Speakers.FivePointOne:
-                case Speakers.SevenPointOne:
-                case Speakers.FivePointOneSurround:
-                    _panMatrix[0] = _panMatrix[4] = lVal;
-                    _panMatrix[1] = _panMatrix[5] = rVal;
-                    break;
-
-                case Speakers.SevenPointOneSurround:
-                    _panMatrix[0] = _panMatrix[4] = _panMatrix[6] = lVal;
-                    _panMatrix[1] = _panMatrix[5] = _panMatrix[7] = rVal;
-                    break;
-
-                case Speakers.Mono:
-                default:
-                    // don't do any panning here   
-                    break;
-            }
+            _panMatrix[0] = lVal;
+            _panMatrix[srcChannelCount + 1] = rVal;
 
             _voice.SetOutputMatrix(srcChannelCount, dstChannelCount, _panMatrix);
         }

--- a/MonoGame.Framework/Audio/SoundEffectInstance.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.cs
@@ -156,6 +156,11 @@ namespace Microsoft.Xna.Framework.Audio
             if (!_isXAct)
                 PlatformSetVolume(_volume * SoundEffect.MasterVolume);
 
+            // Call PlatformSetPan once to avoid abrupt volume changes when setting Pan,
+            // due to the implications of equal-power panning.
+
+            PlatformSetPan(_pan);
+
             PlatformPlay();
         }
 


### PR DESCRIPTION
This should fix #4648, eliminating the distortion and making panning work.

More work should be done on handling surround source / destinations (e.g. up-mixing stereo to 5.1 and vise-versa), but that is out of the scope of this fix, which is aimed at sound distortion. For now, only the front channels are routed, and the rest are silenced.