### PR TITLE
Packed vector tests and fixes

### DIFF
--- a/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 		private static byte Pack(float alpha)
 		{
-			return (byte) (
+			return (byte) Math.Round(
 				MathHelper.Clamp(alpha, 0, 1) * 255.0f
 			);
 		}

--- a/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
@@ -6,123 +6,123 @@ using System;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
-	/// <summary>
-	/// Packed vector type containing a single 8 bit normalized W values that is ranging from 0 to 1.
-	/// </summary>
-	public struct Alpha8 : IPackedVector<byte>, IEquatable<Alpha8>, IPackedVector
+    /// <summary>
+    /// Packed vector type containing a single 8 bit normalized W values that is ranging from 0 to 1.
+    /// </summary>
+    public struct Alpha8 : IPackedVector<byte>, IEquatable<Alpha8>, IPackedVector
     {
         private byte packedValue;
 
-		/// <summary>
-		/// Gets and sets the packed value.
-		/// </summary>
-		[CLSCompliant(false)]
-		public byte PackedValue
-		{
-			get
-			{
-				return packedValue;
-			}
-			set
-			{
-				packedValue = value;
-			}
-		}
+        /// <summary>
+        /// Gets and sets the packed value.
+        /// </summary>
+        [CLSCompliant(false)]
+        public byte PackedValue
+        {
+            get
+            {
+                return packedValue;
+            }
+            set
+            {
+                packedValue = value;
+            }
+        }
 
-		/// <summary>
-		/// Creates a new instance of Alpha8.
-		/// </summary>
-		/// <param name="alpha">The alpha component</param>
-		public Alpha8(float alpha)
-		{
-			packedValue = Pack(alpha);
-		}
+        /// <summary>
+        /// Creates a new instance of Alpha8.
+        /// </summary>
+        /// <param name="alpha">The alpha component</param>
+        public Alpha8(float alpha)
+        {
+            packedValue = Pack(alpha);
+        }
 
-		/// <summary>
-		/// Gets the packed vector in float format.
-		/// </summary>
-		/// <returns>The packed vector in Vector3 format</returns>
-		public float ToAlpha()
-		{
-			return (float) (packedValue / 255.0f);
-		}
+        /// <summary>
+        /// Gets the packed vector in float format.
+        /// </summary>
+        /// <returns>The packed vector in Vector3 format</returns>
+        public float ToAlpha()
+        {
+            return (float) (packedValue / 255.0f);
+        }
 
-		/// <summary>
-		/// Sets the packed vector from a Vector4.
-		/// </summary>
-		/// <param name="vector">Vector containing the components.</param>
-		void IPackedVector.PackFromVector4(Vector4 vector)
-		{
-			packedValue = Pack(vector.W);
-		}
+        /// <summary>
+        /// Sets the packed vector from a Vector4.
+        /// </summary>
+        /// <param name="vector">Vector containing the components.</param>
+        void IPackedVector.PackFromVector4(Vector4 vector)
+        {
+            packedValue = Pack(vector.W);
+        }
 
-		/// <summary>
-		/// Gets the packed vector in Vector4 format.
-		/// </summary>
-		/// <returns>The packed vector in Vector4 format</returns>
-		Vector4 IPackedVector.ToVector4()
-		{
-			return new Vector4(
-				0.0f,
-				0.0f,
-				0.0f,
-				(float) (packedValue / 255.0f)
-			);
-		}
+        /// <summary>
+        /// Gets the packed vector in Vector4 format.
+        /// </summary>
+        /// <returns>The packed vector in Vector4 format</returns>
+        Vector4 IPackedVector.ToVector4()
+        {
+            return new Vector4(
+                0.0f,
+                0.0f,
+                0.0f,
+                (float) (packedValue / 255.0f)
+            );
+        }
 
-		/// <summary>
-		/// Compares an object with the packed vector.
-		/// </summary>
-		/// <param name="obj">The object to compare.</param>
-		/// <returns>True if the object is equal to the packed vector.</returns>
-		public override bool Equals(object obj)
-		{
-			return (obj is Alpha8) && Equals((Alpha8) obj);
-		}
+        /// <summary>
+        /// Compares an object with the packed vector.
+        /// </summary>
+        /// <param name="obj">The object to compare.</param>
+        /// <returns>True if the object is equal to the packed vector.</returns>
+        public override bool Equals(object obj)
+        {
+            return (obj is Alpha8) && Equals((Alpha8) obj);
+        }
 
-		/// <summary>
-		/// Compares another Alpha8 packed vector with the packed vector.
-		/// </summary>
+        /// <summary>
+        /// Compares another Alpha8 packed vector with the packed vector.
+        /// </summary>
         /// <param name="other">The Alpha8 packed vector to compare.</param>
-		/// <returns>True if the packed vectors are equal.</returns>
-		public bool Equals(Alpha8 other)
-		{
-			return packedValue == other.packedValue;
-		}
+        /// <returns>True if the packed vectors are equal.</returns>
+        public bool Equals(Alpha8 other)
+        {
+            return packedValue == other.packedValue;
+        }
 
-		/// <summary>
-		/// Gets a string representation of the packed vector.
-		/// </summary>
-		/// <returns>A string representation of the packed vector.</returns>
-		public override string ToString()
-		{
-			return (packedValue / 255.0f).ToString();
-		}
+        /// <summary>
+        /// Gets a string representation of the packed vector.
+        /// </summary>
+        /// <returns>A string representation of the packed vector.</returns>
+        public override string ToString()
+        {
+            return (packedValue / 255.0f).ToString();
+        }
 
-		/// <summary>
-		/// Gets a hash code of the packed vector.
-		/// </summary>
-		/// <returns>The hash code for the packed vector.</returns>
-		public override int GetHashCode()
-		{
-			return packedValue.GetHashCode();
-		}
+        /// <summary>
+        /// Gets a hash code of the packed vector.
+        /// </summary>
+        /// <returns>The hash code for the packed vector.</returns>
+        public override int GetHashCode()
+        {
+            return packedValue.GetHashCode();
+        }
 
-		public static bool operator ==(Alpha8 lhs, Alpha8 rhs)
-		{
-			return lhs.packedValue == rhs.packedValue;
-		}
+        public static bool operator ==(Alpha8 lhs, Alpha8 rhs)
+        {
+            return lhs.packedValue == rhs.packedValue;
+        }
 
-		public static bool operator !=(Alpha8 lhs, Alpha8 rhs)
-		{
-			return lhs.packedValue != rhs.packedValue;
-		}
+        public static bool operator !=(Alpha8 lhs, Alpha8 rhs)
+        {
+            return lhs.packedValue != rhs.packedValue;
+        }
 
-		private static byte Pack(float alpha)
-		{
-			return (byte) Math.Round(
-				MathHelper.Clamp(alpha, 0, 1) * 255.0f
-			);
-		}
-	}
+        private static byte Pack(float alpha)
+        {
+            return (byte) Math.Round(
+                MathHelper.Clamp(alpha, 0, 1) * 255.0f
+            );
+        }
+    }
 }

--- a/MonoGame.Framework/Graphics/PackedVector/Bgr565.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgr565.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
         private static UInt16 Pack(float x, float y, float z)
         {
-            return (UInt16)((((int)(MathHelper.Clamp(x, 0, 1) * 31.0f) & 0x1F) << 11) |
-                (((int)(MathHelper.Clamp(y, 0, 1) * 63.0f) & 0x3F) << 5) |
-                ((int)(MathHelper.Clamp(z, 0, 1) * 31.0f) & 0x1F));
+            return (UInt16) ((((int) Math.Round(MathHelper.Clamp(x, 0, 1) * 31.0f) & 0x1F) << 11) |
+                (((int) Math.Round(MathHelper.Clamp(y, 0, 1) * 63.0f) & 0x3F) << 5) |
+                ((int) Math.Round(MathHelper.Clamp(z, 0, 1) * 31.0f) & 0x1F));
         }
 
         /// <summary>

--- a/MonoGame.Framework/Graphics/PackedVector/Bgra4444.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgra4444.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
         private static UInt16 Pack(float x, float y, float z, float w)
         {
-            return (UInt16)((((int)(MathHelper.Clamp(w, 0, 1) * 15.0f) & 0x0F) << 12) |
-                (((int)(MathHelper.Clamp(x, 0, 1) * 15.0f) & 0x0F) << 8) |
-                (((int)(MathHelper.Clamp(y, 0, 1) * 15.0f) & 0x0F) << 4) |
-                ((int)(MathHelper.Clamp(z, 0, 1) * 15.0f) & 0x0F));            
+            return (UInt16) ((((int) Math.Round(MathHelper.Clamp(w, 0, 1) * 15.0f) & 0x0F) << 12) |
+                (((int) Math.Round(MathHelper.Clamp(x, 0, 1) * 15.0f) & 0x0F) << 8) |
+                (((int) Math.Round(MathHelper.Clamp(y, 0, 1) * 15.0f) & 0x0F) << 4) |
+                ((int) Math.Round(MathHelper.Clamp(z, 0, 1) * 15.0f) & 0x0F));
         }
 
         /// <summary>

--- a/MonoGame.Framework/Graphics/PackedVector/Bgra5551.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgra5551.cs
@@ -6,132 +6,132 @@ using System;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
-	/// <summary>
-	/// Packed vector type containing unsigned normalized values ranging from 0 to 1. 
-	/// The x , y and z components use 5 bits, and the w component uses 1 bit.
-	/// </summary>
-	public struct Bgra5551 : IPackedVector<UInt16>, IEquatable<Bgra5551>, IPackedVector
-	{
-		/// <summary>
-		/// Gets and sets the packed value.
-		/// </summary>
-		[CLSCompliant(false)]
-		public UInt16 PackedValue
-		{
-			get
-			{
-				return packedValue;
-			}
-			set
-			{
-				packedValue = value;
-			}
-		}
+    /// <summary>
+    /// Packed vector type containing unsigned normalized values ranging from 0 to 1.
+    /// The x , y and z components use 5 bits, and the w component uses 1 bit.
+    /// </summary>
+    public struct Bgra5551 : IPackedVector<UInt16>, IEquatable<Bgra5551>, IPackedVector
+    {
+        /// <summary>
+        /// Gets and sets the packed value.
+        /// </summary>
+        [CLSCompliant(false)]
+        public UInt16 PackedValue
+        {
+            get
+            {
+                return packedValue;
+            }
+            set
+            {
+                packedValue = value;
+            }
+        }
 
-		private UInt16 packedValue;
+        private UInt16 packedValue;
 
-		/// <summary>
-		/// Creates a new instance of Bgra5551.
-		/// </summary>
-		/// <param name="x">The x component</param>
-		/// <param name="y">The y component</param>
-		/// <param name="z">The z component</param>
-		/// <param name="w">The w component</param>
-		public Bgra5551(float x, float y, float z, float w)
-		{
-			packedValue = Pack(x, y, z, w);
-		}
+        /// <summary>
+        /// Creates a new instance of Bgra5551.
+        /// </summary>
+        /// <param name="x">The x component</param>
+        /// <param name="y">The y component</param>
+        /// <param name="z">The z component</param>
+        /// <param name="w">The w component</param>
+        public Bgra5551(float x, float y, float z, float w)
+        {
+            packedValue = Pack(x, y, z, w);
+        }
 
-		/// <summary>
-		/// Creates a new instance of Bgra5551.
-		/// </summary>
-		/// <param name="vector">
-		/// Vector containing the components for the packed vector.
-		/// </param>
-		public Bgra5551(Vector4 vector)
-		{
-			packedValue = Pack(vector.X, vector.Y, vector.Z, vector.W);
-		}
+        /// <summary>
+        /// Creates a new instance of Bgra5551.
+        /// </summary>
+        /// <param name="vector">
+        /// Vector containing the components for the packed vector.
+        /// </param>
+        public Bgra5551(Vector4 vector)
+        {
+            packedValue = Pack(vector.X, vector.Y, vector.Z, vector.W);
+        }
 
-		/// <summary>
-		/// Gets the packed vector in Vector4 format.
-		/// </summary>
-		/// <returns>The packed vector in Vector4 format</returns>
-		public Vector4 ToVector4()
-		{
-			return new Vector4(
-				(float) (((packedValue >> 11) & 0x1F) / 31.0f),
-				(float) (((packedValue >> 6) & 0x1F) / 31.0f),
-				(float) (((packedValue >> 1) & 0x1F) / 31.0f),
-				(float) (packedValue & 0x01)
-			);
-		}
+        /// <summary>
+        /// Gets the packed vector in Vector4 format.
+        /// </summary>
+        /// <returns>The packed vector in Vector4 format</returns>
+        public Vector4 ToVector4()
+        {
+            return new Vector4(
+                (float) (((packedValue >> 10) & 0x1F) / 31.0f),
+                (float) (((packedValue >> 5) & 0x1F) / 31.0f),
+                (float) (((packedValue >> 0) & 0x1F) / 31.0f),
+                (float) ((packedValue >> 15)& 0x01)
+            );
+        }
 
-		/// <summary>
-		/// Sets the packed vector from a Vector4.
-		/// </summary>
-		/// <param name="vector">Vector containing the components.</param>
-		void IPackedVector.PackFromVector4(Vector4 vector)
-		{
-			packedValue = Pack(vector.X, vector.Y, vector.Z, vector.W);
-		}
+        /// <summary>
+        /// Sets the packed vector from a Vector4.
+        /// </summary>
+        /// <param name="vector">Vector containing the components.</param>
+        void IPackedVector.PackFromVector4(Vector4 vector)
+        {
+            packedValue = Pack(vector.X, vector.Y, vector.Z, vector.W);
+        }
 
-		/// <summary>
-		/// Compares an object with the packed vector.
-		/// </summary>
-		/// <param name="obj">The object to compare.</param>
-		/// <returns>True if the object is equal to the packed vector.</returns>
-		public override bool Equals(object obj)
-		{
-			return (obj is Bgra5551) && Equals((Bgra5551) obj);
-		}
+        /// <summary>
+        /// Compares an object with the packed vector.
+        /// </summary>
+        /// <param name="obj">The object to compare.</param>
+        /// <returns>True if the object is equal to the packed vector.</returns>
+        public override bool Equals(object obj)
+        {
+            return (obj is Bgra5551) && Equals((Bgra5551) obj);
+        }
 
-		/// <summary>
-		/// Compares another Bgra5551 packed vector with the packed vector.
-		/// </summary>
-		/// <param name="other">The Bgra5551 packed vector to compare.</param>
-		/// <returns>True if the packed vectors are equal.</returns>
-		public bool Equals(Bgra5551 other)
-		{
-			return packedValue == other.packedValue;
-		}
+        /// <summary>
+        /// Compares another Bgra5551 packed vector with the packed vector.
+        /// </summary>
+        /// <param name="other">The Bgra5551 packed vector to compare.</param>
+        /// <returns>True if the packed vectors are equal.</returns>
+        public bool Equals(Bgra5551 other)
+        {
+            return packedValue == other.packedValue;
+        }
 
-		/// <summary>
-		/// Gets a string representation of the packed vector.
-		/// </summary>
-		/// <returns>A string representation of the packed vector.</returns>
-		public override string ToString()
-		{
-			return ToVector4().ToString();
-		}
+        /// <summary>
+        /// Gets a string representation of the packed vector.
+        /// </summary>
+        /// <returns>A string representation of the packed vector.</returns>
+        public override string ToString()
+        {
+            return ToVector4().ToString();
+        }
 
-		/// <summary>
-		/// Gets a hash code of the packed vector.
-		/// </summary>
-		/// <returns>The hash code for the packed vector.</returns>
-		public override int GetHashCode()
-		{
-			return packedValue.GetHashCode();
-		}
+        /// <summary>
+        /// Gets a hash code of the packed vector.
+        /// </summary>
+        /// <returns>The hash code for the packed vector.</returns>
+        public override int GetHashCode()
+        {
+            return packedValue.GetHashCode();
+        }
 
-		public static bool operator ==(Bgra5551 lhs, Bgra5551 rhs)
-		{
-			return lhs.packedValue == rhs.packedValue;
-		}
+        public static bool operator ==(Bgra5551 lhs, Bgra5551 rhs)
+        {
+            return lhs.packedValue == rhs.packedValue;
+        }
 
-		public static bool operator !=(Bgra5551 lhs, Bgra5551 rhs)
-		{
-			return lhs.packedValue != rhs.packedValue;
-		}
+        public static bool operator !=(Bgra5551 lhs, Bgra5551 rhs)
+        {
+            return lhs.packedValue != rhs.packedValue;
+        }
 
-		private static UInt16 Pack(float x, float y, float z, float w)
-		{
-			return (UInt16) (
-				(((int) (MathHelper.Clamp(x, 0, 1) * 31.0f) & 0x1F) << 11) |
-				(((int) (MathHelper.Clamp(y, 0, 1) * 31.0f) & 0x1F) << 6) |
-				(((int) (MathHelper.Clamp(z, 0, 1) * 31.0f) & 0x1F) << 1) |
-				((int) (MathHelper.Clamp(w, 0, 1)))
-			);
-		}
-	}
+        private static UInt16 Pack(float x, float y, float z, float w)
+        {
+            return (UInt16) (
+                (((int) Math.Round(MathHelper.Clamp(x, 0, 1) * 31.0f) & 0x1F) << 10) |
+                (((int) Math.Round(MathHelper.Clamp(y, 0, 1) * 31.0f) & 0x1F) << 5) |
+                (((int) Math.Round(MathHelper.Clamp(z, 0, 1) * 31.0f) & 0x1F) << 0) |
+                ((((int) Math.Round(MathHelper.Clamp(w, 0, 1)) & 0x1) << 15))
+            );
+        }
+    }
 }

--- a/MonoGame.Framework/Graphics/PackedVector/Byte4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Byte4.cs
@@ -125,10 +125,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             const float min = 0.0f;
 
             // clamp the value between min and max values
-            var byte4 = (uint)MathHelper.Clamp(vector.X, min, max) & 0xFF;
-            var byte3 = ((uint)MathHelper.Clamp(vector.Y, min, max) & 0xFF) << 0x8;
-            var byte2 = ((uint)MathHelper.Clamp(vector.Z, min, max) & 0xFF) << 0x10;
-            var byte1 = ((uint)MathHelper.Clamp(vector.W, min, max) & 0xFF) << 0x18;
+            var byte4 = (uint) Math.Round(MathHelper.Clamp(vector.X, min, max)) & 0xFF;
+            var byte3 = ((uint) Math.Round(MathHelper.Clamp(vector.Y, min, max)) & 0xFF) << 0x8;
+            var byte2 = ((uint) Math.Round(MathHelper.Clamp(vector.Z, min, max)) & 0xFF) << 0x10;
+            var byte1 = ((uint) Math.Round(MathHelper.Clamp(vector.W, min, max)) & 0xFF) << 0x18;
 
             return byte4 | byte3 | byte2 | byte1;
         }

--- a/MonoGame.Framework/Graphics/PackedVector/HalfSingle.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfSingle.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             set
             {
                 _packed = value;
-            } 
+            }
         }
 
         public override bool Equals(object obj)
@@ -62,8 +62,8 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
         private static ushort Pack(float x, float y)
         {
-            var byte2 = (((ushort)(MathHelper.Clamp(x, -1.0f, 1.0f) * 127.0f)) << 0) & 0x00FF;
-            var byte1 = (((ushort)(MathHelper.Clamp(y, -1.0f, 1.0f) * 127.0f)) << 8) & 0xFF00;
+            var byte2 = (((ushort) Math.Round(MathHelper.Clamp(x, -1.0f, 1.0f) * 127.0f)) & 0xFF) << 0;
+            var byte1 = (((ushort) Math.Round(MathHelper.Clamp(y, -1.0f, 1.0f) * 127.0f)) & 0xFF) << 8;
 
             return (ushort)(byte2 | byte1);
         }
@@ -77,12 +77,12 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         {
             return new Vector4(ToVector2(), 0.0f, 1.0f);
         }
-    
+
         public Vector2 ToVector2()
         {
             return new Vector2(
-                ((sbyte)(_packed & 0xFF)) / 127.0f,
-                ((sbyte)((_packed >> 8) & 0xFF)) / 127.0f);
+                ((sbyte) ((_packed >> 0) & 0xFF)) / 127.0f,
+                ((sbyte) ((_packed >> 8) & 0xFF)) / 127.0f);
         }
     }
 }

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
@@ -1,3 +1,8 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+
 using System;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
@@ -36,12 +36,12 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             set
             {
                 _packed = value;
-            } 
+            }
         }
 
         public override bool Equals(object obj)
         {
-            return  (obj is NormalizedByte4) && 
+            return  (obj is NormalizedByte4) &&
                     ((NormalizedByte4)obj)._packed == _packed;
         }
 
@@ -62,10 +62,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
         private static uint Pack(float x, float y, float z, float w)
         {
-            var byte4 = (((uint)(MathHelper.Clamp(x, -1.0f, 1.0f) * 127.0f)) << 0)  & 0x000000FF;
-            var byte3 = (((uint)(MathHelper.Clamp(y, -1.0f, 1.0f) * 127.0f)) << 8)  & 0x0000FF00;
-            var byte2 = (((uint)(MathHelper.Clamp(z, -1.0f, 1.0f) * 127.0f)) << 16) & 0x00FF0000;
-            var byte1 = (((uint)(MathHelper.Clamp(w, -1.0f, 1.0f) * 127.0f)) << 24) & 0xFF000000;
+            var byte4 = (((uint) Math.Round(MathHelper.Clamp(x, -1.0f, 1.0f) * 127.0f)) & 0xff) << 0;
+            var byte3 = (((uint) Math.Round(MathHelper.Clamp(y, -1.0f, 1.0f) * 127.0f)) & 0xff) << 8;
+            var byte2 = (((uint) Math.Round(MathHelper.Clamp(z, -1.0f, 1.0f) * 127.0f)) & 0xff) << 16;
+            var byte1 = (((uint) Math.Round(MathHelper.Clamp(w, -1.0f, 1.0f) * 127.0f)) & 0xff) << 24;
 
             return byte4 | byte3 | byte2 | byte1;
         }
@@ -78,10 +78,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         public Vector4 ToVector4()
         {
             return new Vector4(
-                ((sbyte)(_packed & 0xFF)) / 127.0f,
-                ((sbyte)((_packed >> 8) & 0xFF)) / 127.0f,
-                ((sbyte)((_packed >> 16) & 0xFF)) / 127.0f,
-                ((sbyte)((_packed >> 24) & 0xFF)) / 127.0f);
+                ((sbyte) ((_packed >> 24) & 0xFF)) / 127.0f,
+                ((sbyte) ((_packed >> 16) & 0xFF)) / 127.0f,
+                ((sbyte) ((_packed >> 8) & 0xFF)) / 127.0f,
+                ((sbyte) ((_packed >> 0) & 0xFF)) / 127.0f);
         }
     }
 }

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte4.cs
@@ -1,3 +1,8 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+
 using System;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedShort2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedShort2.cs
@@ -2,34 +2,34 @@
 // /*
 // Microsoft Public License (Ms-PL)
 // MonoGame - Copyright © 2009 The MonoGame Team
-// 
+//
 // All rights reserved.
-// 
+//
 // This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
 // accept the license, do not use the software.
-// 
+//
 // 1. Definitions
-// The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
+// The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under
 // U.S. copyright law.
-// 
+//
 // A "contribution" is the original software, or any additions or changes to the software.
 // A "contributor" is any person that distributes its contribution under this license.
 // "Licensed patents" are a contributor's patent claims that read directly on its contribution.
-// 
+//
 // 2. Grant of Rights
-// (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+// (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3,
 // each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-// (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+// (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3,
 // each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-// 
+//
 // 3. Conditions and Limitations
 // (A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-// (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
+// (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software,
 // your patent license from such contributor to the software ends automatically.
-// (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
+// (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution
 // notices that are present in the software.
-// (D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
-// a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
+// (D) If you distribute any portion of the software in source code form, you may do so only under this license by including
+// a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object
 // code form, you may only do so under a license that complies with this license.
 // (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
 // or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
@@ -78,7 +78,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             set
             {
                 short2Packed = value;
-            } 
+            }
 		}
 
 		public override bool Equals (object obj)

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedShort2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedShort2.cs
@@ -1,44 +1,7 @@
-// #region License
-// /*
-// Microsoft Public License (Ms-PL)
-// MonoGame - Copyright © 2009 The MonoGame Team
-//
-// All rights reserved.
-//
-// This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
-// accept the license, do not use the software.
-//
-// 1. Definitions
-// The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under
-// U.S. copyright law.
-//
-// A "contribution" is the original software, or any additions or changes to the software.
-// A "contributor" is any person that distributes its contribution under this license.
-// "Licensed patents" are a contributor's patent claims that read directly on its contribution.
-//
-// 2. Grant of Rights
-// (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3,
-// each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-// (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3,
-// each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-//
-// 3. Conditions and Limitations
-// (A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-// (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software,
-// your patent license from such contributor to the software ends automatically.
-// (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution
-// notices that are present in the software.
-// (D) If you distribute any portion of the software in source code form, you may do so only under this license by including
-// a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object
-// code form, you may only do so under a license that complies with this license.
-// (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
-// or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
-// permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
-// purpose and non-infringement.
-// */
-// #endregion License
-//
-// Author: Kenneth James Pouncey
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
 
 using System;
 

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedShort4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedShort4.cs
@@ -1,44 +1,7 @@
-// #region License
-// /*
-// Microsoft Public License (Ms-PL)
-// MonoGame - Copyright © 2009 The MonoGame Team
-// 
-// All rights reserved.
-// 
-// This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
-// accept the license, do not use the software.
-// 
-// 1. Definitions
-// The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
-// U.S. copyright law.
-// 
-// A "contribution" is the original software, or any additions or changes to the software.
-// A "contributor" is any person that distributes its contribution under this license.
-// "Licensed patents" are a contributor's patent claims that read directly on its contribution.
-// 
-// 2. Grant of Rights
-// (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-// each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-// (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-// each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-// 
-// 3. Conditions and Limitations
-// (A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-// (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
-// your patent license from such contributor to the software ends automatically.
-// (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
-// notices that are present in the software.
-// (D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
-// a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
-// code form, you may only do so under a license that complies with this license.
-// (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
-// or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
-// permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
-// purpose and non-infringement.
-// */
-// #endregion License
-//
-// Author: Kenneth James Pouncey
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
 
 using System;
 
@@ -78,7 +41,7 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
             set
             {
                 short4Packed = value;
-            } 
+            }
 		}
 
         public override bool Equals(object obj)

--- a/MonoGame.Framework/Graphics/PackedVector/Rg32.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rg32.cs
@@ -6,134 +6,134 @@ using System;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
-	/// <summary>
-	/// Packed vector type containing two 16-bit unsigned normalized values ranging from 0 to 1.
-	/// </summary>
-	public struct Rg32 : IPackedVector<uint>, IEquatable<Rg32>, IPackedVector
-	{
-		/// <summary>
-		/// Gets and sets the packed value.
-		/// </summary>
-		[CLSCompliant(false)]
-		public uint PackedValue
-		{
-			get
-			{
-				return packedValue;
-			}
-			set
-			{
-				packedValue = value;
-			}
-		}
+    /// <summary>
+    /// Packed vector type containing two 16-bit unsigned normalized values ranging from 0 to 1.
+    /// </summary>
+    public struct Rg32 : IPackedVector<uint>, IEquatable<Rg32>, IPackedVector
+    {
+        /// <summary>
+        /// Gets and sets the packed value.
+        /// </summary>
+        [CLSCompliant(false)]
+        public uint PackedValue
+        {
+            get
+            {
+                return packedValue;
+            }
+            set
+            {
+                packedValue = value;
+            }
+        }
 
-		private uint packedValue;
+        private uint packedValue;
 
-		/// <summary>
-		/// Creates a new instance of Rg32.
-		/// </summary>
-		/// <param name="x">The x component</param>
-		/// <param name="y">The y component</param>
-		public Rg32(float x, float y)
-		{
-			packedValue = Pack(x, y);
-		}
+        /// <summary>
+        /// Creates a new instance of Rg32.
+        /// </summary>
+        /// <param name="x">The x component</param>
+        /// <param name="y">The y component</param>
+        public Rg32(float x, float y)
+        {
+            packedValue = Pack(x, y);
+        }
 
-		/// <summary>
-		/// Creates a new instance of Rg32.
-		/// </summary>
-		/// <param name="vector">
-		/// Vector containing the components for the packed vector.
-		/// </param>
-		public Rg32(Vector2 vector)
-		{
-			packedValue = Pack(vector.X, vector.Y);
-		}
+        /// <summary>
+        /// Creates a new instance of Rg32.
+        /// </summary>
+        /// <param name="vector">
+        /// Vector containing the components for the packed vector.
+        /// </param>
+        public Rg32(Vector2 vector)
+        {
+            packedValue = Pack(vector.X, vector.Y);
+        }
 
-		/// <summary>
-		/// Gets the packed vector in Vector2 format.
-		/// </summary>
-		/// <returns>The packed vector in Vector2 format</returns>
-		public Vector2 ToVector2()
-		{
-			return new Vector2(
-				(float) (((packedValue >> 16) & 0xFFFF) / 65535.0f),
-				(float) ((packedValue & 0xFFFF) / 65535.0f)
-			);
-		}
+        /// <summary>
+        /// Gets the packed vector in Vector2 format.
+        /// </summary>
+        /// <returns>The packed vector in Vector2 format</returns>
+        public Vector2 ToVector2()
+        {
+            return new Vector2(
+                (float) (((packedValue >> 16) & 0xFFFF) / 65535.0f),
+                (float) ((packedValue & 0xFFFF) / 65535.0f)
+            );
+        }
 
-		/// <summary>
-		/// Sets the packed vector from a Vector4.
-		/// </summary>
-		/// <param name="vector">Vector containing the components.</param>
-		void IPackedVector.PackFromVector4(Vector4 vector)
-		{
-			packedValue = Pack(vector.X, vector.Y);
-		}
+        /// <summary>
+        /// Sets the packed vector from a Vector4.
+        /// </summary>
+        /// <param name="vector">Vector containing the components.</param>
+        void IPackedVector.PackFromVector4(Vector4 vector)
+        {
+            packedValue = Pack(vector.X, vector.Y);
+        }
 
-		/// <summary>
-		/// Gets the packed vector in Vector4 format.
-		/// </summary>
-		/// <returns>The packed vector in Vector4 format</returns>
-		Vector4 IPackedVector.ToVector4()
-		{
-			return new Vector4(ToVector2(), 0.0f, 1.0f);
-		}
+        /// <summary>
+        /// Gets the packed vector in Vector4 format.
+        /// </summary>
+        /// <returns>The packed vector in Vector4 format</returns>
+        Vector4 IPackedVector.ToVector4()
+        {
+            return new Vector4(ToVector2(), 0.0f, 1.0f);
+        }
 
-		/// <summary>
-		/// Compares an object with the packed vector.
-		/// </summary>
-		/// <param name="obj">The object to compare.</param>
-		/// <returns>True if the object is equal to the packed vector.</returns>
-		public override bool Equals(object obj)
-		{
-			return (obj is Rg32) && Equals((Rg32) obj);
-		}
+        /// <summary>
+        /// Compares an object with the packed vector.
+        /// </summary>
+        /// <param name="obj">The object to compare.</param>
+        /// <returns>True if the object is equal to the packed vector.</returns>
+        public override bool Equals(object obj)
+        {
+            return (obj is Rg32) && Equals((Rg32) obj);
+        }
 
-		/// <summary>
-		/// Compares another Rg32 packed vector with the packed vector.
-		/// </summary>
-		/// <param name="other">The Rg32 packed vector to compare.</param>
-		/// <returns>True if the packed vectors are equal.</returns>
-		public bool Equals(Rg32 other)
-		{
-			return packedValue == other.packedValue;
-		}
+        /// <summary>
+        /// Compares another Rg32 packed vector with the packed vector.
+        /// </summary>
+        /// <param name="other">The Rg32 packed vector to compare.</param>
+        /// <returns>True if the packed vectors are equal.</returns>
+        public bool Equals(Rg32 other)
+        {
+            return packedValue == other.packedValue;
+        }
 
-		/// <summary>
-		/// Gets a string representation of the packed vector.
-		/// </summary>
-		/// <returns>A string representation of the packed vector.</returns>
-		public override string ToString()
-		{
-			return ToVector2().ToString();
-		}
+        /// <summary>
+        /// Gets a string representation of the packed vector.
+        /// </summary>
+        /// <returns>A string representation of the packed vector.</returns>
+        public override string ToString()
+        {
+            return ToVector2().ToString();
+        }
 
-		/// <summary>
-		/// Gets a hash code of the packed vector.
-		/// </summary>
-		/// <returns>The hash code for the packed vector.</returns>
-		public override int GetHashCode()
-		{
-			return packedValue.GetHashCode();
-		}
+        /// <summary>
+        /// Gets a hash code of the packed vector.
+        /// </summary>
+        /// <returns>The hash code for the packed vector.</returns>
+        public override int GetHashCode()
+        {
+            return packedValue.GetHashCode();
+        }
 
-		public static bool operator ==(Rg32 lhs, Rg32 rhs)
-		{
-			return lhs.packedValue == rhs.packedValue;
-		}
+        public static bool operator ==(Rg32 lhs, Rg32 rhs)
+        {
+            return lhs.packedValue == rhs.packedValue;
+        }
 
-		public static bool operator !=(Rg32 lhs, Rg32 rhs)
-		{
-			return lhs.packedValue != rhs.packedValue;
-		}
+        public static bool operator !=(Rg32 lhs, Rg32 rhs)
+        {
+            return lhs.packedValue != rhs.packedValue;
+        }
 
-		private static uint Pack(float x, float y)
-		{
-			return (uint) (
-				(((int) (MathHelper.Clamp(x, 0, 1) * 65535.0f) & 0xFFFF) << 16) |
-				((int) (MathHelper.Clamp(y, 0, 1) * 65535.0f) & 0xFFFF)
-			);
-		}
-	}
+        private static uint Pack(float x, float y)
+        {
+            return (uint) (
+                (((int) Math.Round(MathHelper.Clamp(x, 0, 1) * 65535.0f) & 0xFFFF) ) |
+                (((int) Math.Round(MathHelper.Clamp(y, 0, 1) * 65535.0f) & 0xFFFF) << 16)
+            );
+        }
+    }
 }

--- a/MonoGame.Framework/Graphics/PackedVector/Rgba1010102.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rgba1010102.cs
@@ -6,132 +6,132 @@ using System;
 
 namespace Microsoft.Xna.Framework.Graphics.PackedVector
 {
-	/// <summary>
-	/// Packed vector type containing unsigned normalized values ranging from 0 to 1. 
-	/// The x, y and z components use 10 bits, and the w component uses 2 bits.
-	/// </summary>
-	public struct Rgba1010102 : IPackedVector<uint>, IEquatable<Rgba1010102>, IPackedVector
-	{
-		/// <summary>
-		/// Gets and sets the packed value.
-		/// </summary>
-		[CLSCompliant(false)]
-		public uint PackedValue
-		{
-			get
-			{
-				return packedValue;
-			}
-			set
-			{
-				packedValue = value;
-			}
-		}
+    /// <summary>
+    /// Packed vector type containing unsigned normalized values ranging from 0 to 1.
+    /// The x, y and z components use 10 bits, and the w component uses 2 bits.
+    /// </summary>
+    public struct Rgba1010102 : IPackedVector<uint>, IEquatable<Rgba1010102>, IPackedVector
+    {
+        /// <summary>
+        /// Gets and sets the packed value.
+        /// </summary>
+        [CLSCompliant(false)]
+        public uint PackedValue
+        {
+            get
+            {
+                return packedValue;
+            }
+            set
+            {
+                packedValue = value;
+            }
+        }
 
-		private uint packedValue;
+        private uint packedValue;
 
-		/// <summary>
-		/// Creates a new instance of Rgba1010102.
-		/// </summary>
-		/// <param name="x">The x component</param>
-		/// <param name="y">The y component</param>
-		/// <param name="z">The z component</param>
-		/// <param name="w">The w component</param>
-		public Rgba1010102(float x, float y, float z, float w)
-		{
-			packedValue = Pack(x, y, z, w);
-		}
+        /// <summary>
+        /// Creates a new instance of Rgba1010102.
+        /// </summary>
+        /// <param name="x">The x component</param>
+        /// <param name="y">The y component</param>
+        /// <param name="z">The z component</param>
+        /// <param name="w">The w component</param>
+        public Rgba1010102(float x, float y, float z, float w)
+        {
+            packedValue = Pack(x, y, z, w);
+        }
 
-		/// <summary>
-		/// Creates a new instance of Rgba1010102.
-		/// </summary>
-		/// <param name="vector">
-		/// Vector containing the components for the packed vector.
-		/// </param>
-		public Rgba1010102(Vector4 vector)
-		{
-			packedValue = Pack(vector.X, vector.Y, vector.Z, vector.W);
-		}
+        /// <summary>
+        /// Creates a new instance of Rgba1010102.
+        /// </summary>
+        /// <param name="vector">
+        /// Vector containing the components for the packed vector.
+        /// </param>
+        public Rgba1010102(Vector4 vector)
+        {
+            packedValue = Pack(vector.X, vector.Y, vector.Z, vector.W);
+        }
 
-		/// <summary>
-		/// Gets the packed vector in Vector4 format.
-		/// </summary>
-		/// <returns>The packed vector in Vector4 format</returns>
-		public Vector4 ToVector4()
-		{
-			return new Vector4(
-				(float) (((packedValue >> 22) & 0x03FF) / 1023.0f),
-				(float) (((packedValue >> 12) & 0x03FF) / 1023.0f),
-				(float) (((packedValue >> 2) & 0x03FF) / 1023.0f),
-				(float) ((packedValue & 0x03) / 3.0f)
-			);
-		}
+        /// <summary>
+        /// Gets the packed vector in Vector4 format.
+        /// </summary>
+        /// <returns>The packed vector in Vector4 format</returns>
+        public Vector4 ToVector4()
+        {
+            return new Vector4(
+                (float) (((packedValue >> 0) & 0x03FF) / 1023.0f),
+                (float) (((packedValue >> 10) & 0x03FF) / 1023.0f),
+                (float) (((packedValue >> 20) & 0x03FF) / 1023.0f),
+                (float) (((packedValue >> 30) & 0x03) / 3.0f)
+            );
+        }
 
-		/// <summary>
-		/// Sets the packed vector from a Vector4.
-		/// </summary>
-		/// <param name="vector">Vector containing the components.</param>
-		void IPackedVector.PackFromVector4(Vector4 vector)
-		{
-			packedValue = Pack(vector.X, vector.Y, vector.Z, vector.W);
-		}
+        /// <summary>
+        /// Sets the packed vector from a Vector4.
+        /// </summary>
+        /// <param name="vector">Vector containing the components.</param>
+        void IPackedVector.PackFromVector4(Vector4 vector)
+        {
+            packedValue = Pack(vector.X, vector.Y, vector.Z, vector.W);
+        }
 
-		/// <summary>
-		/// Compares an object with the packed vector.
-		/// </summary>
-		/// <param name="obj">The object to compare.</param>
-		/// <returns>True if the object is equal to the packed vector.</returns>
-		public override bool Equals(object obj)
-		{
-			return (obj is Rgba1010102) && Equals((Rgba1010102) obj);
-		}
+        /// <summary>
+        /// Compares an object with the packed vector.
+        /// </summary>
+        /// <param name="obj">The object to compare.</param>
+        /// <returns>True if the object is equal to the packed vector.</returns>
+        public override bool Equals(object obj)
+        {
+            return (obj is Rgba1010102) && Equals((Rgba1010102) obj);
+        }
 
-		/// <summary>
-		/// Compares another Rgba1010102 packed vector with the packed vector.
-		/// </summary>
-		/// <param name="other">The Rgba1010102 packed vector to compare.</param>
-		/// <returns>True if the packed vectors are equal.</returns>
-		public bool Equals(Rgba1010102 other)
-		{
-			return packedValue == other.packedValue;
-		}
+        /// <summary>
+        /// Compares another Rgba1010102 packed vector with the packed vector.
+        /// </summary>
+        /// <param name="other">The Rgba1010102 packed vector to compare.</param>
+        /// <returns>True if the packed vectors are equal.</returns>
+        public bool Equals(Rgba1010102 other)
+        {
+            return packedValue == other.packedValue;
+        }
 
-		/// <summary>
-		/// Gets a string representation of the packed vector.
-		/// </summary>
-		/// <returns>A string representation of the packed vector.</returns>
-		public override string ToString()
-		{
-			return ToVector4().ToString();
-		}
+        /// <summary>
+        /// Gets a string representation of the packed vector.
+        /// </summary>
+        /// <returns>A string representation of the packed vector.</returns>
+        public override string ToString()
+        {
+            return ToVector4().ToString();
+        }
 
-		/// <summary>
-		/// Gets a hash code of the packed vector.
-		/// </summary>
-		/// <returns>The hash code for the packed vector.</returns>
-		public override int GetHashCode()
-		{
-			return packedValue.GetHashCode();
-		}
+        /// <summary>
+        /// Gets a hash code of the packed vector.
+        /// </summary>
+        /// <returns>The hash code for the packed vector.</returns>
+        public override int GetHashCode()
+        {
+            return packedValue.GetHashCode();
+        }
 
-		public static bool operator ==(Rgba1010102 lhs, Rgba1010102 rhs)
-		{
-			return lhs.packedValue == rhs.packedValue;
-		}
+        public static bool operator ==(Rgba1010102 lhs, Rgba1010102 rhs)
+        {
+            return lhs.packedValue == rhs.packedValue;
+        }
 
-		public static bool operator !=(Rgba1010102 lhs, Rgba1010102 rhs)
-		{
-			return lhs.packedValue != rhs.packedValue;
-		}
+        public static bool operator !=(Rgba1010102 lhs, Rgba1010102 rhs)
+        {
+            return lhs.packedValue != rhs.packedValue;
+        }
 
-		private static uint Pack(float x, float y, float z, float w)
-		{
-			return (uint) (
-				(((int) (MathHelper.Clamp(x, 0, 1) * 1023.0f) & 0x03FF) << 22) |
-				(((int) (MathHelper.Clamp(y, 0, 1) * 1023.0f) & 0x03FF) << 12) |
-				(((int) (MathHelper.Clamp(z, 0, 1) * 1023.0f) & 0x03FF) << 2) |
-				((int) (MathHelper.Clamp(w, 0, 1) * 3.0f) & 0x03)
-			);
-		}
-	}
+        private static uint Pack(float x, float y, float z, float w)
+        {
+            return (uint) (
+                (((int) Math.Round(MathHelper.Clamp(x, 0, 1) * 1023.0f) & 0x03FF) << 0) |
+                (((int) Math.Round(MathHelper.Clamp(y, 0, 1) * 1023.0f) & 0x03FF) << 10) |
+                (((int) Math.Round(MathHelper.Clamp(z, 0, 1) * 1023.0f) & 0x03FF) << 20) |
+                (((int) Math.Round(MathHelper.Clamp(w, 0, 1) * 3.0f) & 0x03) << 30)
+            );
+        }
+    }
 }

--- a/MonoGame.Framework/Graphics/PackedVector/Rgba64.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rgba64.cs
@@ -126,10 +126,10 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 		private static ulong Pack(float x, float y, float z, float w)
 		{
 			return (ulong) (
-				(((ulong) (MathHelper.Clamp(x, 0, 1) * 65535.0f) ) ) |
-				(((ulong) (MathHelper.Clamp(y, 0, 1) * 65535.0f) ) << 16) |
-				(((ulong) (MathHelper.Clamp(z, 0, 1) * 65535.0f) ) << 32) |
-                (((ulong) (MathHelper.Clamp(w, 0, 1) * 65535.0f) ) << 48)
+				(((ulong) Math.Round(MathHelper.Clamp(x, 0, 1) * 65535.0f) ) ) |
+				(((ulong) Math.Round(MathHelper.Clamp(y, 0, 1) * 65535.0f) ) << 16) |
+				(((ulong) Math.Round(MathHelper.Clamp(z, 0, 1) * 65535.0f) ) << 32) |
+                (((ulong) Math.Round(MathHelper.Clamp(w, 0, 1) * 65535.0f) ) << 48)
             );
 		}
 	}

--- a/MonoGame.Framework/Graphics/PackedVector/Short2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Short2.cs
@@ -2,34 +2,34 @@
 // /*
 // Microsoft Public License (Ms-PL)
 // MonoGame - Copyright © 2009 The MonoGame Team
-// 
+//
 // All rights reserved.
-// 
+//
 // This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
 // accept the license, do not use the software.
-// 
+//
 // 1. Definitions
-// The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
+// The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under
 // U.S. copyright law.
-// 
+//
 // A "contribution" is the original software, or any additions or changes to the software.
 // A "contributor" is any person that distributes its contribution under this license.
 // "Licensed patents" are a contributor's patent claims that read directly on its contribution.
-// 
+//
 // 2. Grant of Rights
-// (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+// (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3,
 // each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-// (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
+// (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3,
 // each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-// 
+//
 // 3. Conditions and Limitations
 // (A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-// (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
+// (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software,
 // your patent license from such contributor to the software ends automatically.
-// (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
+// (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution
 // notices that are present in the software.
-// (D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
-// a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
+// (D) If you distribute any portion of the software in source code form, you may do so only under this license by including
+// a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object
 // code form, you may only do so under a license that complies with this license.
 // (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
 // or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
@@ -70,15 +70,15 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
         [CLSCompliant(false)]
 		public uint PackedValue
-        { 
+        {
 			get
-            { 
-				return _short2Packed; 
-			} 
+            {
+				return _short2Packed;
+			}
 			set
-            { 
-				_short2Packed = value; 
-			} 
+            {
+				_short2Packed = value;
+			}
 		}
 
 		public override bool Equals (object obj)
@@ -113,14 +113,14 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 		private static uint PackInTwo (float vectorX, float vectorY)
 		{
-			const float maxPos = 0x7FFF; // Largest two byte positive number 0xFFFF >> 1; 
+			const float maxPos = 0x7FFF; // Largest two byte positive number 0xFFFF >> 1;
 			const float minNeg = ~(int)maxPos; // two's complement
 
-			// clamp the value between min and max values
-			var word2 = (uint)((int)Math.Max (Math.Min (vectorX, maxPos), minNeg) & 0xFFFF);
-			var word1 = (uint)(((int)Math.Max (Math.Min (vectorY, maxPos), minNeg) & 0xFFFF) << 0x10);
+            // clamp the value between min and max values
+            var word2 = ((uint) Math.Round(MathHelper.Clamp(vectorX, minNeg, maxPos)) & 0xFFFF);
+            var word1 = (((uint) Math.Round(MathHelper.Clamp(vectorY, minNeg, maxPos)) & 0xFFFF) << 0x10);
 
-			return (word2 | word1);
+            return (word2 | word1);
 		}
 
 		void IPackedVector.PackFromVector4 (Vector4 vector)

--- a/MonoGame.Framework/Graphics/PackedVector/Short2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Short2.cs
@@ -1,44 +1,7 @@
-// #region License
-// /*
-// Microsoft Public License (Ms-PL)
-// MonoGame - Copyright © 2009 The MonoGame Team
-//
-// All rights reserved.
-//
-// This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
-// accept the license, do not use the software.
-//
-// 1. Definitions
-// The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under
-// U.S. copyright law.
-//
-// A "contribution" is the original software, or any additions or changes to the software.
-// A "contributor" is any person that distributes its contribution under this license.
-// "Licensed patents" are a contributor's patent claims that read directly on its contribution.
-//
-// 2. Grant of Rights
-// (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3,
-// each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-// (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3,
-// each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-//
-// 3. Conditions and Limitations
-// (A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-// (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software,
-// your patent license from such contributor to the software ends automatically.
-// (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution
-// notices that are present in the software.
-// (D) If you distribute any portion of the software in source code form, you may do so only under this license by including
-// a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object
-// code form, you may only do so under a license that complies with this license.
-// (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
-// or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
-// permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
-// purpose and non-infringement.
-// */
-// #endregion License
-//
-// Author: Kenneth James Pouncey
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
 
 using System;
 

--- a/MonoGame.Framework/Graphics/PackedVector/Short4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Short4.cs
@@ -121,14 +121,14 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         /// <returns>The ulong containing the packed values.</returns>
         static ulong Pack(ref Vector4 vector)
         {
-            const float maxPos = 0x7FFF; // Largest two byte positive number 0xFFFF >> 1; 
+            const float maxPos = 0x7FFF; // Largest two byte positive number 0xFFFF >> 1;
             const float minNeg = ~(int)maxPos; // two's complement
 
             // clamp the value between min and max values
-            var word4 = ((ulong)MathHelper.Clamp(vector.X, minNeg, maxPos) & 0xFFFF) << 0x00;
-            var word3 = ((ulong)MathHelper.Clamp(vector.Y, minNeg, maxPos) & 0xFFFF) << 0x10;
-            var word2 = ((ulong)MathHelper.Clamp(vector.Z, minNeg, maxPos) & 0xFFFF) << 0x20;
-            var word1 = ((ulong)MathHelper.Clamp(vector.W, minNeg, maxPos) & 0xFFFF) << 0x30;
+            var word4 = ((ulong) Math.Round(MathHelper.Clamp(vector.X, minNeg, maxPos)) & 0xFFFF) << 0x00;
+            var word3 = ((ulong) Math.Round(MathHelper.Clamp(vector.Y, minNeg, maxPos)) & 0xFFFF) << 0x10;
+            var word2 = ((ulong) Math.Round(MathHelper.Clamp(vector.Z, minNeg, maxPos)) & 0xFFFF) << 0x20;
+            var word1 = ((ulong) Math.Round(MathHelper.Clamp(vector.W, minNeg, maxPos)) & 0xFFFF) << 0x30;
 
             return word4 | word3 | word2 | word1;
         }

--- a/Test/Framework/PackedVectorTest.cs
+++ b/Test/Framework/PackedVectorTest.cs
@@ -121,6 +121,7 @@ namespace MonoGame.Tests.Framework
             //Test data ordering
             Assert.AreEqual(0xC7AD8F5C570A1EB8, new Rgba64(((float) 0x1EB8) / 0xffff, ((float) 0x570A) / 0xffff, ((float) 0x8F5C) / 0xffff, ((float) 0xC7AD) / 0xffff).PackedValue);
             Assert.AreEqual(0xC7AD8F5C570A1EB8, new Rgba64(0.12f, 0.34f, 0.56f, 0.78f).PackedValue);
+            Assert.AreEqual(0x73334CCC2666147B, new Rgba64(0.08f, 0.15f, 0.30f, 0.45f).PackedValue);
         }
 
         [Test]
@@ -141,6 +142,8 @@ namespace MonoGame.Tests.Framework
             float z = 0.5f;
             float w = -0.7f;
             Assert.AreEqual(0xA740DA0D, new NormalizedByte4(x, y, z, w).PackedValue);
+            Assert.AreEqual(958796544, new NormalizedByte4(0.0008f, 0.15f, 0.30f, 0.45f).PackedValue);
+
         }
 
         [Test]
@@ -185,6 +188,8 @@ namespace MonoGame.Tests.Framework
             float w = -0.7f;
 
             Assert.AreEqual(0xa6674000d99a0ccd, new NormalizedShort4(x, y, z, w).PackedValue);
+            Assert.AreEqual(4150390751449251866, new NormalizedShort4(0.0008f, 0.15f, 0.30f, 0.45f).PackedValue);
+
         }
 
         [Test]
@@ -278,6 +283,7 @@ namespace MonoGame.Tests.Framework
             z = 0.5f;
             w = -0.7f;
             Assert.AreEqual(18446462598732840960, new Short4(x, y, z, w).PackedValue);
+
         }
 
         [Test]
@@ -372,6 +378,57 @@ namespace MonoGame.Tests.Framework
             z = 0.5f;
             w = -0.7f;
             Assert.AreEqual(128, new Byte4(x, y, z, w).PackedValue);
+        }
+
+        [Test]
+        public void HalfSingle()
+        {
+            //Test limits
+            Assert.AreEqual(15360, new HalfSingle(1f).PackedValue);
+            Assert.AreEqual(0, new HalfSingle(0f).PackedValue);
+            Assert.AreEqual(48128, new HalfSingle(-1f).PackedValue);
+
+            //Test values
+            Assert.AreEqual(11878, new HalfSingle(0.1f).PackedValue);
+            Assert.AreEqual(46285, new HalfSingle(-0.3f).PackedValue);
+        }
+
+        [Test]
+        public void HalfVector2()
+        {
+            //Test PackedValue
+            Assert.AreEqual(0u, new HalfVector2(Vector2.Zero).PackedValue);
+            Assert.AreEqual(1006648320u, new HalfVector2(Vector2.One).PackedValue);
+            Assert.AreEqual(3033345638u, new HalfVector2(0.1f, -0.3f).PackedValue);
+
+            //Test ToVector2
+            Assert.AreEqual(Vector2.Zero, new HalfVector2(Vector2.Zero).ToVector2());
+            Assert.AreEqual(Vector2.One, new HalfVector2(Vector2.One).ToVector2());
+            Assert.AreEqual(Vector2.UnitX, new HalfVector2(Vector2.UnitX).ToVector2());
+            Assert.AreEqual(Vector2.UnitY, new HalfVector2(Vector2.UnitY).ToVector2());
+        }
+
+        [Test]
+        public void HalfVector4()
+        {
+            //Test PackedValue
+            Assert.AreEqual(0uL, new HalfVector4(Vector4.Zero).PackedValue);
+            Assert.AreEqual(4323521613979991040uL, new HalfVector4(Vector4.One).PackedValue);
+            Assert.AreEqual(13547034390470638592uL, new HalfVector4(-Vector4.One).PackedValue);
+            Assert.AreEqual(15360uL, new HalfVector4(Vector4.UnitX).PackedValue);
+            Assert.AreEqual(1006632960uL, new HalfVector4(Vector4.UnitY).PackedValue);
+            Assert.AreEqual(65970697666560uL, new HalfVector4(Vector4.UnitZ).PackedValue);
+            Assert.AreEqual(4323455642275676160uL, new HalfVector4(Vector4.UnitW).PackedValue);
+            Assert.AreEqual(4035285078724390502uL, new HalfVector4(0.1f, 0.3f, 0.4f, 0.5f).PackedValue);
+
+            //Test ToVector4
+            Assert.AreEqual(Vector4.Zero, new HalfVector4(Vector4.Zero).ToVector4());
+            Assert.AreEqual(Vector4.One, new HalfVector4(Vector4.One).ToVector4());
+            Assert.AreEqual(-Vector4.One, new HalfVector4(-Vector4.One).ToVector4());
+            Assert.AreEqual(Vector4.UnitX, new HalfVector4(Vector4.UnitX).ToVector4());
+            Assert.AreEqual(Vector4.UnitY, new HalfVector4(Vector4.UnitY).ToVector4());
+            Assert.AreEqual(Vector4.UnitZ, new HalfVector4(Vector4.UnitZ).ToVector4());
+            Assert.AreEqual(Vector4.UnitW, new HalfVector4(Vector4.UnitW).ToVector4());
         }
     }
 }

--- a/Test/Framework/PackedVectorTest.cs
+++ b/Test/Framework/PackedVectorTest.cs
@@ -19,6 +19,7 @@ namespace MonoGame.Tests.Framework
 
             //Test ordering
             Assert.AreEqual(124, new Alpha8(124f / 0xff).PackedValue);
+            Assert.AreEqual(26, new Alpha8(0.1f).PackedValue);
         }
 
         [Test]
@@ -42,6 +43,11 @@ namespace MonoGame.Tests.Framework
             float z = 0xd;
             float w = 0x1;
             Assert.AreEqual(0xeacd, new Bgra5551(x / 0x1f, y / 0x1f, z / 0x1f, w).PackedValue);
+            x = 0.1f;
+            y = -0.3f;
+            z = 0.5f;
+            w = -0.7f;
+            Assert.AreEqual(3088, new Bgra5551(x, y, z, w).PackedValue);
         }
 
         [Test]
@@ -63,6 +69,10 @@ namespace MonoGame.Tests.Framework
             float x = 0xb6dc;
             float y = 0xA59f;
             Assert.AreEqual(0xa59fb6dc, new Rg32(x / 0xffff, y / 0xffff).PackedValue);
+            x = 0.1f;
+            y = -0.3f;
+            Assert.AreEqual(6554, new Rg32(x, y).PackedValue);
+
         }
 
         [Test]
@@ -85,8 +95,12 @@ namespace MonoGame.Tests.Framework
             float y = 0x36d;
             float z = 0x3b7;
             float w = 0x1;
-
             Assert.AreEqual(0x7B7DB6DB, new Rgba1010102(x / 0x3ff, y / 0x3ff, z / 0x3ff, w / 3).PackedValue);
+            x = 0.1f;
+            y = -0.3f;
+            z = 0.5f;
+            w = -0.7f;
+            Assert.AreEqual(536871014, new Rgba1010102(x, y, z, w).PackedValue);
         }
 
         [Test]
@@ -106,6 +120,7 @@ namespace MonoGame.Tests.Framework
 
             //Test data ordering
             Assert.AreEqual(0xC7AD8F5C570A1EB8, new Rgba64(((float) 0x1EB8) / 0xffff, ((float) 0x570A) / 0xffff, ((float) 0x8F5C) / 0xffff, ((float) 0xC7AD) / 0xffff).PackedValue);
+            Assert.AreEqual(0xC7AD8F5C570A1EB8, new Rgba64(0.12f, 0.34f, 0.56f, 0.78f).PackedValue);
         }
 
         [Test]
@@ -125,7 +140,6 @@ namespace MonoGame.Tests.Framework
             float y = -0.3f;
             float z = 0.5f;
             float w = -0.7f;
-
             Assert.AreEqual(0xA740DA0D, new NormalizedByte4(x, y, z, w).PackedValue);
         }
 
@@ -148,7 +162,6 @@ namespace MonoGame.Tests.Framework
             //Test Ordering
             float x = 0.1f;
             float y = -0.3f;
-
             Assert.AreEqual(0xda0d, new NormalizedByte2(x, y).PackedValue);
         }
 
@@ -194,6 +207,9 @@ namespace MonoGame.Tests.Framework
             float x = 0.35f;
             float y = -0.2f;
             Assert.AreEqual(0xE6672CCC, new NormalizedShort2(x, y).PackedValue);
+            x = 0.1f;
+            y = -0.3f;
+            Assert.AreEqual(3650751693, new NormalizedShort2(x, y).PackedValue);
         }
 
         [Test]
@@ -224,6 +240,9 @@ namespace MonoGame.Tests.Framework
             float x = 0x2db1;
             float y = 0x361d;
             Assert.AreEqual(0x361d2db1, new Short2(x, y).PackedValue);
+            x = 127.5f;
+            y = -5.3f;
+            Assert.AreEqual(4294639744, new Short2(x, y).PackedValue);
 
         }
 
@@ -254,6 +273,11 @@ namespace MonoGame.Tests.Framework
             float z = 0x73b7;
             float w = 0x00c1;
             Assert.AreEqual(0x00c173b7316d2d1b, new Short4(x, y, z, w).PackedValue);
+            x = 0.1f;
+            y = -0.3f;
+            z = 0.5f;
+            w = -0.7f;
+            Assert.AreEqual(18446462598732840960, new Short4(x, y, z, w).PackedValue);
         }
 
         [Test]
@@ -280,6 +304,12 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual(0x00F0, new Bgra4444(Vector4.UnitY).PackedValue);
             Assert.AreEqual(0x000F, new Bgra4444(Vector4.UnitZ).PackedValue);
             Assert.AreEqual(0xF000, new Bgra4444(Vector4.UnitW).PackedValue);
+
+            float x = 0.1f;
+            float y = -0.3f;
+            float z = 0.5f;
+            float w = -0.7f;
+            Assert.AreEqual(520, new Bgra4444(x, y, z, w).PackedValue);
         }
 
         [Test]
@@ -304,6 +334,11 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual(0xF800, new Bgr565(Vector3.UnitX).PackedValue);
             Assert.AreEqual(0x07E0, new Bgr565(Vector3.UnitY).PackedValue);
             Assert.AreEqual(0x001F, new Bgr565(Vector3.UnitZ).PackedValue);
+
+            float x = 0.1f;
+            float y = -0.3f;
+            float z = 0.5f;
+            Assert.AreEqual(6160, new Bgr565(x, y, z).PackedValue);
         }
 
         [Test]
@@ -331,6 +366,12 @@ namespace MonoGame.Tests.Framework
             float z = 0x7b;
             float w = 0x1a;
             Assert.AreEqual(0x1a7b362d, new Byte4(x, y, z, w).PackedValue);
+
+            x = 127.5f;
+            y = -12.3f;
+            z = 0.5f;
+            w = -0.7f;
+            Assert.AreEqual(128, new Byte4(x, y, z, w).PackedValue);
         }
     }
 }

--- a/Test/Framework/PackedVectorTest.cs
+++ b/Test/Framework/PackedVectorTest.cs
@@ -16,6 +16,9 @@ namespace MonoGame.Tests.Framework
             // Test clamping.
             Assert.AreEqual(0x0, new Alpha8(-1234f).PackedValue);
             Assert.AreEqual(0xFF, new Alpha8(1234f).PackedValue);
+
+            //Test ordering
+            Assert.AreEqual(124, new Alpha8(124f / 0xff).PackedValue);
         }
 
         [Test]
@@ -32,6 +35,13 @@ namespace MonoGame.Tests.Framework
             // Test clamping.
             Assert.AreEqual(Vector4.Zero, new Bgra5551(Vector4.One * -1234.0f).ToVector4());
             Assert.AreEqual(Vector4.One, new Bgra5551(Vector4.One * 1234.0f).ToVector4());
+
+            //Test Ordering
+            float x = 0x1a;
+            float y = 0x16;
+            float z = 0xd;
+            float w = 0x1;
+            Assert.AreEqual(0xeacd, new Bgra5551(x / 0x1f, y / 0x1f, z / 0x1f, w).PackedValue);
         }
 
         [Test]
@@ -48,6 +58,11 @@ namespace MonoGame.Tests.Framework
             // Test clamping.
             Assert.AreEqual(Vector2.Zero, new Rg32(Vector2.One * -1234.0f).ToVector2());
             Assert.AreEqual(Vector2.One, new Rg32(Vector2.One * 1234.0f).ToVector2());
+
+            //Test Ordering
+            float x = 0xb6dc;
+            float y = 0xA59f;
+            Assert.AreEqual(0xa59fb6dc, new Rg32(x / 0xffff, y / 0xffff).PackedValue);
         }
 
         [Test]
@@ -64,6 +79,14 @@ namespace MonoGame.Tests.Framework
             // Test clamping.
             Assert.AreEqual(Vector4.Zero, new Rgba1010102(Vector4.One * -1234.0f).ToVector4());
             Assert.AreEqual(Vector4.One, new Rgba1010102(Vector4.One * 1234.0f).ToVector4());
+
+            //Test Ordering
+            float x = 0x2db;
+            float y = 0x36d;
+            float z = 0x3b7;
+            float w = 0x1;
+
+            Assert.AreEqual(0x7B7DB6DB, new Rgba1010102(x / 0x3ff, y / 0x3ff, z / 0x3ff, w / 3).PackedValue);
         }
 
         [Test]
@@ -82,7 +105,7 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual(Vector4.One, new Rgba64(Vector4.One * 1234.0f).ToVector4());
 
             //Test data ordering
-            Assert.AreEqual(0xC7AD8F5C570A1EB8, new Rgba64(((float) 0x1EB8) / 0xffff, ((float) 0x570A) / 0xffff, ((float) 0x8F5C) / 0xffff, ((float) 0xC7AD) /0xffff).PackedValue);
+            Assert.AreEqual(0xC7AD8F5C570A1EB8, new Rgba64(((float) 0x1EB8) / 0xffff, ((float) 0x570A) / 0xffff, ((float) 0x8F5C) / 0xffff, ((float) 0xC7AD) / 0xffff).PackedValue);
         }
 
         [Test]
@@ -97,6 +120,13 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual(-Vector4.One, new NormalizedByte4(-Vector4.One).ToVector4());
             Assert.AreEqual(Vector4.One, new NormalizedByte4(Vector4.One * 1234.0f).ToVector4());
             Assert.AreEqual(-Vector4.One, new NormalizedByte4(Vector4.One * -1234.0f).ToVector4());
+            //Test Ordering
+            float x = 0.1f;
+            float y = -0.3f;
+            float z = 0.5f;
+            float w = -0.7f;
+
+            Assert.AreEqual(0xA740DA0D, new NormalizedByte4(x, y, z, w).PackedValue);
         }
 
         [Test]
@@ -112,8 +142,14 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual(Vector2.One, new NormalizedByte2(Vector2.One * 1234.0f).ToVector2());
             Assert.AreEqual(-Vector2.One, new NormalizedByte2(Vector2.One * -1234.0f).ToVector2());
 
-            Assert.AreEqual(new Vector4(1,1,0,1), ((IPackedVector)new NormalizedByte2(Vector2.One)).ToVector4());
-            Assert.AreEqual(new Vector4(0,0,0,1), ((IPackedVector)new NormalizedByte2(Vector2.Zero)).ToVector4());
+            Assert.AreEqual(new Vector4(1, 1, 0, 1), ((IPackedVector) new NormalizedByte2(Vector2.One)).ToVector4());
+            Assert.AreEqual(new Vector4(0, 0, 0, 1), ((IPackedVector) new NormalizedByte2(Vector2.Zero)).ToVector4());
+
+            //Test Ordering
+            float x = 0.1f;
+            float y = -0.3f;
+
+            Assert.AreEqual(0xda0d, new NormalizedByte2(x, y).PackedValue);
         }
 
         [Test]
@@ -128,6 +164,14 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual(-Vector4.One, new NormalizedShort4(-Vector4.One).ToVector4());
             Assert.AreEqual(Vector4.One, new NormalizedShort4(Vector4.One * 1234.0f).ToVector4());
             Assert.AreEqual(-Vector4.One, new NormalizedShort4(Vector4.One * -1234.0f).ToVector4());
+
+            //Test Ordering
+            float x = 0.1f;
+            float y = -0.3f;
+            float z = 0.5f;
+            float w = -0.7f;
+
+            Assert.AreEqual(0xa6674000d99a0ccd, new NormalizedShort4(x, y, z, w).PackedValue);
         }
 
         [Test]
@@ -143,8 +187,13 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual(Vector2.One, new NormalizedShort2(Vector2.One * 1234.0f).ToVector2());
             Assert.AreEqual(-Vector2.One, new NormalizedShort2(Vector2.One * -1234.0f).ToVector2());
 
-            Assert.AreEqual(new Vector4(1, 1, 0, 1), ((IPackedVector)new NormalizedShort2(Vector2.One)).ToVector4());
-            Assert.AreEqual(new Vector4(0, 0, 0, 1), ((IPackedVector)new NormalizedShort2(Vector2.Zero)).ToVector4());
+            Assert.AreEqual(new Vector4(1, 1, 0, 1), ((IPackedVector) new NormalizedShort2(Vector2.One)).ToVector4());
+            Assert.AreEqual(new Vector4(0, 0, 0, 1), ((IPackedVector) new NormalizedShort2(Vector2.Zero)).ToVector4());
+
+            //Test Ordering
+            float x = 0.35f;
+            float y = -0.2f;
+            Assert.AreEqual(0xE6672CCC, new NormalizedShort2(x, y).PackedValue);
         }
 
         [Test]
@@ -167,9 +216,15 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual(Vector2.One * -0x8000, new Short2(Vector2.One * -1234567.0f).ToVector2());
 
             // Test ToVector4.
-            Assert.AreEqual(new Vector4(0x7FFF, 0x7FFF, 0, 1), ((IPackedVector)new Short2(Vector2.One * 0x7FFF)).ToVector4());
-            Assert.AreEqual(new Vector4(0, 0, 0, 1), ((IPackedVector)new Short2(Vector2.Zero)).ToVector4());
-            Assert.AreEqual(new Vector4(-0x8000, -0x8000, 0, 1), ((IPackedVector)new Short2(Vector2.One * -0x8000)).ToVector4());
+            Assert.AreEqual(new Vector4(0x7FFF, 0x7FFF, 0, 1), ((IPackedVector) new Short2(Vector2.One * 0x7FFF)).ToVector4());
+            Assert.AreEqual(new Vector4(0, 0, 0, 1), ((IPackedVector) new Short2(Vector2.Zero)).ToVector4());
+            Assert.AreEqual(new Vector4(-0x8000, -0x8000, 0, 1), ((IPackedVector) new Short2(Vector2.One * -0x8000)).ToVector4());
+
+            //Test ordering
+            float x = 0x2db1;
+            float y = 0x361d;
+            Assert.AreEqual(0x361d2db1, new Short2(x, y).PackedValue);
+
         }
 
         [Test]
@@ -192,6 +247,13 @@ namespace MonoGame.Tests.Framework
             // Test clamping.
             Assert.AreEqual(Vector4.One * 0x7FFF, new Short4(Vector4.One * 1234567.0f).ToVector4());
             Assert.AreEqual(Vector4.One * -0x8000, new Short4(Vector4.One * -1234567.0f).ToVector4());
+
+            //Test Ordering
+            float x = 0x2d1b;
+            float y = 0x316d;
+            float z = 0x73b7;
+            float w = 0x00c1;
+            Assert.AreEqual(0x00c173b7316d2d1b, new Short4(x, y, z, w).PackedValue);
         }
 
         [Test]
@@ -262,6 +324,13 @@ namespace MonoGame.Tests.Framework
             // Test clamping.
             Assert.AreEqual(Vector4.Zero, new Byte4(Vector4.One * -1234.0f).ToVector4());
             Assert.AreEqual(Vector4.One * 255, new Byte4(Vector4.One * 1234.0f).ToVector4());
+
+            //Test ordering
+            float x = 0x2d;
+            float y = 0x36;
+            float z = 0x7b;
+            float w = 0x1a;
+            Assert.AreEqual(0x1a7b362d, new Byte4(x, y, z, w).PackedValue);
         }
     }
 }


### PR DESCRIPTION
Fixes #4685 
This should fix all differences between the Packed Vector classes between XNA and MonoGame. 
The main difference between them was the data ordering, but also that XNA was rounding the values while packaging them, so now the following test is working while previously wasn't
```
// Test packing order.
Assert.AreEqual(0xC7AD8F5C570A1EB8, new Rgba64(0.12f, 0.34f, 0.56f, 0.78f).PackedValue);
```

Apart from the fixes I also did a few upgrades, and in a few cases I replaced the tabs with spaces.

Also `Short2` or `NormalizedShort2` still contains the old license information, should I update it?
