### PR TITLE
Fix Gamepad crash when platform doesn't support the amount

### DIFF
--- a/MonoGame.Framework/Input/GamePad.cs
+++ b/MonoGame.Framework/Input/GamePad.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Xna.Framework.Input
         public static GamePadCapabilities GetCapabilities(int index)
         {
             if (index < 0 || index >= PlatformGetMaxNumberOfGamePads())
-                throw new InvalidOperationException();
+                return new GamePadCapabilities();
 
             return PlatformGetCapabilities(index);
         }
@@ -76,7 +76,7 @@ namespace Microsoft.Xna.Framework.Input
         public static GamePadState GetState(int index, GamePadDeadZone deadZoneMode)
         {
             if (index < 0 || index >= PlatformGetMaxNumberOfGamePads())
-                throw new InvalidOperationException();
+                return GamePadState.Default;
             
             return PlatformGetState(index, deadZoneMode);
         }
@@ -103,7 +103,7 @@ namespace Microsoft.Xna.Framework.Input
         public static bool SetVibration(int index, float leftMotor, float rightMotor)
         {
             if (index < 0 || index >= PlatformGetMaxNumberOfGamePads())
-                throw new InvalidOperationException();
+                return false;
             
             return PlatformSetVibration(index, MathHelper.Clamp(leftMotor, 0.0f, 1.0f), MathHelper.Clamp(rightMotor, 0.0f, 1.0f));
         }


### PR DESCRIPTION
Instead of throwing an exception we should just return an empty state, this also makes the style of this more XNAish.

http://community.monogame.net/t/monogame-3-5-gamepad-getstate/7288