### PR TITLE
Add NVorbis submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "ThirdParty/Dependencies"]
 	path = ThirdParty/Dependencies
 	url = https://github.com/Mono-Game/MonoGame.Dependencies.git
+[submodule "ThirdParty/NVorbis"]
+	path = ThirdParty/NVorbis
+	url = https://github.com/ioctlLR/NVorbis.git

--- a/Build/Projects/FrameworkReferences.definition
+++ b/Build/Projects/FrameworkReferences.definition
@@ -17,9 +17,6 @@
     <Service Name="MonoGame.Framework/OpenGLGraphics">
       <Reference Include="System.Drawing" />
       <Binary
-        Name="NVorbis"
-        Path="ThirdParty/Dependencies/NVorbis/NVorbis.dll" />
-      <Binary
         Name="OpenTK"
         Path="ThirdParty/Dependencies/OpenTK.dll" />
     </Service>
@@ -147,9 +144,6 @@
       <Reference Include="System.Web.Services" />
       <Reference Include="System.Windows.Forms" />
       <Reference Include="System.Xml" />
-      <Binary
-        Name="NVorbis"
-        Path="ThirdParty/Dependencies/NVorbis/NVorbis.dll" />
       <Binary
         Name="OpenTK"
         Path="ThirdParty/Dependencies/OpenTK.dll" />

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -78,6 +78,9 @@
     <Uses Name="_XNADesignProvided">
       <Platforms>Windows,WindowsGL,Linux,MacOS</Platforms>
     </Uses>
+    <Uses Name="NVorbis">
+      <Platforms>WindowsGL,Linux</Platforms>
+    </Uses>
     <Uses Name="_FrameworkDispatcherProvided">
       <Platforms>Windows,WindowsGL,MacOS</Platforms>
     </Uses>
@@ -129,6 +132,9 @@
     <Service Name="WebAudio">
       <Platforms>Web</Platforms>
       <Conflicts>OpenALAudio,XAudioAudio</Conflicts>
+    </Service>
+    <Service Name="NVorbis">
+      <Platforms>WindowsGL,Linux</Platforms>
     </Service>
 
     <!-- Base supporting features -->
@@ -1351,6 +1357,107 @@
       <Services>DirectXGraphics</Services>
     </EmbeddedResource>
 
+    <!-- NVorbis -->
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\BufferedReadStream.cs">
+      <Link>Utilities\NVorbis\BufferedReadStream.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\DataPacket.cs">
+      <Link>Utilities\NVorbis\DataPacket.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Huffman.cs">
+      <Link>Utilities\NVorbis\Huffman.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\IContainerReader.cs">
+      <Link>Utilities\NVorbis\IContainerReader.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\IPacketProvider.cs">
+      <Link>Utilities\NVorbis\IPacketProvider.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\IVorbisStreamStatus.cs">
+      <Link>Utilities\NVorbis\IVorbisStreamStatus.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Mdct.cs">
+      <Link>Utilities\NVorbis\Mdct.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\NewStreamEventArgs.cs">
+      <Link>Utilities\NVorbis\NewStreamEventArgs.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\ParameterChangeEventArgs.cs">
+      <Link>Utilities\NVorbis\ParameterChangeEventArgs.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\RingBuffer.cs">
+      <Link>Utilities\NVorbis\RingBuffer.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\StreamReadBuffer.cs">
+      <Link>Utilities\NVorbis\StreamReadBuffer.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Utils.cs">
+      <Link>Utilities\NVorbis\Utils.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisCodebook.cs">
+      <Link>Utilities\NVorbis\VorbisCodebook.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisFloor.cs">
+      <Link>Utilities\NVorbis\VorbisFloor.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisMapping.cs">
+      <Link>Utilities\NVorbis\VorbisMapping.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisMode.cs">
+      <Link>Utilities\NVorbis\VorbisMode.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisReader.cs">
+      <Link>Utilities\NVorbis\VorbisReader.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisResidue.cs">
+      <Link>Utilities\NVorbis\VorbisResidue.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisStreamDecoder.cs">
+      <Link>Utilities\NVorbis\VorbisStreamDecoder.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisTime.cs">
+      <Link>Utilities\NVorbis\VorbisTime.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggContainerReader.cs">
+      <Link>Utilities\NVorbis\Ogg\OggContainerReader.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggCrc.cs">
+      <Link>Utilities\NVorbis\Ogg\OggCrc.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggPacket.cs">
+      <Link>Utilities\NVorbis\Ogg\OggPacket.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggPacketReader.cs">
+      <Link>Utilities\NVorbis\Ogg\OggPacketReader.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggPageFlags.cs">
+      <Link>Utilities\NVorbis\Ogg\OggPageFlags.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
 
   </Files>
 </Project>


### PR DESCRIPTION
So instead of us having an external .dll dependency we could just include the entire NVorbis source code inside. This will allow for the end user to only have to reference MonoGame.Framework.dll and not have to worry about any other dlls.