### PR TITLE
Make SpriteEffect public

### DIFF
--- a/MonoGame.Framework/Graphics/Effect/SpriteEffect.cs
+++ b/MonoGame.Framework/Graphics/Effect/SpriteEffect.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Xna.Framework.Graphics
     /// <summary>
     /// The default effect used by SpriteBatch.
     /// </summary>
-    internal class SpriteEffect : Effect
+    public class SpriteEffect : Effect
     {
         #region Effect Parameters
 


### PR DESCRIPTION
This makes SpriteEffect public like the other built-in effects as discussed in #4766.