### PR TITLE
Remove unused POINT struct.

### DIFF
--- a/MonoGame.Framework/Input/Mouse.cs
+++ b/MonoGame.Framework/Input/Mouse.cs
@@ -247,23 +247,6 @@ namespace Microsoft.Xna.Framework.Input
         [return: MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.Bool)]
         internal static extern bool SetCursorPos(int X, int Y);
 
-        /// <summary>
-        /// Struct representing a point. 
-        /// (Suggestion : Make another class for mouse extensions)
-        /// </summary>
-        [StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
-        internal struct POINT
-        {
-            public int X;
-            public int Y;
-
-            public System.Drawing.Point ToPoint()
-            {
-                return new System.Drawing.Point(X, Y);
-            }
-
-        }
-
 #elif MONOMAC
 #if PLATFORM_MACOS_LEGACY
         [DllImport (MonoMac.Constants.CoreGraphicsLibrary)]


### PR DESCRIPTION
All references to this struct were removed in [this commit](https://github.com/mono/MonoGame/commit/d1d3133e2c10104469a4e84227d5718a42c14f8d).