### PR TITLE
SetRenderTarget garbage reduction

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private readonly RenderTargetBinding[] _currentRenderTargetBindings = new RenderTargetBinding[4];
         private int _currentRenderTargetCount;
+        private readonly RenderTargetBinding[] _tempRenderTargetBinding = new RenderTargetBinding[1];
 
         internal GraphicsCapabilities GraphicsCapabilities { get; private set; }
 
@@ -655,17 +656,27 @@ namespace Microsoft.Xna.Framework.Graphics
 		public void SetRenderTarget(RenderTarget2D renderTarget)
 		{
 			if (renderTarget == null)
+		    {
                 SetRenderTargets(null);
+		    }
 			else
-				SetRenderTargets(new RenderTargetBinding(renderTarget));
+			{
+				_tempRenderTargetBinding[0] = new RenderTargetBinding(renderTarget);
+				SetRenderTargets(_tempRenderTargetBinding);
+			}
 		}
 
         public void SetRenderTarget(RenderTargetCube renderTarget, CubeMapFace cubeMapFace)
         {
             if (renderTarget == null)
-                SetRenderTarget(null);
+            {
+                SetRenderTargets(null);
+            }
             else
-                SetRenderTargets(new RenderTargetBinding(renderTarget, cubeMapFace));
+            {
+                _tempRenderTargetBinding[0] = new RenderTargetBinding(renderTarget, cubeMapFace);
+                SetRenderTargets(_tempRenderTargetBinding);
+            }
         }
 
 		public void SetRenderTargets(params RenderTargetBinding[] renderTargets)


### PR DESCRIPTION
Resolves #4843 as per @KonajuGames advice

Also fixes a little typo in `SetRenderTarget(RenderTargetCube)` where it called `SetRenderTarget(RenderTarget2D)` instead of `SetRenderTargets` when the render target was null. It still actually worked, it just meant that it went through another unnecessary method call to get there.