### PR TITLE
Fixed layout of UWP windows in VS template to ignore window chrome.

### DIFF
--- a/ProjectTemplates/VisualStudio2015/WindowsUniversal/App.xaml.cs
+++ b/ProjectTemplates/VisualStudio2015/WindowsUniversal/App.xaml.cs
@@ -7,6 +7,7 @@ using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -41,6 +42,8 @@ namespace $safeprojectname$
         /// <param name="e">Details about the launch request and process.</param>
         protected override void OnLaunched(LaunchActivatedEventArgs e)
         {
+            // By default we want to fill the entire core window.
+            ApplicationView.GetForCurrentView().SetDesiredBoundsMode(ApplicationViewBoundsMode.UseCoreWindow);
 
 #if DEBUG
             if (System.Diagnostics.Debugger.IsAttached)


### PR DESCRIPTION
This fixes the layout to use entire core window on UWP apps.  This helps in particular on Xbox One where it otherwise adds borders around your swap chain to keep the app from the safe zone area (something done manually in games).

Part of the fixes for #4697 .

