### PR TITLE
Fix SDL Game Window Resize

### DIFF
--- a/MonoGame.Framework/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/SDL/SDLGameWindow.cs
@@ -249,6 +249,12 @@ namespace Microsoft.Xna.Framework
 
         public void ClientResize(int width, int height)
         {
+            // SDL reports many resize events even if the Size didn't change.
+            // Only call the code below if it actually changed.
+            if (_game.GraphicsDevice.PresentationParameters.BackBufferWidth == width &&
+                _game.GraphicsDevice.PresentationParameters.BackBufferHeight == height) {
+                return;
+            }
             _game.GraphicsDevice.PresentationParameters.BackBufferWidth = width;
             _game.GraphicsDevice.PresentationParameters.BackBufferHeight = height;
             _game.GraphicsDevice.Viewport = new Viewport(0, 0, width, height);


### PR DESCRIPTION
For some reason SDL seems to sometimes report multipe resize
events with the same width and height. This can cause problems
for game if they are doing things like creating render targets
in the event.

So we need to make sure we only call the event when we actually change
the width or height.