### PR TITLE
Fixing and cleaning AL source management

### DIFF
--- a/MonoGame.Framework/Android/AndroidGamePlatform.cs
+++ b/MonoGame.Framework/Android/AndroidGamePlatform.cs
@@ -11,8 +11,6 @@ namespace Microsoft.Xna.Framework
 {
     class AndroidGamePlatform : GamePlatform
     {
-        OpenALSoundController soundControllerInstance = null;
-
         public AndroidGamePlatform(Game game)
             : base(game)
         {
@@ -27,7 +25,7 @@ namespace Microsoft.Xna.Framework
             MediaLibrary.Context = Game.Activity;
             try
             {
-                soundControllerInstance = OpenALSoundController.GetInstance;
+                OpenALSoundController soundControllerInstance = OpenALSoundController.GetInstance;
             }
             catch (DllNotFoundException ex)
             {

--- a/MonoGame.Framework/Audio/OALSoundBuffer.cs
+++ b/MonoGame.Framework/Audio/OALSoundBuffer.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Xna.Framework.Audio
                 alError = AL.GetError();
                 if (alError != ALError.NoError)
                 {
-                    Console.WriteLine("Failed to get buffer bits: {0}, format={1}, size={2}, sampleRate={3}", AL.GetErrorString(alError), format, size, sampleRate);
+                    Console.WriteLine("Failed to get buffer channels: {0}, format={1}, size={2}, sampleRate={3}", AL.GetErrorString(alError), format, size, sampleRate);
                     Duration = -1;
                 }
                 else

--- a/MonoGame.Framework/Audio/OggStream.cs
+++ b/MonoGame.Framework/Audio/OggStream.cs
@@ -405,10 +405,8 @@ namespace Microsoft.Xna.Framework.Audio
         public bool FillBuffer(OggStream stream, int bufferId)
         {
             int readSamples;
-            long readerPosition = 0;
             lock (readMutex)
             {
-                readerPosition = stream.Reader.DecodedPosition;
                 readSamples = stream.Reader.ReadSamples(readSampleBuffer, 0, BufferSize);
                 CastBuffer(readSampleBuffer, castBuffer, readSamples);
             }

--- a/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.OpenAL.cs
@@ -143,8 +143,9 @@ namespace Microsoft.Xna.Framework.Audio
 			AL.Source (SourceId, ALSourcef.Pitch, XnaPitchToAlPitch(_pitch));
             ALHelper.CheckError("Failed to set source pitch.");
 
-            controller.PlaySound (this);
-            //Console.WriteLine ("playing: " + sourceId + " : " + soundEffect.Name);
+            AL.SourcePlay(SourceId);
+            ALHelper.CheckError("Failed to play source.");
+
             SoundState = SoundState.Playing;
         }
 
@@ -176,9 +177,6 @@ namespace Microsoft.Xna.Framework.Audio
         {
             if (HasSourceId)
             {
-                //Console.WriteLine ("stop " + sourceId + " : " + soundEffect.Name);
-                
-
                 if (!controller.CheckInitState())
                 {
                     return;

--- a/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstancePool.cs
@@ -97,10 +97,6 @@ namespace Microsoft.Xna.Framework.Audio
         /// </summary>
         internal static void Update()
         {
-#if OPENAL
-            OpenALSoundController.GetInstance.Update();
-#endif
-
             SoundEffectInstance inst = null;
             // Cleanup instances which have finished playing.                    
             for (var x = 0; x < _playingInstances.Count;)
@@ -109,6 +105,9 @@ namespace Microsoft.Xna.Framework.Audio
 
                 if (inst.State == SoundState.Stopped || inst.IsDisposed || inst._effect == null)
                 {
+#if OPENAL
+                    inst.Stop(true); // force stopping it to free its AL source
+#endif
                     Add(inst);
                     continue;
                 }

--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -207,9 +207,6 @@ namespace Microsoft.Xna.Framework
         {
             IsActive = _view.Window.Focused;
 
-            // Update our OpenAL sound buffer pools
-            if (soundControllerInstance != null)
-                soundControllerInstance.Update();
             return true;
         }
 

--- a/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
+++ b/MonoGame.Framework/Desktop/OpenTKGamePlatform.cs
@@ -114,7 +114,6 @@ namespace Microsoft.Xna.Framework
     class OpenTKGamePlatform : GamePlatform
     {
         private OpenTKGameWindow _view;
-		private OpenALSoundController soundControllerInstance = null;
         // stored the current screen state, so we can check if it has changed.
         private bool isCurrentlyFullScreen = false;
         private int isExiting; // int, so we can use Interlocked.Increment
@@ -133,7 +132,7 @@ namespace Microsoft.Xna.Framework
 			// Setup our OpenALSoundController to handle our SoundBuffer pools
             try
             {
-                soundControllerInstance = OpenALSoundController.GetInstance;
+                OpenALSoundController soundControllerInstance = OpenALSoundController.GetInstance;
             }
             catch (DllNotFoundException ex)
             {

--- a/MonoGame.Framework/MacOS/MacGamePlatform.cs
+++ b/MonoGame.Framework/MacOS/MacGamePlatform.cs
@@ -103,7 +103,6 @@ namespace Microsoft.Xna.Framework
         private MacGameNSWindow _mainWindow;
         private GameWindow _gameWindow;
         private bool _wasResizeable;
-        private OpenALSoundController soundControllerInstance = null;
 
         public MacGamePlatform(Game game) :
             base(game)
@@ -112,7 +111,14 @@ namespace Microsoft.Xna.Framework
             game.Services.AddService(typeof(MacGamePlatform), this);
 
             // Setup our OpenALSoundController to handle our SoundBuffer pools
-            soundControllerInstance = OpenALSoundController.GetInstance;
+            try
+            {
+                OpenALSoundController soundControllerInstance = OpenALSoundController.GetInstance;
+            }
+            catch (DllNotFoundException ex)
+            {
+                throw (new NoAudioHardwareException("Failed to init OpenALSoundController", ex));
+            }
 
             InitializeMainWindow();
 
@@ -265,8 +271,6 @@ namespace Microsoft.Xna.Framework
 
         public override bool BeforeUpdate(GameTime gameTime)
         {
-            // Update our OpenAL sound buffer pools
-            soundControllerInstance.Update();
             if (_needsToResetElapsedTime)
                 _needsToResetElapsedTime = false;
 

--- a/MonoGame.Framework/Windows8/MetroGamePlatform.cs
+++ b/MonoGame.Framework/Windows8/MetroGamePlatform.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Xna.Framework
 {
     class MetroGamePlatform : GamePlatform
     {
-		//private OpenALSoundController soundControllerInstance = null;
         internal static string LaunchParameters;
 
         internal static readonly TouchQueue TouchQueue = new TouchQueue();

--- a/MonoGame.Framework/WindowsUniversal/UAPGamePlatform.cs
+++ b/MonoGame.Framework/WindowsUniversal/UAPGamePlatform.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Xna.Framework
 {
     class UAPGamePlatform : GamePlatform
     {
-		//private OpenALSoundController soundControllerInstance = null;
         internal static string LaunchParameters;
 
         internal static readonly TouchQueue TouchQueue = new TouchQueue();

--- a/MonoGame.Framework/iOS/iOSGamePlatform.cs
+++ b/MonoGame.Framework/iOS/iOSGamePlatform.cs
@@ -89,7 +89,6 @@ namespace Microsoft.Xna.Framework
         private iOSGameViewController _viewController;
         private UIWindow _mainWindow;
         private List<NSObject> _applicationObservers;
-		private OpenALSoundController soundControllerInstance = null;
         private CADisplayLink _displayLink;
 
         public iOSGamePlatform(Game game) :
@@ -98,7 +97,14 @@ namespace Microsoft.Xna.Framework
             game.Services.AddService(typeof(iOSGamePlatform), this);
 			
 			// Setup our OpenALSoundController to handle our SoundBuffer pools
-			soundControllerInstance = OpenALSoundController.GetInstance;
+            try
+            {
+                OpenALSoundController soundControllerInstance = OpenALSoundController.GetInstance;
+            }
+            catch (DllNotFoundException ex)
+            {
+                throw (new NoAudioHardwareException("Failed to init OpenALSoundController", ex));
+            }
 
             //This also runs the TitleContainer static constructor, ensuring it is done on the main thread
             Directory.SetCurrentDirectory(TitleContainer.Location);
@@ -244,9 +250,6 @@ namespace Microsoft.Xna.Framework
 
         public override bool BeforeDraw(GameTime gameTime)
         {
-    		// Update our OpenAL sound buffer pools
-    		soundControllerInstance.Update();
-
             if (IsPlayingVideo)
                 return false;
 


### PR DESCRIPTION
Fixes #4672 
Fixes #4660

This PR fixes an issue where a ```SoundEffectInstance``` could share its AL source with another ```SoundEffectInstance``` or even ```Song```. It was happening because ```OpenALSoundController``` was not thread-safe and because AL sources were not recycled soon enough by the pool once an instance stopped playing (and sometime not recycled at all).

It also simplifies ```OpenALSoundController``` (removed ```Update()``` and ```PlaySound()```) which was doing pretty much the same work as ```SoundEffectInstancePool.Update()```.

@iodiot Could you give it a test to see if it also fixes #4686 ?

@cra0zy @dellis1972 @KonajuGames Could you test it on your respective systems? I could only test on Windows & OS X.