### PR TITLE
Allow Bgra4444 textures to be created in DirectX desktop

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -33,9 +33,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
             _renderTarget = (type == SurfaceType.RenderTarget);
             _mipmap = mipmap;
-
-            // Create texture
-            GetTexture();
         }
 
         private void PlatformSetData<T>(int level, int arraySlice, Rectangle? rect, T[] data, int startIndex, int elementCount) where T : struct
@@ -80,8 +77,6 @@ namespace Microsoft.Xna.Framework.Graphics
                     }
                 }
 
-                var box = new SharpDX.DataBox(dataPtr, GetPitch(w), 0);
-
                 var region = new SharpDX.Direct3D11.ResourceRegion();
                 region.Top = y;
                 region.Front = 0;
@@ -90,11 +85,12 @@ namespace Microsoft.Xna.Framework.Graphics
                 region.Left = x;
                 region.Right = x + w;
 
+                
                 // TODO: We need to deal with threaded contexts here!
                 int subresourceIndex = CalculateSubresourceIndex(arraySlice, level);
                 var d3dContext = GraphicsDevice._d3dContext;
                 lock (d3dContext)
-                    d3dContext.UpdateSubresource(box, GetTexture(), subresourceIndex, region);
+                    d3dContext.UpdateSubresource(GetTexture(), subresourceIndex, region, dataPtr, GetPitch(w), 0);
             }
             finally
             {
@@ -320,7 +316,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #if !WINDOWS_PHONE
 
         [CLSCompliant(false)]
-        public static SharpDX.Direct3D11.Texture2D CreateTex2DFromBitmap(SharpDX.WIC.BitmapSource bsource, GraphicsDevice device)
+        static SharpDX.Direct3D11.Texture2D CreateTex2DFromBitmap(SharpDX.WIC.BitmapSource bsource, GraphicsDevice device)
         {
 
             SharpDX.Direct3D11.Texture2DDescription desc;

--- a/MonoGame.Framework/Windows8/SharpDXHelper.cs
+++ b/MonoGame.Framework/Windows8/SharpDXHelper.cs
@@ -65,11 +65,12 @@ namespace Microsoft.Xna.Framework
                     return SharpDX.DXGI.Format.B5G6R5_UNorm;
                 case SurfaceFormat.Bgra5551:
                     return SharpDX.DXGI.Format.B5G5R5A1_UNorm;
-#if WINRT
                 case SurfaceFormat.Bgra4444:
+#if WINRT
                     return SharpDX.DXGI.Format.B4G4R4A4_UNorm;
+#else
+                    return (SharpDX.DXGI.Format)115;
 #endif
-
                 case SurfaceFormat.Dxt1:
                     return SharpDX.DXGI.Format.BC1_UNorm;
                 case SurfaceFormat.Dxt3:


### PR DESCRIPTION
Fixes http://community.monogame.net/t/reading-c-ushort-in-hlsl-float-is-wrong-in-monogame-64-bit-compilation/7443

- DirectX 11.2 re-added Bgra4444 texture format after it was removed in DirectX 10 (Bgra5551 and Bgr565 were re-added in DirectX 11.1). SharpDX for Windows does not appear to have the enum value for it.  Added the special case for this so it didn't create a Color format texture by default.

Other issues found during the investigation of the above fix.

- Found a resource leak when using Texture2D.FromStream() in DirectX.  The texture created in PlatformConstruct() was overwritten by the texture created in PlatformFromStream().  Texture2D instances constructed normally already had the texture created in the call to PlatformSetData() if required.
- Removed a redundant creation of DataBox in PlatformSetData(). UpdateSubresource has an override to take the separate parameters that was called internally by the DataBox override anyway.
- Texture2D.CreateTex2DFromBitmap() should not need to be public since it is only used internally.