### PR TITLE
Fix PlatformGetData

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -158,14 +158,13 @@ namespace Microsoft.Xna.Framework.Graphics
                         {
                             // Some drivers may add pitch to rows.
                             // We need to copy each row separatly and skip trailing zeros.
-                            stream.Seek(startIndex, SeekOrigin.Begin);
+                            stream.Seek(0, SeekOrigin.Begin);
 
                             int elementSizeInByte = Marshal.SizeOf(typeof(T));
                             for (var row = 0; row < rows; row++)
                             {
                                 int i;
                                 for (i = row * rowSize / elementSizeInByte; i < (row + 1) * rowSize / elementSizeInByte; i++)
-                                    data[i] = stream.Read<T>();
                                     data[i + startIndex] = stream.Read<T>();
 
                                 if (i >= elementCount)

--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -166,6 +166,7 @@ namespace Microsoft.Xna.Framework.Graphics
                                 int i;
                                 for (i = row * rowSize / elementSizeInByte; i < (row + 1) * rowSize / elementSizeInByte; i++)
                                     data[i] = stream.Read<T>();
+                                    data[i + startIndex] = stream.Read<T>();
 
                                 if (i >= elementCount)
                                     break;

--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new ArgumentException("The data passed has a length of " + data.Length + " but " + elementCount + " pixels have been requested.");
             if (arraySlice > 0 && !GraphicsDevice.GraphicsCapabilities.SupportsTextureArrays)
                 throw new ArgumentException("Texture arrays are not supported on this graphics device", "arraySlice");
-
+                throw new ArgumentException("The size of the data passed in is too large or too small for this resource");
             PlatformGetData<T>(level, arraySlice, rect, data, startIndex, elementCount);
         }
         /// <summary>

--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -194,6 +194,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new ArgumentException("The data passed has a length of " + data.Length + " but " + elementCount + " pixels have been requested.");
             if (arraySlice > 0 && !GraphicsDevice.GraphicsCapabilities.SupportsTextureArrays)
                 throw new ArgumentException("Texture arrays are not supported on this graphics device", "arraySlice");
+            if (rect.HasValue && rect.Value.Width * rect.Value.Height != elementCount)
                 throw new ArgumentException("The size of the data passed in is too large or too small for this resource");
             PlatformGetData<T>(level, arraySlice, rect, data, startIndex, elementCount);
         }

--- a/Test/Framework/Texture2DNonVisualTest.cs
+++ b/Test/Framework/Texture2DNonVisualTest.cs
@@ -77,6 +77,49 @@ namespace MonoGame.Tests.Framework
                 Assert.Throws<InvalidOperationException>(() => _texture = Texture2D.FromStream(_game.GraphicsDevice, reader.BaseStream));
             }
         }
+        [TestCase(25, 23, 1, 1, 0, 1)]
+        [TestCase(25, 23, 1, 1, 1, 1)]
+        [TestCase(25, 23, 2, 1, 0, 2)]
+        [TestCase(25, 23, 2, 1, 1, 2)]
+        [TestCase(25, 23, 1, 2, 0, 2)]
+        [TestCase(25, 23, 1, 2, 1, 2)]
+        [TestCase(25, 23, 2, 2, 0, 4)]
+        [TestCase(25, 23, 2, 2, 1, 4)]
+
+        public void PlatformGetDataWithOffsetTest(int rx, int ry, int rw, int rh, int startIndex, int elementsToRead)
+        {
+            using (System.IO.StreamReader reader = new System.IO.StreamReader("Assets/Textures/LogoOnly_64px.png"))
+            {
+                Rectangle toReadArea = new Rectangle(rx, ry, rw, rh);
+                Texture2D t = Texture2D.FromStream(_game.GraphicsDevice, reader.BaseStream);
+                Color[] colors = new Color[startIndex + elementsToRead];
+                for (int i = 0; i < colors.Length; i++)
+                {
+                    colors[i] = Color.White;
+                }
+                t.GetData(0, toReadArea, colors, startIndex, elementsToRead);
+                for (int i = 0; i < elementsToRead; i++)
+                {
+                    Assert.AreNotEqual(255, colors[i + startIndex].R, "colors was not overwritten in position {0}", startIndex + i);
+                }
+            }
+        }
+        [TestCase(25, 23, 2, 2, 0, 2)]
+        [TestCase(25, 23, 2, 2, 1, 2)]
+        public void GetDataException(int rx, int ry, int rw, int rh, int startIndex, int elementsToRead)
+        {
+            using (System.IO.StreamReader reader = new System.IO.StreamReader("Assets/Textures/LogoOnly_64px.png"))
+            {
+                Rectangle toReadArea = new Rectangle(rx, ry, rw, rh);
+                Texture2D t = Texture2D.FromStream(_game.GraphicsDevice, reader.BaseStream);
+                Color[] colors = new Color[startIndex + elementsToRead];
+                for (int i = 0; i < colors.Length; i++)
+                {
+                    colors[i] = Color.White;
+                }
+                Assert.Throws<ArgumentException>(() => t.GetData(0, toReadArea, colors, startIndex, elementsToRead));
+            }
+        }
         [TestFixtureTearDown]
         public void TearDown()
         {


### PR DESCRIPTION
Implement the tests that demonstrate the bug stated in #4832.
While readying the test found another difference compared to XNA and added another test for that: XNA throws an `ArgumentException` if the `elementCount` parameter is less than the area of the `Rectangle` from where to get the Texture data.