### PR TITLE
MonoGame tvOS now compiles. Fixes:

### DIFF
--- a/Build/Projects/FrameworkReferences.definition
+++ b/Build/Projects/FrameworkReferences.definition
@@ -8,6 +8,9 @@
     <Reference Include="OpenTK-1.0" />
   </Platform>
   <Platform Type="tvOS">
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition” />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Core" />
     <Reference Include="OpenTK-1.0" />
   </Platform>

--- a/Build/Projects/FrameworkReferences.definition
+++ b/Build/Projects/FrameworkReferences.definition
@@ -9,7 +9,7 @@
   </Platform>
   <Platform Type="tvOS">
     <Reference Include="System" />
-    <Reference Include="System.ComponentModel.Composition” />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Core" />
     <Reference Include="OpenTK-1.0" />

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -209,7 +209,7 @@
       <Platforms>Angle,Linux,MacOS,Windows,Windows8,WindowsGL,WindowsUniversal</Platforms>
     </Compile>
     <Compile Include="GamePlatform.Mobile.cs">
-      <Platforms>Android,iOS,Ouya,WindowsPhone,WindowsPhone81,Web</Platforms>
+      <Platforms>Android,iOS,Ouya,WindowsPhone,WindowsPhone81,Web,tvOS</Platforms>
     </Compile>
     <Compile Include="GameRunBehavior.cs" />
     <Compile Include="GameServiceContainer.cs" />

--- a/MonoGame.Framework/Input/GamePad.tvOS.cs
+++ b/MonoGame.Framework/Input/GamePad.tvOS.cs
@@ -13,14 +13,9 @@ namespace Microsoft.Xna.Framework.Input
     {
         internal static bool MenuPressed = false;
 
-        private static int PlatformGetMaxIndex()
-        {
-            return 4;
-        }
-
         private static int PlatformGetMaxNumberOfGamePads ()
         {
-            return PlatformGetMaxIndex ();
+            return 4;
         }
 
         static bool IndexIsUsed (GCControllerPlayerIndex index)

--- a/MonoGame.Framework/Input/GamePad.tvOS.cs
+++ b/MonoGame.Framework/Input/GamePad.tvOS.cs
@@ -18,10 +18,15 @@ namespace Microsoft.Xna.Framework.Input
             return 4;
         }
 
+        private static int PlatformGetMaxNumberOfGamePads ()
+        {
+            return PlatformGetMaxIndex ();
+        }
+
         static bool IndexIsUsed (GCControllerPlayerIndex index)
         {
             foreach (var ctrl in GCController.Controllers)
-                if (ctrl.PlayerIndex==index) return true;
+                if (ctrl.PlayerIndex==(int)index) return true;
 
             return false;
         }
@@ -31,11 +36,11 @@ namespace Microsoft.Xna.Framework.Input
                 return;
             foreach (var controller in GCController.Controllers)
             {
-                if (controller.PlayerIndex == index)
+                if (controller.PlayerIndex == (int)index)
                     break;
-                if (controller.PlayerIndex == GCControllerPlayerIndex.Unset)
+                if (controller.PlayerIndex == (int)GCControllerPlayerIndex.Unset)
                 {
-                    controller.PlayerIndex = index;
+                    controller.PlayerIndex = (int)index;
                     break;
                 }
             }
@@ -51,7 +56,7 @@ namespace Microsoft.Xna.Framework.Input
             {
                 if (controller == null)
                     continue;
-                if (controller.PlayerIndex == ind)
+                if (controller.PlayerIndex == (int)ind)
                     return GetCapabilities(controller);
             }
             return new GamePadCapabilities { IsConnected = false };
@@ -76,7 +81,7 @@ namespace Microsoft.Xna.Framework.Input
                 if (controller == null)
                     continue;
 
-                if (controller.PlayerIndex != ind)
+                if (controller.PlayerIndex != (int)ind)
                     continue;
 
                 connected = true;

--- a/MonoGame.Framework/Media/Album.cs
+++ b/MonoGame.Framework/Media/Album.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Xna.Framework.Media
         private SongCollection songCollection;
 #if WINDOWS_STOREAPP || WINDOWS_UAP
         private StorageItemThumbnail thumbnail;
-#elif IOS
+#elif IOS && !TVOS
         private MPMediaItemArtwork thumbnail;
 #elif ANDROID
         private Android.Net.Uri thumbnail;
@@ -173,7 +173,7 @@ namespace Microsoft.Xna.Framework.Media
         {
             this.thumbnail = thumbnail;
         }
-#elif IOS
+#elif IOS && !TVOS
         internal Album(SongCollection songCollection, string name, Artist artist, Genre genre, MPMediaItemArtwork thumbnail)
             : this(songCollection, name, artist, genre)
         {


### PR DESCRIPTION
 - Added needed assembly references in protobuild .definition file.
 - Added code reference to GamePlatform.Mobile.cs
 - Added explicit cast to deal with nine
 - Removed thumbnail from Album.cs since backing class seems to not exist on tvOS.