### PR TITLE
Workaround for converting variable bitrate audio files

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
@@ -27,44 +27,86 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
         /// Gets the raw audio data.
         /// </summary>
         /// <value>If unprocessed, the source data; otherwise, the processed data.</value>
-        public ReadOnlyCollection<byte> Data { get { return data.AsReadOnly(); } }
+        public ReadOnlyCollection<byte> Data
+        {
+            get
+            {
+                return data.AsReadOnly();
+            }
+        }
 
         /// <summary>
         /// Gets the duration (in milliseconds) of the audio data.
         /// </summary>
         /// <value>Duration of the audio data.</value>
-        public TimeSpan Duration { get { return duration; } }
+        public TimeSpan Duration
+        {
+            get
+            {
+                return duration;
+            }
+        }
 
         /// <summary>
         /// Gets the file name containing the audio data.
         /// </summary>
         /// <value>The name of the file containing this data.</value>
         [ContentSerializerAttribute]
-        public string FileName { get { return fileName; } }
+        public string FileName
+        {
+            get
+            {
+                return fileName;
+            }
+        }
 
         /// <summary>
         /// Gets the AudioFileType of this audio source.
         /// </summary>
         /// <value>The AudioFileType of this audio source.</value>
-        public AudioFileType FileType { get { return fileType; } }
+        public AudioFileType FileType
+        {
+            get
+            {
+                return fileType;
+            }
+        }
 
         /// <summary>
         /// Gets the AudioFormat of this audio source.
         /// </summary>
         /// <value>The AudioFormat of this audio source.</value>
-        public AudioFormat Format { get { return format; } }
+        public AudioFormat Format
+        {
+            get
+            {
+                return format;
+            }
+        }
 
         /// <summary>
         /// Gets the loop length, in samples.
         /// </summary>
         /// <value>The number of samples in the loop.</value>
-        public int LoopLength { get { return loopLength; } }
+        public int LoopLength
+        {
+            get
+            {
+                return loopLength;
+            }
+        }
 
         /// <summary>
         /// Gets the loop start, in samples.
         /// </summary>
         /// <value>The number of samples to the start of the loop.</value>
-        public int LoopStart { get { return loopStart; } }
+        public int LoopStart
+        {
+            get
+            {
+                return loopStart;
+            }
+        }
 
         /// <summary>
         /// Initializes a new instance of AudioContent.
@@ -123,7 +165,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
         /// the audio is stored external to the XNB file.  If this is null, then the converted audio is stored in
         /// the Data property.
         /// </param>
-        public void ConvertFormat(ConversionFormat formatType, ConversionQuality quality, string saveToFile)
+        public ConversionQuality ConvertFormat(ConversionFormat formatType, ConversionQuality quality, string saveToFile)
         {
             var temporarySource = Path.GetTempFileName();
             var temporaryOutput = Path.GetTempFileName();
@@ -185,17 +227,25 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
                 }
 
                 string ffmpegStdout, ffmpegStderr;
-                var ffmpegExitCode = ExternalTool.Run(
-                    "ffmpeg",
-                    string.Format(
-                        "-y -i \"{0}\" -vn -c:a {1} -b:a {2} -f:a {3} -strict experimental \"{4}\"",
-                        temporarySource,
-                        ffmpegCodecName,
-                        QualityToBitRate(quality),
-                        ffmpegMuxerName,
-                        temporaryOutput),
-                    out ffmpegStdout,
-                    out ffmpegStderr);
+                int ffmpegExitCode = 0;
+                do
+                {
+                    ffmpegExitCode = ExternalTool.Run(
+                        "ffmpeg",
+                        string.Format(
+                            "-y -i \"{0}\" -vn -c:a {1} -b:a {2} -f:a {3} -strict experimental \"{4}\"",
+                            temporarySource,
+                            ffmpegCodecName,
+                            QualityToBitRate(quality),
+                            ffmpegMuxerName,
+                            temporaryOutput),
+                        out ffmpegStdout,
+                        out ffmpegStderr);
+                    if (ffmpegExitCode != 0)
+                    {
+                        quality--;
+                    }
+                } while (quality >= 0 && ffmpegExitCode!=0);
                 if (ffmpegExitCode != 0)
                 {
                     throw new InvalidOperationException("ffmpeg exited with non-zero exit code: \n" + ffmpegStdout + "\n" + ffmpegStderr);
@@ -310,6 +360,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
                 File.Delete(temporarySource);
                 File.Delete(temporaryOutput);
             }
+            return quality;
         }
 
         private void Read(string filename)
@@ -383,5 +434,5 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
 
             return audioData;
         }
-	}
+    }
 }

--- a/MonoGame.Framework.Content.Pipeline/Processors/SongProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/SongProcessor.cs
@@ -61,10 +61,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             Directory.CreateDirectory(Path.GetDirectoryName(songFileName));
 
             // Convert and write out the song media file.
-            input.ConvertFormat(targetFormat, quality, songFileName);
+            ConversionQuality finalQuality = input.ConvertFormat(targetFormat, quality, songFileName);
 
             // Let the pipeline know about the song file so it can clean things up.
             context.AddOutputFile(songFileName);
+            if (quality != finalQuality)
+                context.Logger.LogMessage("Failed to convert using \"{0}\" quality, used \"{1}\" quality", quality, finalQuality);
 
             // Return the XNB song content.
             return new SongContent(PathHelper.GetRelativePath(Path.GetDirectoryName(context.OutputFilename) + Path.DirectorySeparatorChar, songFileName), input.Duration);

--- a/MonoGame.Framework.Content.Pipeline/Processors/SoundEffectProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/SoundEffectProcessor.cs
@@ -49,14 +49,16 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                     else
                     {
                         // TODO: For some reason this doesn't work on Windows
-                        // so we fallback to plain PCM and depend on the 
+                        // so we fallback to plain PCM and depend on the
                         // bitrate reduction only.
                         //targetFormat = ConversionFormat.Adpcm;
                     }
                     break;
             }
 
-            input.ConvertFormat(targetFormat, quality, null);
+            var finalQuality= input.ConvertFormat(targetFormat, quality, null);
+            if (quality != finalQuality)
+                context.Logger.LogMessage("Failed to convert using \"{0}\" quality, used \"{1}\" quality", quality, finalQuality);
 
             return new SoundEffectContent(input.Format.NativeWaveFormat, input.Data, input.LoopStart, input.LoopLength, (int)input.Duration.TotalMilliseconds);
         }


### PR DESCRIPTION
This fixes #4591 and also fix #4588, at least the original problem.
Basically I have put the call ffmpeg in a loop that tries to convert the file with lower quality each time, if the file can be converted with a lower quality there's a new log message stating it
![audio message](https://cloud.githubusercontent.com/assets/11319966/14845622/aa0d68c8-0c5f-11e6-9e63-e9b975c735d6.PNG)

Changelog:

AudioContent:
- ConvertFormat() now returns the quality used to convert the file.
- ConvertFormat() will keep lowering the quality used to convert the
sound file until the conversion succedes or runs out of possible
qualities, in the latter case still throws the exception

SongProcessor:
- Process(): Updated to receive the used quality, if it is different
from the original adds a log message

SoundEffectProcessor:
- Process(): Updated to receive the used quality, if it is different
from the original adds a log message