### PR TITLE
Red/Blue swap implemented in DDS loader

### DIFF
--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -821,6 +821,9 @@
     <Content Include="Assets\Textures\SampleCube64DXT1Mips.dds">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Assets\Textures\Sunset.dds">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
 	<Content Include="Assets\Textures\LogoOnly_64px.dds">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Test/ContentPipeline/TextureImporterTests.cs
+++ b/Test/ContentPipeline/TextureImporterTests.cs
@@ -146,11 +146,40 @@ namespace MonoGame.Tests.ContentPipeline
             Assert.AreEqual(content.Faces.Count, 6);
             for (int f = 0; f < 6; ++f)
             {
-                CheckDdsFace(content, f);
+                CheckDdsFace(content, f, 7, 64, 64);
             }
             SurfaceFormat format;
             Assert.True(content.Faces[0][0].TryGetFormat(out format));
             Assert.AreEqual(format, SurfaceFormat.Dxt1);
+            // Clean-up the directories it may have produced, ignoring DirectoryNotFound exceptions
+            try
+            {
+                Directory.Delete(intermediateDirectory, true);
+                Directory.Delete(outputDirectory, true);
+            }
+            catch (DirectoryNotFoundException)
+            { }
+        }
+
+        [Test]
+        public void ImportDdsCubemapColor()
+        {
+            var importer = new TextureImporter();
+            var context = new TestImporterContext(intermediateDirectory, outputDirectory);
+            var content = importer.Import("Assets/Textures/Sunset.dds", context);
+            Assert.NotNull(content);
+            Assert.AreEqual(content.Faces.Count, 6);
+            for (int f = 0; f < 6; ++f)
+            {
+                CheckDdsFace(content, f, 1, 512, 512);
+            }
+            SurfaceFormat format;
+            Assert.True(content.Faces[0][0].TryGetFormat(out format));
+            // Ensure the red and blue bytes have been correctly swapped
+            Assert.AreEqual(format, SurfaceFormat.Color);
+            var bytes = content.Faces[0][0].GetPixelData();
+            Assert.AreEqual(bytes[0], 208);
+            Assert.AreEqual(bytes[2], 62);
             // Clean-up the directories it may have produced, ignoring DirectoryNotFound exceptions
             try
             {
@@ -176,7 +205,7 @@ namespace MonoGame.Tests.ContentPipeline
             var content = importer.Import("Assets/Textures/LogoOnly_64px-mipmaps.dds", context);
             Assert.NotNull(content);
             Assert.AreEqual(content.Faces.Count, 1);
-            CheckDdsFace(content, 0);
+            CheckDdsFace(content, 0, 7, 64, 64);
 
             SurfaceFormat format;
             Assert.True(content.Faces[0][0].TryGetFormat(out format));
@@ -191,28 +220,15 @@ namespace MonoGame.Tests.ContentPipeline
             {
             }
         }
-        /// <summary>
-        /// Checks that the face of the texture contains 7 mipmaps and that their sizes decline from 64x64 to 1x1
-        /// </summary>
-        /// <param name="content">Texture to check</param>
-        /// <param name="faceIndex">Index of the face from the texture</param>
-        private static void CheckDdsFace(TextureContent content, int faceIndex)
+
+        private static void CheckDdsFace(TextureContent content, int faceIndex, int mipMapCount, int width, int height)
         {
-            Assert.AreEqual(content.Faces[faceIndex].Count, 7);
-            Assert.AreEqual(content.Faces[faceIndex][0].Width, 64);
-            Assert.AreEqual(content.Faces[faceIndex][0].Height, 64);
-            Assert.AreEqual(content.Faces[faceIndex][1].Width, 32);
-            Assert.AreEqual(content.Faces[faceIndex][1].Height, 32);
-            Assert.AreEqual(content.Faces[faceIndex][2].Width, 16);
-            Assert.AreEqual(content.Faces[faceIndex][2].Height, 16);
-            Assert.AreEqual(content.Faces[faceIndex][3].Width, 8);
-            Assert.AreEqual(content.Faces[faceIndex][3].Height, 8);
-            Assert.AreEqual(content.Faces[faceIndex][4].Width, 4);
-            Assert.AreEqual(content.Faces[faceIndex][4].Height, 4);
-            Assert.AreEqual(content.Faces[faceIndex][5].Width, 2);
-            Assert.AreEqual(content.Faces[faceIndex][5].Height, 2);
-            Assert.AreEqual(content.Faces[faceIndex][6].Width, 1);
-            Assert.AreEqual(content.Faces[faceIndex][6].Height, 1);
+            Assert.AreEqual(content.Faces[faceIndex].Count, mipMapCount);
+            for (int i = 0; i < mipMapCount; ++i)
+            {
+                Assert.AreEqual(content.Faces[faceIndex][i].Width, width >> i);
+                Assert.AreEqual(content.Faces[faceIndex][i].Height, height >> i);
+            }
         }
     }
 }


### PR DESCRIPTION
The test for a RB swap was incorrect for 32-bit colour textures.
Implemented the RB swap for when it was needed.
Added unit test for a full colour cubemap DDS that needs a RB swap.