### PR TITLE
Fixed thumbstick virtual buttons to always use independent axes.

### DIFF
--- a/MonoGame.Framework/Input/GamePad.XInput.cs
+++ b/MonoGame.Framework/Input/GamePad.XInput.cs
@@ -198,10 +198,6 @@ namespace Microsoft.Xna.Framework.Input
 
             var buttons = ConvertToButtons(
                 buttonFlags: gamepad.Buttons,
-                leftThumbX: gamepad.LeftThumbX,
-                leftThumbY: gamepad.LeftThumbY,
-                rightThumbX: gamepad.RightThumbX,
-                rightThumbY: gamepad.RightThumbY,
                 leftTrigger: gamepad.LeftTrigger,
                 rightTrigger: gamepad.RightTrigger);
 
@@ -232,29 +228,7 @@ namespace Microsoft.Xna.Framework.Input
             return buttonState == ButtonState.Pressed ? xnaButton : 0;
         }
 
-        private static Buttons AddThumbstickButtons(
-            short thumbX, short thumbY, short deadZone, 
-            Buttons thumbstickLeft, 
-            Buttons thumbStickRight, 
-            Buttons thumbStickUp, 
-            Buttons thumbStickDown)
-        {
-            // TODO: this needs adjustment. Very naive implementation. Doesn't match XNA yet
-            var result = (Buttons)0;
-            if (thumbX < -deadZone)
-                result |= thumbstickLeft;
-            if (thumbX > deadZone)
-                result |= thumbStickRight;
-            if (thumbY < -deadZone)
-                result |= thumbStickDown;
-            else if (thumbY > deadZone)
-                result |= thumbStickUp;
-            return result;
-        }
-
         private static GamePadButtons ConvertToButtons(SharpDX.XInput.GamepadButtonFlags buttonFlags,
-            short leftThumbX, short leftThumbY,
-            short rightThumbX, short rightThumbY,
             byte leftTrigger,
             byte rightTrigger)
         {
@@ -273,20 +247,6 @@ namespace Microsoft.Xna.Framework.Input
             ret |= AddButtonIfPressed(buttonFlags, GBF.Start, Buttons.Start);
             ret |= AddButtonIfPressed(buttonFlags, GBF.X, Buttons.X);
             ret |= AddButtonIfPressed(buttonFlags, GBF.Y, Buttons.Y);
-
-            ret |= AddThumbstickButtons(leftThumbX, leftThumbY,
-                SharpDX.XInput.Gamepad.LeftThumbDeadZone,
-                Buttons.LeftThumbstickLeft, 
-                Buttons.LeftThumbstickRight, 
-                Buttons.LeftThumbstickUp, 
-                Buttons.LeftThumbstickDown);
-
-            ret |= AddThumbstickButtons(rightThumbX, rightThumbY,
-                SharpDX.XInput.Gamepad.RightThumbDeadZone,
-                Buttons.RightThumbstickLeft, 
-                Buttons.RightThumbstickRight, 
-                Buttons.RightThumbstickUp, 
-                Buttons.RightThumbstickDown);
 
             if (leftTrigger >= SharpDX.XInput.Gamepad.TriggerThreshold)
                 ret |= Buttons.LeftTrigger;

--- a/MonoGame.Framework/Input/GamePadState.cs
+++ b/MonoGame.Framework/Input/GamePadState.cs
@@ -141,28 +141,9 @@ namespace Microsoft.Xna.Framework.Input
         /// </summary>
         private Buttons GetVirtualButtons () {
             var result = Buttons.buttons;
-            var sticks = ThumbSticks;
-            
-            if (sticks.Left.X < 0)
-                result |= Microsoft.Xna.Framework.Input.Buttons.LeftThumbstickLeft;
-            else if (sticks.Left.X > 0)
-                result |= Microsoft.Xna.Framework.Input.Buttons.LeftThumbstickRight;
-            
-            if (sticks.Left.Y < 0)
-                result |= Microsoft.Xna.Framework.Input.Buttons.LeftThumbstickDown;
-            else if (sticks.Left.Y > 0)
-                result |= Microsoft.Xna.Framework.Input.Buttons.LeftThumbstickUp;
-            
-            if (sticks.Right.X < 0)
-                result |= Microsoft.Xna.Framework.Input.Buttons.RightThumbstickLeft;
-            else if (sticks.Right.X > 0)
-                result |= Microsoft.Xna.Framework.Input.Buttons.RightThumbstickRight;
-            
-            if (sticks.Right.Y < 0)
-                result |= Microsoft.Xna.Framework.Input.Buttons.RightThumbstickDown;
-            else if (sticks.Right.Y > 0)
-                result |= Microsoft.Xna.Framework.Input.Buttons.RightThumbstickUp;
 
+            result |= ThumbSticks.VirtualButtons;
+            
             if (DPad.Down == ButtonState.Pressed)
                 result |= Microsoft.Xna.Framework.Input.Buttons.DPadDown;
             if (DPad.Up == ButtonState.Pressed)

--- a/MonoGame.Framework/Input/GamePadThumbSticks.cs
+++ b/MonoGame.Framework/Input/GamePadThumbSticks.cs
@@ -1,45 +1,6 @@
-#region License
-/*
-Microsoft Public License (Ms-PL)
-MonoGame - Copyright © 2009 The MonoGame Team
-
-All rights reserved.
-
-This license governs use of the accompanying software. If you use the software, you accept this license. If you do not
-accept the license, do not use the software.
-
-1. Definitions
-The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under 
-U.S. copyright law.
-
-A "contribution" is the original software, or any additions or changes to the software.
-A "contributor" is any person that distributes its contribution under this license.
-"Licensed patents" are a contributor's patent claims that read directly on its contribution.
-
-2. Grant of Rights
-(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, 
-each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-
-3. Conditions and Limitations
-(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, 
-your patent license from such contributor to the software ends automatically.
-(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution 
-notices that are present in the software.
-(D) If you distribute any portion of the software in source code form, you may do so only under this license by including 
-a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object 
-code form, you may only do so under a license that complies with this license.
-(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees
-or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent
-permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular
-purpose and non-infringement.
-*/
-#endregion License
-
-using Microsoft.Xna.Framework;
-using System;
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
 
 namespace Microsoft.Xna.Framework.Input
 {
@@ -63,11 +24,32 @@ namespace Microsoft.Xna.Framework.Input
             }
         }
 
+        internal Buttons VirtualButtons { get; private set; }
+
+#if DIRECTX && !WINDOWS_PHONE && !WINDOWS_PHONE81 && !WINDOWS_UAP
+        // XInput Xbox 360 Controller dead zones
+        // Dead zones are slighty different between left and right sticks, this may come from Microsoft usability tests
+        private const float leftThumbDeadZone = SharpDX.XInput.Gamepad.LeftThumbDeadZone / (float)short.MaxValue;
+        private const float rightThumbDeadZone = SharpDX.XInput.Gamepad.RightThumbDeadZone / (float)short.MaxValue;
+#elif OUYA
+        // OUYA dead zones should
+        // They are a bit larger to accomodate OUYA Gamepad (but will also affect Xbox 360 controllers plugged to an OUYA)
+        private const float leftThumbDeadZone = 0.3f;
+        private const float rightThumbDeadZone = 0.3f;
+#else
+        // Default & SDL Xbox 360 Controller dead zones
+        // Based on the XInput constants
+        private const float leftThumbDeadZone = 0.24f;
+        private const float rightThumbDeadZone = 0.265f;
+#endif
+
 		public GamePadThumbSticks(Vector2 leftPosition, Vector2 rightPosition):this()
 		{
 			left = leftPosition;
 			right = rightPosition;
             ApplySquareClamp();
+
+            SetVirtualButtons(leftPosition, rightPosition);
 		}
 
         internal GamePadThumbSticks(Vector2 leftPosition, Vector2 rightPosition, GamePadDeadZone deadZoneMode):this()
@@ -80,6 +62,8 @@ namespace Microsoft.Xna.Framework.Input
                 ApplyCircularClamp();
             else
                 ApplySquareClamp();
+
+            SetVirtualButtons(leftPosition, rightPosition);
         }
 
         private void ApplySquareClamp()
@@ -98,22 +82,6 @@ namespace Microsoft.Xna.Framework.Input
 
         private void ApplyDeadZone(GamePadDeadZone dz)
         {
-#if DIRECTX && !WINDOWS_PHONE && !WINDOWS_PHONE81 && !WINDOWS_UAP
-            // XInput Xbox 360 Controller dead zones
-            // Dead zones are slighty different between left and right sticks, this may come from Microsoft usability tests
-            const float leftThumbDeadZone = SharpDX.XInput.Gamepad.LeftThumbDeadZone / (float)short.MaxValue;
-            const float rightThumbDeadZone = SharpDX.XInput.Gamepad.RightThumbDeadZone / (float)short.MaxValue;
-#elif OUYA
-            // OUYA dead zones should
-            // They are a bit larger to accomodate OUYA Gamepad (but will also affect Xbox 360 controllers plugged to an OUYA)
-            const float leftThumbDeadZone = 0.3f;
-            const float rightThumbDeadZone = 0.3f;
-#else
-            // Default & SDL Xbox 360 Controller dead zones
-            // Based on the XInput constants
-            const float leftThumbDeadZone = 0.24f;
-            const float rightThumbDeadZone = 0.265f;
-#endif
             switch (dz)
             {
                 case GamePadDeadZone.None:
@@ -152,6 +120,31 @@ namespace Microsoft.Xna.Framework.Input
                 return Vector2.Zero;
             var newLength = (originalLength - deadZone) / (1f - deadZone);
             return value * (newLength / originalLength);
+        }
+
+        private void SetVirtualButtons(Vector2 leftPosition, Vector2 rightPosition)
+        {
+            VirtualButtons = 0;
+
+            if (leftPosition.X < -leftThumbDeadZone)
+                VirtualButtons |= Buttons.LeftThumbstickLeft;
+            else if (leftPosition.X > leftThumbDeadZone)
+                VirtualButtons |= Buttons.LeftThumbstickRight;
+
+            if (leftPosition.Y < -leftThumbDeadZone)
+                VirtualButtons |= Buttons.LeftThumbstickDown;
+            else if (leftPosition.Y > leftThumbDeadZone)
+                VirtualButtons |= Buttons.LeftThumbstickUp;
+
+            if (rightPosition.X < -rightThumbDeadZone)
+                VirtualButtons |= Buttons.RightThumbstickLeft;
+            else if (rightPosition.X > rightThumbDeadZone)
+                VirtualButtons |= Buttons.RightThumbstickRight;
+
+            if (rightPosition.Y < -rightThumbDeadZone)
+                VirtualButtons |= Buttons.RightThumbstickDown;
+            else if (rightPosition.Y > rightThumbDeadZone)
+                VirtualButtons |= Buttons.RightThumbstickUp;
         }
 
         /// <summary>

--- a/Test/Framework/GamePadStateTest.cs
+++ b/Test/Framework/GamePadStateTest.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using NUnit.Framework;
@@ -52,5 +54,53 @@ namespace MonoGame.Tests.Framework
             Assert.AreEqual(expectedDPadButtonStates[2], state.DPad.Right, "DPad.Right Pressed or Released");
             Assert.AreEqual(expectedDPadButtonStates[3], state.DPad.Up, "DPad.Up Pressed or Released");
         }
+
+#if !XNA
+        [TestCaseSource("ThumbStickVirtualButtonsIgnoreDeadZoneTestCases")]
+        public void ThumbStickVirtualButtonsIgnoreDeadZone(Vector2 left, Vector2 right, GamePadDeadZone deadZone, Buttons expectedButtons)
+        {
+            var state = new GamePadState(new GamePadThumbSticks(left, right, deadZone), new GamePadTriggers(), new GamePadButtons(), new GamePadDPad());
+
+            Assert.AreEqual(expectedButtons, GetAllPressedButtons(state));
+        }
+
+        private static IEnumerable<TestCaseData> ThumbStickVirtualButtonsIgnoreDeadZoneTestCases
+        {
+            get
+            {
+                yield return new TestCaseData(
+                    Vector2.Zero, Vector2.Zero, GamePadDeadZone.Circular,
+                    (Buttons)0);
+
+                yield return new TestCaseData(
+                    new Vector2(1f, 0.1f), new Vector2(0.1f, 1f), GamePadDeadZone.Circular,
+                    Buttons.LeftThumbstickRight | Buttons.RightThumbstickUp);
+
+                yield return new TestCaseData(
+                    new Vector2(1f, 0.1f), new Vector2(0.1f, 1f), GamePadDeadZone.None,
+                    Buttons.LeftThumbstickRight | Buttons.RightThumbstickUp);
+
+                yield return new TestCaseData(
+                    new Vector2(1f, 0.1f), new Vector2(0.1f, 1f), GamePadDeadZone.IndependentAxes,
+                    Buttons.LeftThumbstickRight | Buttons.RightThumbstickUp);
+
+                yield return new TestCaseData(
+                    new Vector2(0.5f, -0.5f), new Vector2(-0.5f, 0.5f), GamePadDeadZone.Circular,
+                    Buttons.LeftThumbstickRight | Buttons.LeftThumbstickDown | Buttons.RightThumbstickLeft | Buttons.RightThumbstickUp);
+
+                yield return new TestCaseData(
+                    new Vector2(0.1f, -0.1f), new Vector2(-0.1f, 0.1f), GamePadDeadZone.None,
+                    (Buttons)0);
+            }
+        }
+
+        private static Buttons GetAllPressedButtons(GamePadState state)
+        {
+            Buttons buttons = 0;
+            foreach (var button in Enum.GetValues(typeof(Buttons)).Cast<Buttons>().Where(state.IsButtonDown))
+                buttons |= button;
+            return buttons;
+        }
+#endif
     }
 }


### PR DESCRIPTION
Fixes #4741.

This PR changes how the thumbstick "virtual buttons" (e.g. `Buttons.LeftThumbstickUp`) are set so that it more closely matches XNA behaviour. Basically it now always uses the "independent axes" mode to determine the virtual buttons state regardless of the actual dead-zone mode being used.