### PR TITLE
Added support for KeyDown/Up to the GameWindow.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "ThirdParty/Dependencies"]
 	path = ThirdParty/Dependencies
 	url = https://github.com/Mono-Game/MonoGame.Dependencies.git
+[submodule "ThirdParty/NVorbis"]
+	path = ThirdParty/NVorbis
+	url = https://github.com/ioctlLR/NVorbis.git

--- a/Build/Projects/FrameworkReferences.definition
+++ b/Build/Projects/FrameworkReferences.definition
@@ -20,9 +20,6 @@
     <Service Name="MonoGame.Framework/OpenGLGraphics">
       <Reference Include="System.Drawing" />
       <Binary
-        Name="NVorbis"
-        Path="ThirdParty/Dependencies/NVorbis/NVorbis.dll" />
-      <Binary
         Name="OpenTK"
         Path="ThirdParty/Dependencies/OpenTK.dll" />
     </Service>
@@ -150,9 +147,6 @@
       <Reference Include="System.Web.Services" />
       <Reference Include="System.Windows.Forms" />
       <Reference Include="System.Xml" />
-      <Binary
-        Name="NVorbis"
-        Path="ThirdParty/Dependencies/NVorbis/NVorbis.dll" />
       <Binary
         Name="OpenTK"
         Path="ThirdParty/Dependencies/OpenTK.dll" />

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -285,6 +285,9 @@
     <Compile Include="TextInputEventArgs.cs">
       <Platforms>Angle,Linux,MacOS,Windows,WindowsGL,WindowsUniversal</Platforms>
     </Compile>
+    <Compile Include="KeyInputEventArgs.cs">
+      <Platforms>Angle,Linux,MacOS,Windows,WindowsGL,WindowsUniversal</Platforms>
+    </Compile>
     <Compile Include="Threading.cs">
       <Platforms>Android,Angle,iOS,Linux,MacOS,Ouya,WindowsGL,WindowsPhone,tvOS</Platforms>
     </Compile>

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -78,6 +78,9 @@
     <Uses Name="_XNADesignProvided">
       <Platforms>Windows,WindowsGL,Linux,MacOS</Platforms>
     </Uses>
+    <Uses Name="NVorbis">
+      <Platforms>WindowsGL,Linux</Platforms>
+    </Uses>
     <Uses Name="_FrameworkDispatcherProvided">
       <Platforms>Windows,WindowsGL,MacOS</Platforms>
     </Uses>
@@ -129,6 +132,9 @@
     <Service Name="WebAudio">
       <Platforms>Web</Platforms>
       <Conflicts>OpenALAudio,XAudioAudio</Conflicts>
+    </Service>
+    <Service Name="NVorbis">
+      <Platforms>WindowsGL,Linux</Platforms>
     </Service>
 
     <!-- Base supporting features -->
@@ -1389,6 +1395,107 @@
       <Services>DirectXGraphics</Services>
     </EmbeddedResource>
 
+    <!-- NVorbis -->
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\BufferedReadStream.cs">
+      <Link>Utilities\NVorbis\BufferedReadStream.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\DataPacket.cs">
+      <Link>Utilities\NVorbis\DataPacket.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Huffman.cs">
+      <Link>Utilities\NVorbis\Huffman.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\IContainerReader.cs">
+      <Link>Utilities\NVorbis\IContainerReader.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\IPacketProvider.cs">
+      <Link>Utilities\NVorbis\IPacketProvider.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\IVorbisStreamStatus.cs">
+      <Link>Utilities\NVorbis\IVorbisStreamStatus.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Mdct.cs">
+      <Link>Utilities\NVorbis\Mdct.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\NewStreamEventArgs.cs">
+      <Link>Utilities\NVorbis\NewStreamEventArgs.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\ParameterChangeEventArgs.cs">
+      <Link>Utilities\NVorbis\ParameterChangeEventArgs.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\RingBuffer.cs">
+      <Link>Utilities\NVorbis\RingBuffer.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\StreamReadBuffer.cs">
+      <Link>Utilities\NVorbis\StreamReadBuffer.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Utils.cs">
+      <Link>Utilities\NVorbis\Utils.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisCodebook.cs">
+      <Link>Utilities\NVorbis\VorbisCodebook.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisFloor.cs">
+      <Link>Utilities\NVorbis\VorbisFloor.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisMapping.cs">
+      <Link>Utilities\NVorbis\VorbisMapping.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisMode.cs">
+      <Link>Utilities\NVorbis\VorbisMode.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisReader.cs">
+      <Link>Utilities\NVorbis\VorbisReader.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisResidue.cs">
+      <Link>Utilities\NVorbis\VorbisResidue.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisStreamDecoder.cs">
+      <Link>Utilities\NVorbis\VorbisStreamDecoder.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\VorbisTime.cs">
+      <Link>Utilities\NVorbis\VorbisTime.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggContainerReader.cs">
+      <Link>Utilities\NVorbis\Ogg\OggContainerReader.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggCrc.cs">
+      <Link>Utilities\NVorbis\Ogg\OggCrc.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggPacket.cs">
+      <Link>Utilities\NVorbis\Ogg\OggPacket.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggPacketReader.cs">
+      <Link>Utilities\NVorbis\Ogg\OggPacketReader.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
+    <Compile Include="..\ThirdParty\NVorbis\NVorbis\Ogg\OggPageFlags.cs">
+      <Link>Utilities\NVorbis\Ogg\OggPageFlags.cs</Link>
+      <Services>NVorbis</Services>
+    </Compile>
 
   </Files>
 </Project>

--- a/MonoGame.Framework.Content.Pipeline/Graphics/VertexChannelNames.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/VertexChannelNames.cs
@@ -76,8 +76,14 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             string baseName = DecodeBaseName(encodedName);
             if (string.IsNullOrEmpty(baseName))
                 throw new InvalidOperationException("encodedName");
-            // Subtract the base name from the string and convert the remainder to an integer
-            return Int32.Parse(encodedName.Substring(baseName.Length), CultureInfo.InvariantCulture);
+
+            // Subtract the base name from the string and convert the remainder to an integer.
+            // TryParse solves the problem when name is just 'BlendIndicies' for example, in 
+            // which case we default to index 0, assuming only 1 index.
+            int index = 0;
+            int.TryParse(encodedName.Substring(baseName.Length), NumberStyles.Integer, CultureInfo.InvariantCulture, out index);
+
+            return index;
         }
 
         /// <summary>

--- a/MonoGame.Framework/Audio/SoundEffect.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Xna.Framework.Audio
 {
     /// <summary>Represents a loaded sound resource.</summary>
     /// <remarks>
-    /// <para>A SoundEffect represents the buffer used to hold audio data and metadata. SoundEffectInstances are used to play from SoundEffects. Multiple SoundEffectinstance objects can be created and played from the same SoundEffect object.</para>
+    /// <para>A SoundEffect represents the buffer used to hold audio data and metadata. SoundEffectInstances are used to play from SoundEffects. Multiple SoundEffectInstance objects can be created and played from the same SoundEffect object.</para>
     /// <para>The only limit on the number of loaded SoundEffects is restricted by available memory. When a SoundEffect is disposed, all SoundEffectInstances created from it will become invalid.</para>
     /// <para>SoundEffect.Play() can be used for 'fire and forget' sounds. If advanced playback controls like volume or pitch is required, use SoundEffect.CreateInstance().</para>
     /// </remarks>

--- a/MonoGame.Framework/Audio/Xact/Cue.cs
+++ b/MonoGame.Framework/Audio/Xact/Cue.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Xna.Framework.Audio
         }
 		
 		
-		/// <summary>Indicateds whether or not the object has been disposed.</summary>
+		/// <summary>Indicates whether or not the object has been disposed.</summary>
 		public bool IsDisposed { get { return false; } }
 		
 		#region IDisposable implementation

--- a/MonoGame.Framework/GameWindow.cs
+++ b/MonoGame.Framework/GameWindow.cs
@@ -100,8 +100,35 @@ namespace Microsoft.Xna.Framework {
 		/// </summary>
 		/// <remarks>
 		/// This event is only supported on the Windows DirectX, Windows OpenGL and Linux platforms.
-		/// </remarks>
+		/// It should only be used to handle input for Textboxes it does not replace Keyboard.GetState
+        /// </remarks>
 		public event EventHandler<TextInputEventArgs> TextInput;
+        /// <summary>
+        /// Use this event to get notified when a Key is Pressed.
+        /// This event should be used in conjuciton with the TextInput event
+        /// to handle draw Text Input and NOT as a replacement for 
+        /// Keyboard.GetState. The TextInput event is raised for character
+        /// keys only. In order to support keys like Backspace, Tab and Enter
+        /// you will need to use this event. 
+        /// </summary>
+        /// <remarks>
+        /// This event is only supported on the Windows DirectX, Windows OpenGL and Linux platforms.
+        /// It should only be used to handle input for Textboxes it does not replace Keyboard.GetState
+        /// </remarks>
+        public event EventHandler<KeyInputEventArgs> KeyDown;
+        /// <summary>
+        /// Use this event to get notified when a Key is Released.
+        /// This event should be used in conjuciton with the TextInput event
+        /// to handle draw Text Input and NOT as a replacement for 
+        /// Keyboard.GetState. The TextInput event is raised for character
+        /// keys only. In order to support keys like Backspace, Tab and Enter
+        /// you will need to use this event. 
+        /// </summary>
+        /// <remarks>
+        /// This event is only supported on the Windows DirectX, Windows OpenGL and Linux platforms.
+        /// It should only be used to handle input for Textboxes it does not replace Keyboard.GetState
+        /// </remarks>
+        public event EventHandler<KeyInputEventArgs> KeyUp;
 #endif
 
 		#endregion Events
@@ -152,6 +179,18 @@ namespace Microsoft.Xna.Framework {
 			if (TextInput != null)
 				TextInput(sender, e);
 		}
+
+        protected void OnKeyDown (object sender, KeyInputEventArgs e)
+        {
+            if (KeyDown != null)
+                KeyDown (sender, e);
+        }
+
+        protected void OnKeyUp (object sender, KeyInputEventArgs e)
+        {
+            if (KeyUp != null)
+                KeyUp (sender, e);
+        }
 #endif
 
 		protected internal abstract void SetSupportedOrientations (DisplayOrientation orientations);

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -631,8 +631,11 @@ namespace Microsoft.Xna.Framework.Graphics
                     this.framebufferHelper.BindFramebuffer(glResolveFramebuffer);
                 }
                 // The only fragment operations which affect the resolve are the pixel ownership test, the scissor test, and dithering.
-                GL.Disable(EnableCap.ScissorTest);
-                GraphicsExtensions.CheckGLError();
+                if (this._lastDepthStencilState.StencilEnable)
+                {
+                    GL.Disable(EnableCap.ScissorTest);
+                    GraphicsExtensions.CheckGLError();
+                }
                 var glFramebuffer = this.glFramebuffers[this._currentRenderTargetBindings];
                 this.framebufferHelper.BindReadFramebuffer(glFramebuffer);
                 for (var i = 0; i < this._currentRenderTargetCount; ++i)
@@ -643,7 +646,11 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
                 if (renderTarget.RenderTargetUsage == RenderTargetUsage.DiscardContents && this.framebufferHelper.SupportsInvalidateFramebuffer)
                     this.framebufferHelper.InvalidateReadFramebuffer();
-                this._depthStencilStateDirty = true;
+                if (this._lastDepthStencilState.StencilEnable)
+                {
+                    GL.Enable(EnableCap.ScissorTest);
+                    GraphicsExtensions.CheckGLError();
+                }
             }
             for (var i = 0; i < this._currentRenderTargetCount; ++i)
             {

--- a/MonoGame.Framework/Input/GamePad.UWP.cs
+++ b/MonoGame.Framework/Input/GamePad.UWP.cs
@@ -92,6 +92,14 @@ namespace Microsoft.Xna.Framework.Input
                 (state.Buttons.HasFlag(WGI.GamepadButtons.X) ? Buttons.X : 0) |
                 (state.Buttons.HasFlag(WGI.GamepadButtons.Y) ? Buttons.Y : 0) |
                 0;
+
+            // Check triggers
+            const double triggerThreshold = 0.1;
+            if (triggers.Left > triggerThreshold)
+                buttonStates |= Buttons.LeftTrigger;
+            if (triggers.Right > triggerThreshold)
+                buttonStates |= Buttons.RightTrigger;
+
             var buttons = new GamePadButtons(buttonStates);
 
             var dpad = new GamePadDPad(

--- a/MonoGame.Framework/Input/GamePad.UWP.cs
+++ b/MonoGame.Framework/Input/GamePad.UWP.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Xna.Framework.Input
     {
         /// <summary>
         /// Attempts to mimic SharpDX.XInput.Gamepad which defines the trigger threshold as 30 with a range of 0 to 255. 
-        /// We trigger here has a range of 0.0 to 1.0. So, 30 / 255 = 0.11765.
+        /// The trigger here has a range of 0.0 to 1.0. So, 30 / 255 = 0.11765.
         /// </summary>
         private const double TriggerThreshold = 0.11765;
 

--- a/MonoGame.Framework/Input/GamePad.UWP.cs
+++ b/MonoGame.Framework/Input/GamePad.UWP.cs
@@ -9,10 +9,8 @@ namespace Microsoft.Xna.Framework.Input
 {
     static partial class GamePad
     {
-        /// <summary>
-        /// Attempts to mimic SharpDX.XInput.Gamepad which defines the trigger threshold as 30 with a range of 0 to 255. 
-        /// The trigger here has a range of 0.0 to 1.0. So, 30 / 255 = 0.11765.
-        /// </summary>
+        // Attempts to mimic SharpDX.XInput.Gamepad which defines the trigger threshold as 30 with a range of 0 to 255. 
+        // The trigger here has a range of 0.0 to 1.0. So, 30 / 255 = 0.11765.
         private const double TriggerThreshold = 0.11765;
 
         internal static bool Back;

--- a/MonoGame.Framework/Input/GamePad.UWP.cs
+++ b/MonoGame.Framework/Input/GamePad.UWP.cs
@@ -9,6 +9,12 @@ namespace Microsoft.Xna.Framework.Input
 {
     static partial class GamePad
     {
+        /// <summary>
+        /// Attempts to mimic SharpDX.XInput.Gamepad which defines the trigger threshold as 30 with a range of 0 to 255. 
+        /// We trigger here has a range of 0.0 to 1.0. So, 30 / 255 = 0.11765.
+        /// </summary>
+        private const double triggerThreshold = 0.11765;
+
         internal static bool Back;
 
         private static int PlatformGetMaxNumberOfGamePads()
@@ -94,7 +100,6 @@ namespace Microsoft.Xna.Framework.Input
                 0;
 
             // Check triggers
-            const double triggerThreshold = 0.1;
             if (triggers.Left > triggerThreshold)
                 buttonStates |= Buttons.LeftTrigger;
             if (triggers.Right > triggerThreshold)

--- a/MonoGame.Framework/Input/GamePad.UWP.cs
+++ b/MonoGame.Framework/Input/GamePad.UWP.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Xna.Framework.Input
         /// Attempts to mimic SharpDX.XInput.Gamepad which defines the trigger threshold as 30 with a range of 0 to 255. 
         /// We trigger here has a range of 0.0 to 1.0. So, 30 / 255 = 0.11765.
         /// </summary>
-        private const double triggerThreshold = 0.11765;
+        private const double TriggerThreshold = 0.11765;
 
         internal static bool Back;
 
@@ -100,9 +100,9 @@ namespace Microsoft.Xna.Framework.Input
                 0;
 
             // Check triggers
-            if (triggers.Left > triggerThreshold)
+            if (triggers.Left > TriggerThreshold)
                 buttonStates |= Buttons.LeftTrigger;
-            if (triggers.Right > triggerThreshold)
+            if (triggers.Right > TriggerThreshold)
                 buttonStates |= Buttons.RightTrigger;
 
             var buttons = new GamePadButtons(buttonStates);

--- a/MonoGame.Framework/Input/Mouse.SDL.cs
+++ b/MonoGame.Framework/Input/Mouse.SDL.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Xna.Framework.Input
                     Sdl.Mouse.GetState(out x, out y);
             var clientBounds = window.ClientBounds;
 
-            if (clientBounds.Contains(x, y) && winFlags.HasFlag(Sdl.Window.State.MouseFocus))
+            if (winFlags.HasFlag(Sdl.Window.State.MouseFocus))
             {
                 window.MouseState.LeftButton = (state.HasFlag(Sdl.Mouse.Button.Left)) ? ButtonState.Pressed : ButtonState.Released;
                 window.MouseState.MiddleButton = (state.HasFlag(Sdl.Mouse.Button.Middle)) ? ButtonState.Pressed : ButtonState.Released;

--- a/MonoGame.Framework/KeyInputEventArgs.cs
+++ b/MonoGame.Framework/KeyInputEventArgs.cs
@@ -1,0 +1,20 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using Microsoft.Xna.Framework.Input;
+
+namespace Microsoft.Xna.Framework
+{
+    public class KeyInputEventArgs : EventArgs
+    {
+        public KeyInputEventArgs (Keys key)
+        {
+            this.Key = key;
+        }
+
+        public Keys Key { get; private set; }
+    }
+}
+

--- a/MonoGame.Framework/SDL/SDL2.cs
+++ b/MonoGame.Framework/SDL/SDL2.cs
@@ -255,6 +255,9 @@ internal static class Sdl
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_SetWindowPosition")]
         public static extern void SetPosition(IntPtr window, int x, int y);
 
+        [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_SetWindowResizable")]
+        public static extern void SetResizable(IntPtr window, bool resizable);
+
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_SetWindowSize")]
         public static extern void SetSize(IntPtr window, int w, int h);
 

--- a/MonoGame.Framework/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/SDL/SDLGamePlatform.cs
@@ -39,17 +39,28 @@ namespace Microsoft.Xna.Framework
             Sdl.Minor = sversion.Minor;
             Sdl.Patch = sversion.Patch;
 
+            try
+            {
+                // HACK: The current development version of SDL
+                // returns 2.0.4, to check SDL version we simply
+                // need to try and execute a function that's only
+                // available in the newer version of it.
+                Sdl.Window.SetResizable(IntPtr.Zero, false);
+                Sdl.Patch = 5;
+            }
+            catch { }
+
             var version = 100 * Sdl.Major + 10 * Sdl.Minor + Sdl.Patch;
 
             if (version <= 204)
                 Debug.WriteLine ("Please use SDL 2.0.5 or higher.");
 
-            Sdl.Init((int) (
+            Sdl.Init((int)(
                 Sdl.InitFlags.Video |
                 Sdl.InitFlags.Joystick |
                 Sdl.InitFlags.GameController |
                 Sdl.InitFlags.Haptic
-                ));
+            ));
 
             Sdl.DisableScreenSaver();
 

--- a/MonoGame.Framework/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/SDL/SDLGamePlatform.cs
@@ -112,13 +112,16 @@ namespace Microsoft.Xna.Framework
                 {
                     var key = KeyboardUtil.ToXna(ev.Key.Keysym.Sym);
 
-                    if (!_keys.Contains(key))
-                        _keys.Add(key);
+                    if (!_keys.Contains (key)) {
+                        _keys.Add (key);
+                        _view.CallKeyDown (key);
+                    }
                 }
                 else if (ev.Type == Sdl.EventType.KeyUp)
                 {
                     var key = KeyboardUtil.ToXna(ev.Key.Keysym.Sym);
                     _keys.Remove(key);
+                    _view.CallKeyUp (key);
                 }
                 else if (ev.Type == Sdl.EventType.TextInput)
                 {

--- a/MonoGame.Framework/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/SDL/SDLGameWindow.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Reflection;
 using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
 
 namespace Microsoft.Xna.Framework
 {
@@ -267,6 +268,16 @@ namespace Microsoft.Xna.Framework
         public void CallTextInput(char c)
         {
             OnTextInput(this, new TextInputEventArgs(c));
+        }
+
+        public void CallKeyDown(Keys key)
+        {
+            OnKeyDown(this, new KeyInputEventArgs(key));
+        }
+
+        public void CallKeyUp(Keys key)
+        {
+            OnKeyUp(this, new KeyInputEventArgs(key));
         }
 
         protected internal override void SetSupportedOrientations(DisplayOrientation orientations)

--- a/MonoGame.Framework/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/SDL/SDLGameWindow.cs
@@ -18,7 +18,12 @@ namespace Microsoft.Xna.Framework
             set
             {
                 if (_init)
-                    throw new Exception("SDL does not support changing resizable parameter of the window after it's already been created.");
+                {
+                    if (Sdl.Patch > 4)
+                        Sdl.Window.SetResizable(_handle, value);
+                    else
+                        throw new Exception("SDL does not support changing resizable parameter of the window after it's already been created.");
+                }
 
                 _resizable = value;
             }
@@ -237,11 +242,11 @@ namespace Microsoft.Xna.Framework
                 centerY = displayRect.Y + displayRect.Height / 2 - clientHeight / 2;
             }
 
-            // If this window is resizable, there is a bug in SDL where
+            // If this window is resizable, there is a bug in SDL 2.0.4 where
             // after the window gets resized, window position information
             // becomes wrong (for me it always returned 10 8). Solution is
             // to not try and set the window position because it will be wrong.
-            if (!AllowUserResizing)
+            if (Sdl.Patch > 4 || !AllowUserResizing)
                 Sdl.Window.SetPosition(Handle, centerX, centerY);
 
             IsFullScreen = _willBeFullScreen;

--- a/MonoGame.Framework/Utilities/Deflate/ZlibStream.cs
+++ b/MonoGame.Framework/Utilities/Deflate/ZlibStream.cs
@@ -44,7 +44,7 @@ namespace MonoGame.Utilities.Deflate
     /// </para>
     ///
     /// <para> Using this stream, applications can compress or decompress data via
-    /// stream <c>Read()</c> and <c>Write()</c> operations.  Either compresssion or
+    /// stream <c>Read()</c> and <c>Write()</c> operations.  Either compression or
     /// decompression can occur through either reading or writing. The compression
     /// format used is ZLIB, which is documented in <see
     /// href="http://www.ietf.org/rfc/rfc1950.txt">IETF RFC 1950</see>, "ZLIB Compressed

--- a/MonoGame.Framework/Utilities/ZLibStream/ZlibStream.cs
+++ b/MonoGame.Framework/Utilities/ZLibStream/ZlibStream.cs
@@ -107,7 +107,7 @@ namespace MonoGame.Utilities
     /// </para>
     ///
     /// <para> Using this stream, applications can compress or decompress data via
-    /// stream <c>Read()</c> and <c>Write()</c> operations.  Either compresssion or
+    /// stream <c>Read()</c> and <c>Write()</c> operations.  Either compression or
     /// decompression can occur through either reading or writing. The compression
     /// format used is ZLIB, which is documented in <see
     /// href="http://www.ietf.org/rfc/rfc1950.txt">IETF RFC 1950</see>, "ZLIB Compressed
@@ -8709,7 +8709,7 @@ namespace MonoGame.Utilities
         /// </summary>
         /// <returns>
         /// The number of bytes produced by encoding the specified characters. This class
-        /// alwas returns the value of <paramref name="count"/>.
+        /// always returns the value of <paramref name="count"/>.
         /// </returns>
         public override int GetByteCount(char[] chars, int index, int count)
         {
@@ -8723,7 +8723,7 @@ namespace MonoGame.Utilities
         /// </summary>
         /// <returns>
         /// The number of characters produced by decoding the specified sequence of bytes. This class
-        /// alwas returns the value of <paramref name="count"/>. 
+        /// always returns the value of <paramref name="count"/>. 
         /// </returns>
         public override int GetCharCount(byte[] bytes, int index, int count)
         {
@@ -8736,7 +8736,7 @@ namespace MonoGame.Utilities
         /// </summary>
         /// <returns>
         /// The maximum number of bytes produced by encoding the specified number of characters. This
-        /// class alwas returns the value of <paramref name="charCount"/>.
+        /// class always returns the value of <paramref name="charCount"/>.
         /// </returns>
         /// <param name="charCount">The number of characters to encode. 
         /// </param>
@@ -8750,7 +8750,7 @@ namespace MonoGame.Utilities
         /// </summary>
         /// <returns>
         /// The maximum number of characters produced by decoding the specified number of bytes. This class
-        /// alwas returns the value of <paramref name="byteCount"/>.
+        /// always returns the value of <paramref name="byteCount"/>.
         /// </returns>
         /// <param name="byteCount">The number of bytes to decode.</param> 
         public override int GetMaxCharCount(int byteCount)

--- a/Tools/Pipeline/Controls/PropertyGridTable.cs
+++ b/Tools/Pipeline/Controls/PropertyGridTable.cs
@@ -195,10 +195,10 @@ namespace MonoGame.Tools.Pipeline
             // dialog at the end of Paint event so everything gets drawn.
             if(_edit)
             {
+                _edit = false;
+
                 if (!Global.Unix)
                     _selectedCell.Edit(pixel1);
-
-                _edit = false;
             }
         }
 


### PR DESCRIPTION
XNA was missing some Key input features which make
implementing text boxes a bit easier. One of these
new features was the TextInput event on the game
window. However this only gave us access to characters
that were pressed.

This commit adds a new KeyDown/Up events which give us
access to the actual keypress events. This will allow
for better text input control.

Users can now do

	window.KeyDown += delegate (s, e) => {
		if (e.Key == Keys.Back)
			// Handle the Back key
	};

Note this does NOT replace the Keyboard.GetState and it should
only really be used when trying to capture keyboard input for
TextInput.