### PR TITLE
ADPCM support for SoundEffect

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Audio/AudioContent.cs
@@ -350,10 +350,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Audio
 
                 // Loop start and length in number of samples. Defaults to entire sound
                 loopStart = 0;
-                if (data != null && bitsPerSample > 0 && channelCount > 0)
-                    loopLength = data.Count / ((bitsPerSample / 8) * channelCount);
-                else
-                    loopLength = 0;
+                loopLength = (int)Math.Floor(sampleRate * durationInSeconds);
             }
             finally
             {

--- a/MonoGame.Framework.Content.Pipeline/Processors/SoundEffectProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/SoundEffectProcessor.cs
@@ -47,15 +47,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                     if ((context.TargetPlatform == TargetPlatform.iOS) || (context.TargetPlatform == TargetPlatform.MacOSX))
                         targetFormat = ConversionFormat.ImaAdpcm;
                     else
-                    {
-                        // TODO: For some reason this doesn't work on Windows
-                        // so we fallback to plain PCM and depend on the
-                        // bitrate reduction only.
-                        //targetFormat = ConversionFormat.Adpcm;
-                    }
+                        targetFormat = ConversionFormat.Adpcm;
                     break;
             }
 
+            input.ConvertFormat(targetFormat, quality, null);
             var finalQuality= input.ConvertFormat(targetFormat, quality, null);
             if (quality != finalQuality)
                 context.Logger.LogMessage("Failed to convert using \"{0}\" quality, used \"{1}\" quality", quality, finalQuality);

--- a/MonoGame.Framework.Content.Pipeline/Processors/SoundEffectProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/SoundEffectProcessor.cs
@@ -51,8 +51,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                     break;
             }
 
-            input.ConvertFormat(targetFormat, quality, null);
-            var finalQuality= input.ConvertFormat(targetFormat, quality, null);
+            var finalQuality = input.ConvertFormat(targetFormat, quality, null);
             if (quality != finalQuality)
                 context.Logger.LogMessage("Failed to convert using \"{0}\" quality, used \"{1}\" quality", quality, finalQuality);
 

--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -76,13 +76,13 @@ namespace Microsoft.Xna.Framework.Audio
         /// <param name="buffer">Buffer containing PCM or ADPCM wave data.</param>
         /// <param name="offset">Offset, in bytes, to the starting position of the audio data.</param>
         /// <param name="count">Amount, in bytes, of audio data.</param>
-        /// <param name="duration">Duration of the sound.</param>
+        /// <param name="sampleCount">Number of samples.</param>
         /// <param name="sampleRate">Sample rate, in Hertz (Hz)</param>
         /// <param name="channels">Number of channels (mono or stereo).</param>
         /// <param name="loopStart">The position, in samples, where the audio should begin looping.</param>
         /// <param name="loopLength">The duration, in samples, that audio should loop over.</param>
         /// <remarks>Use SoundEffect.GetSampleDuration() to convert time to samples.</remarks>
-        public SoundEffect(byte[] buffer, int offset, int count, TimeSpan duration, int sampleRate, AudioChannels channels, int loopStart, int loopLength)
+        public SoundEffect(byte[] buffer, int offset, int count, int sampleCount, int sampleRate, AudioChannels channels, int loopStart, int loopLength)
         {
             if (sampleRate < 8000 || sampleRate > 48000)
                 throw new ArgumentOutOfRangeException("sampleRate");
@@ -105,22 +105,20 @@ namespace Microsoft.Xna.Framework.Audio
             if (((ulong)count + (ulong)offset) > (ulong)buffer.Length)
                 throw new ArgumentException("Ensure that the offset+count region lines within the buffer.", "offset");
 
-            var totalSamples = (int)Math.Floor(duration.TotalSeconds * sampleRate);
-
             if (loopStart < 0)
                 throw new ArgumentException("The loopStart cannot be negative.", "loopStart");
-            if (loopStart > totalSamples)
+            if (loopStart > sampleCount)
                 throw new ArgumentException("The loopStart cannot be greater than the total number of samples.", "loopStart");
 
             if (loopLength == 0)
-                loopLength = totalSamples - loopStart;
+                loopLength = sampleCount - loopStart;
 
             if (loopLength < 0)
                 throw new ArgumentException("The loopLength cannot be negative.", "loopLength");
-            if (((ulong)loopStart + (ulong)loopLength) > (ulong)totalSamples)
+            if (((ulong)loopStart + (ulong)loopLength) > (ulong)sampleCount)
                 throw new ArgumentException("Ensure that the loopStart+loopLength region lies within the sample range.", "loopLength");
 
-            _duration = duration;
+            _duration = TimeSpan.FromSeconds((double)sampleCount/sampleRate);
 
             PlatformInitializePCM(buffer, offset, count, sampleRate, channels, loopStart, loopLength);
         }

--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -73,16 +73,15 @@ namespace Microsoft.Xna.Framework.Audio
             PlatformInitializePCM(buffer, 0, buffer.Length, sampleRate, channels, 0, loopLength);
         }
 
-        /// <param name="buffer">Buffer containing PCM or ADPCM wave data.</param>
+        /// <param name="buffer">Buffer containing 16bit PCM wave data.</param>
         /// <param name="offset">Offset, in bytes, to the starting position of the audio data.</param>
         /// <param name="count">Amount, in bytes, of audio data.</param>
-        /// <param name="sampleCount">Number of samples.</param>
         /// <param name="sampleRate">Sample rate, in Hertz (Hz)</param>
         /// <param name="channels">Number of channels (mono or stereo).</param>
         /// <param name="loopStart">The position, in samples, where the audio should begin looping.</param>
         /// <param name="loopLength">The duration, in samples, that audio should loop over.</param>
         /// <remarks>Use SoundEffect.GetSampleDuration() to convert time to samples.</remarks>
-        public SoundEffect(byte[] buffer, int offset, int count, int sampleCount, int sampleRate, AudioChannels channels, int loopStart, int loopLength)
+        public SoundEffect(byte[] buffer, int offset, int count, int sampleRate, AudioChannels channels, int loopStart, int loopLength)
         {
             if (sampleRate < 8000 || sampleRate > 48000)
                 throw new ArgumentOutOfRangeException("sampleRate");
@@ -105,20 +104,22 @@ namespace Microsoft.Xna.Framework.Audio
             if (((ulong)count + (ulong)offset) > (ulong)buffer.Length)
                 throw new ArgumentException("Ensure that the offset+count region lines within the buffer.", "offset");
 
+            var totalSamples = buffer.Length / blockAlign;
+
             if (loopStart < 0)
                 throw new ArgumentException("The loopStart cannot be negative.", "loopStart");
-            if (loopStart > sampleCount)
+            if (loopStart > totalSamples)
                 throw new ArgumentException("The loopStart cannot be greater than the total number of samples.", "loopStart");
 
             if (loopLength == 0)
-                loopLength = sampleCount - loopStart;
+                loopLength = totalSamples - loopStart;
 
             if (loopLength < 0)
                 throw new ArgumentException("The loopLength cannot be negative.", "loopLength");
-            if (((ulong)loopStart + (ulong)loopLength) > (ulong)sampleCount)
+            if (((ulong)loopStart + (ulong)loopLength) > (ulong)totalSamples)
                 throw new ArgumentException("Ensure that the loopStart+loopLength region lies within the sample range.", "loopLength");
 
-            _duration = TimeSpan.FromSeconds((double)sampleCount/sampleRate);
+            _duration = GetSampleDuration(count, sampleRate, channels);
 
             PlatformInitializePCM(buffer, offset, count, sampleRate, channels, loopStart, loopLength);
         }

--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -73,15 +73,16 @@ namespace Microsoft.Xna.Framework.Audio
             PlatformInitializePCM(buffer, 0, buffer.Length, sampleRate, channels, 0, loopLength);
         }
 
-        /// <param name="buffer">Buffer containing 16bit PCM wave data.</param>
+        /// <param name="buffer">Buffer containing PCM or ADPCM wave data.</param>
         /// <param name="offset">Offset, in bytes, to the starting position of the audio data.</param>
         /// <param name="count">Amount, in bytes, of audio data.</param>
+        /// <param name="duration">Duration of the sound.</param>
         /// <param name="sampleRate">Sample rate, in Hertz (Hz)</param>
         /// <param name="channels">Number of channels (mono or stereo).</param>
         /// <param name="loopStart">The position, in samples, where the audio should begin looping.</param>
         /// <param name="loopLength">The duration, in samples, that audio should loop over.</param>
         /// <remarks>Use SoundEffect.GetSampleDuration() to convert time to samples.</remarks>
-        public SoundEffect(byte[] buffer, int offset, int count, int sampleRate, AudioChannels channels, int loopStart, int loopLength)
+        public SoundEffect(byte[] buffer, int offset, int count, TimeSpan duration, int sampleRate, AudioChannels channels, int loopStart, int loopLength)
         {
             if (sampleRate < 8000 || sampleRate > 48000)
                 throw new ArgumentOutOfRangeException("sampleRate");
@@ -104,7 +105,7 @@ namespace Microsoft.Xna.Framework.Audio
             if (((ulong)count + (ulong)offset) > (ulong)buffer.Length)
                 throw new ArgumentException("Ensure that the offset+count region lines within the buffer.", "offset");
 
-            var totalSamples = buffer.Length / blockAlign;
+            var totalSamples = (int)Math.Floor(duration.TotalSeconds * sampleRate);
 
             if (loopStart < 0)
                 throw new ArgumentException("The loopStart cannot be negative.", "loopStart");
@@ -119,7 +120,7 @@ namespace Microsoft.Xna.Framework.Audio
             if (((ulong)loopStart + (ulong)loopLength) > (ulong)totalSamples)
                 throw new ArgumentException("Ensure that the loopStart+loopLength region lies within the sample range.", "loopLength");
 
-            _duration = GetSampleDuration(count, sampleRate, channels);
+            _duration = duration;
 
             PlatformInitializePCM(buffer, offset, count, sampleRate, channels, loopStart, loopLength);
         }

--- a/MonoGame.Framework/Audio/Xact/WaveBank.cs
+++ b/MonoGame.Framework/Audio/Xact/WaveBank.cs
@@ -306,15 +306,16 @@ namespace Microsoft.Xna.Framework.Audio
                 byte[] audiodata = reader.ReadBytes(wavebankentry.PlayRegion.Length);
                 
                 if (codec == MiniFormatTag_PCM) {
-                    
+
                     //write PCM data into a wav
 #if DIRECTX
-                    
+                    TimeSpan duration = SoundEffect.GetSampleDuration(audiodata.Length, rate, (AudioChannels)chans);
+
                     // TODO: Wouldn't storing a SoundEffectInstance like this
                     // result in the "parent" SoundEffect being garbage collected?
-                    
-					SharpDX.Multimedia.WaveFormat waveFormat = new SharpDX.Multimedia.WaveFormat(rate, chans);
-                    var sfx = new SoundEffect(audiodata, 0, audiodata.Length, rate, (AudioChannels)chans, wavebankentry.LoopRegion.Offset, wavebankentry.LoopRegion.Length)
+
+                    SharpDX.Multimedia.WaveFormat waveFormat = new SharpDX.Multimedia.WaveFormat(rate, chans);
+                    var sfx = new SoundEffect(audiodata, 0, audiodata.Length, duration, rate, (AudioChannels)chans, wavebankentry.LoopRegion.Offset, wavebankentry.LoopRegion.Length)
                         {
                             _format = waveFormat
                         };

--- a/MonoGame.Framework/Audio/Xact/WaveBank.cs
+++ b/MonoGame.Framework/Audio/Xact/WaveBank.cs
@@ -309,13 +309,11 @@ namespace Microsoft.Xna.Framework.Audio
 
                     //write PCM data into a wav
 #if DIRECTX
-                    int sampleCount = audiodata.Length / (chans * 16 / 8);
-
                     // TODO: Wouldn't storing a SoundEffectInstance like this
                     // result in the "parent" SoundEffect being garbage collected?
 
                     SharpDX.Multimedia.WaveFormat waveFormat = new SharpDX.Multimedia.WaveFormat(rate, chans);
-                    var sfx = new SoundEffect(audiodata, 0, audiodata.Length, sampleCount, rate, (AudioChannels)chans, wavebankentry.LoopRegion.Offset, wavebankentry.LoopRegion.Length)
+                    var sfx = new SoundEffect(audiodata, 0, audiodata.Length, rate, (AudioChannels)chans, wavebankentry.LoopRegion.Offset, wavebankentry.LoopRegion.Length)
                         {
                             _format = waveFormat
                         };
@@ -387,7 +385,9 @@ namespace Microsoft.Xna.Framework.Audio
                 else if (codec == MiniFormatTag_ADPCM) 
                 {
 #if DIRECTX
-                    _sounds[current_entry] = new SoundEffect(audiodata, rate, (AudioChannels)chans)
+                    // TODO not sure if this is the right way to calculate the duration
+                    int durationMs = 1000 * wavebankentry.LoopRegion.Length / rate;
+                    _sounds[current_entry] = new SoundEffect(audiodata, 0x0002 /*ADPCM*/, rate, chans, align, durationMs, wavebankentry.LoopRegion.Offset, wavebankentry.LoopRegion.Length)
                     {
                         _format = new SharpDX.Multimedia.WaveFormatAdpcm(rate, chans, align)
                     };

--- a/MonoGame.Framework/Audio/Xact/WaveBank.cs
+++ b/MonoGame.Framework/Audio/Xact/WaveBank.cs
@@ -309,13 +309,13 @@ namespace Microsoft.Xna.Framework.Audio
 
                     //write PCM data into a wav
 #if DIRECTX
-                    TimeSpan duration = SoundEffect.GetSampleDuration(audiodata.Length, rate, (AudioChannels)chans);
+                    int sampleCount = audiodata.Length / (chans * 16 / 8);
 
                     // TODO: Wouldn't storing a SoundEffectInstance like this
                     // result in the "parent" SoundEffect being garbage collected?
 
                     SharpDX.Multimedia.WaveFormat waveFormat = new SharpDX.Multimedia.WaveFormat(rate, chans);
-                    var sfx = new SoundEffect(audiodata, 0, audiodata.Length, duration, rate, (AudioChannels)chans, wavebankentry.LoopRegion.Offset, wavebankentry.LoopRegion.Length)
+                    var sfx = new SoundEffect(audiodata, 0, audiodata.Length, sampleCount, rate, (AudioChannels)chans, wavebankentry.LoopRegion.Offset, wavebankentry.LoopRegion.Length)
                         {
                             _format = waveFormat
                         };

--- a/MonoGame.Framework/Content/ContentReaders/SoundEffectReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/SoundEffectReader.cs
@@ -45,6 +45,8 @@ namespace Microsoft.Xna.Framework.Content
             //var avgBPS = (int)BitConverter.ToUInt16(header, 8);
             var blockAlignment = (int)BitConverter.ToUInt16(header, 12);
             //var bps = (int)BitConverter.ToUInt16(header, 14);
+            // used to be calculated based on bps. This works for ADPCM, too
+            TimeSpan duration = TimeSpan.FromSeconds((float)loopLength / sampleRate);
 
             // Initialize the effect.
             var effect = new SoundEffect(data, format, sampleRate, channels, blockAlignment, durationMs, loopStart, loopLength);


### PR DESCRIPTION
Fixes the calculation of loopLength for ADPCM sound files

What this pull request is missing (from my point of view) is a clear distinction between the SoundEffect constructor that supports ADPCM and the one that doesn't.