### PR TITLE
Only use Default implementation on older Mac APIs

### DIFF
--- a/MonoGame.Framework/Input/GamePad.Default.cs
+++ b/MonoGame.Framework/Input/GamePad.Default.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#if !MONOMAC || PLATFORM_MACOS_LEGACY
+
 namespace Microsoft.Xna.Framework.Input
 {
     static partial class GamePad
@@ -44,3 +46,6 @@ namespace Microsoft.Xna.Framework.Input
         }
     }
 }
+
+#endif
+

--- a/MonoGame.Framework/Input/Joystick.Default.cs
+++ b/MonoGame.Framework/Input/Joystick.Default.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+#if !MONOMAC || PLATFORM_MACOS_LEGACY
+
 using System;
 
 namespace Microsoft.Xna.Framework.Input
@@ -31,3 +33,6 @@ namespace Microsoft.Xna.Framework.Input
         }
     }
 }
+
+#endif
+


### PR DESCRIPTION
This allows Xamarin.Mac to build again without introducing any regressions in the current behaviour.  If we opted for only GamePad.Mac or GamePad.Default to be included in the project, then we'd either introduce regressions for MonoMac or regressions for Xamarin.Mac.