### PR TITLE
Testing Texture2D.SetData

### DIFF
--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -133,17 +133,20 @@ namespace Microsoft.Xna.Framework.Graphics
         /// <param name="elementCount"></param>
         public void SetData<T>(int level, int arraySlice, Rectangle? rect, T[] data, int startIndex, int elementCount) where T : struct
         {
+            Rectangle resizedBounds = new Rectangle(0, 0, Math.Max(Bounds.Width >> level, 1), Math.Max(Bounds.Height >> level, 1));
+            if (level >= LevelCount)
+                throw new ArgumentException("Texture only has "+_levelCount+" levels", "level");
             if (data == null)
                 throw new ArgumentNullException("data");
-            if ((!rect.HasValue && (data.Length - startIndex < Bounds.Width * Bounds.Height)) || (rect.HasValue && (rect.Value.Height * rect.Value.Width > data.Length)))
+            if ((!rect.HasValue && (data.Length - startIndex < resizedBounds.Width * resizedBounds.Height)) || (rect.HasValue && (rect.Value.Height * rect.Value.Width > data.Length)))
                 throw new ArgumentException("data array is too small");
             if (elementCount + startIndex > data.Length)
                 throw new ArgumentException("ElementCount must be a valid index in the data array", "elementCount");
-            // if (data.Length < elementCount || (rect.HasValue && data.Length < rect.Value.Width * rect.Value.Height))
-            //   throw new ArgumentException("data array is too short", "data");
             if (arraySlice > 0 && !GraphicsDevice.GraphicsCapabilities.SupportsTextureArrays)
                 throw new ArgumentException("Texture arrays are not supported on this graphics device", "arraySlice");
-            if (rect.HasValue && !Bounds.Contains(rect.Value))
+            if (arraySlice >= ArraySize)
+                throw new ArgumentException("Texture array only has "+ArraySize+" textures","arraySlice");
+            if (rect.HasValue && !resizedBounds.Contains(rect.Value))
                 throw new ArgumentException("Rectangle must be inside the Texture Bounds", "rect");
             PlatformSetData<T>(level, arraySlice, rect, data, startIndex, elementCount);
         }

--- a/MonoGame.Framework/Graphics/Texture2D.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.cs
@@ -135,10 +135,16 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             if (data == null)
                 throw new ArgumentNullException("data");
-
+            if ((!rect.HasValue && (data.Length - startIndex < Bounds.Width * Bounds.Height)) || (rect.HasValue && (rect.Value.Height * rect.Value.Width > data.Length)))
+                throw new ArgumentException("data array is too small");
+            if (elementCount + startIndex > data.Length)
+                throw new ArgumentException("ElementCount must be a valid index in the data array", "elementCount");
+            // if (data.Length < elementCount || (rect.HasValue && data.Length < rect.Value.Width * rect.Value.Height))
+            //   throw new ArgumentException("data array is too short", "data");
             if (arraySlice > 0 && !GraphicsDevice.GraphicsCapabilities.SupportsTextureArrays)
                 throw new ArgumentException("Texture arrays are not supported on this graphics device", "arraySlice");
-
+            if (rect.HasValue && !Bounds.Contains(rect.Value))
+                throw new ArgumentException("Rectangle must be inside the Texture Bounds", "rect");
             PlatformSetData<T>(level, arraySlice, rect, data, startIndex, elementCount);
         }
         /// <summary>

--- a/Test/Framework/Texture2DNonVisualTest.cs
+++ b/Test/Framework/Texture2DNonVisualTest.cs
@@ -120,12 +120,12 @@ namespace MonoGame.Tests.Framework
                 Assert.Throws<ArgumentException>(() => t.GetData(0, toReadArea, colors, startIndex, elementsToRead));
             }
         }
-
+#if !XNA
         [TestCase(2000000)]
         [TestCase(2000)]
         [TestCase(4095)]
         [TestCase(4097)]
-
+#endif
         [TestCase(4096)]
         public void SetData1ParameterGoodTest(int arraySize)
         {
@@ -144,7 +144,6 @@ namespace MonoGame.Tests.Framework
                 t.GetData(written);
                 for (int i = 0; i < written.Length; i++)
                 {
-
                     if (i < arraySize)
                     {
                         Assert.AreEqual(255, written[i].R, "Bad color written in position:{0};", i);
@@ -154,17 +153,47 @@ namespace MonoGame.Tests.Framework
                     }
                     else
                     {
-                        Assert.AreNotEqual(reference[i].R, written[i].R, "Color written in position:{0}; beyond array data", i);
-                        Assert.AreNotEqual(reference[i].G, written[i].G, "Color written in position:{0}; beyond array data", i);
-                        Assert.AreNotEqual(reference[i].B, written[i].B, "Color written in position:{0}; beyond array data", i);
-                        Assert.AreNotEqual(reference[i].A, written[i].A, "Color written in position:{0}; beyond array data", i);
+                        Assert.AreEqual(reference[i].R, written[i].R, "Color written in position:{0}; beyond array data", i);
+                        Assert.AreEqual(reference[i].G, written[i].G, "Color written in position:{0}; beyond array data", i);
+                        Assert.AreEqual(reference[i].B, written[i].B, "Color written in position:{0}; beyond array data", i);
+                        Assert.AreEqual(reference[i].A, written[i].A, "Color written in position:{0}; beyond array data", i);
                     }
                 }
             }
         }
-        [TestCase(4200, 0, 4096)]
-        [TestCase(2000, 0, 4096)]
+#if XNA
+        [TestCase(2000000)]
+        [TestCase(2000)]
+        [TestCase(4095)]
+        [TestCase(4097)]
+#endif
+        public void SetData1ParameterExceptionTest(int arraySize)
+        {
+            using (System.IO.StreamReader reader = new System.IO.StreamReader("Assets/Textures/LogoOnly_64px.png"))
+            {
+                Color[] data = new Color[arraySize];
+                Color[] reference = new Color[4096];
+                Color[] written = new Color[4096];
+                for (int i = 0; i < arraySize; i++)
+                {
+                    data[i] = Color.White;
+                }
+                Texture2D t = Texture2D.FromStream(_game.GraphicsDevice, reader.BaseStream);
+                t.GetData(reference);
+                Assert.Throws(Is.InstanceOf<Exception>(), () => t.SetData(data));
+                t.GetData(written);
+                for (int i = 0; i < written.Length; i++)
+                {
+                    Assert.AreEqual(reference[i].R, written[i].R, "Bad color written in position:{0};", i);
+                    Assert.AreEqual(reference[i].G, written[i].G, "Bad color written in position:{0};", i);
+                    Assert.AreEqual(reference[i].B, written[i].B, "Bad color written in position:{0};", i);
+                    Assert.AreEqual(reference[i].A, written[i].A, "Bad color written in position:{0};", i);
+                }
+            }
+        }
 
+#if !XNA
+        [TestCase(2000, 0, 4096)]
         [TestCase(4095, 0, 4095)]
         [TestCase(4095, 1, 4095)]
         [TestCase(4096, 1, 4096)]
@@ -178,7 +207,8 @@ namespace MonoGame.Tests.Framework
         [TestCase(4097, 1, 4098)]
         [TestCase(4097, 0, 4097)]
         [TestCase(4096, 0, 4095)]
-
+#endif
+        [TestCase(4200, 0, 4096)]
         [TestCase(4097, 1, 4096)]
         [TestCase(4097, 0, 4096)]
         [TestCase(4096, 0, 4096)]
@@ -208,15 +238,57 @@ namespace MonoGame.Tests.Framework
                     }
                     else
                     {
-                        Assert.AreNotEqual(reference[i].R, written[i].R, "Color written in position:{0}; beyond array data", i);
-                        Assert.AreNotEqual(reference[i].G, written[i].G, "Color written in position:{0}; beyond array data", i);
-                        Assert.AreNotEqual(reference[i].B, written[i].B, "Color written in position:{0}; beyond array data", i);
-                        Assert.AreNotEqual(reference[i].A, written[i].A, "Color written in position:{0}; beyond array data", i);
+                        Assert.AreEqual(reference[i].R, written[i].R, "Color written in position:{0}; beyond array data", i);
+                        Assert.AreEqual(reference[i].G, written[i].G, "Color written in position:{0}; beyond array data", i);
+                        Assert.AreEqual(reference[i].B, written[i].B, "Color written in position:{0}; beyond array data", i);
+                        Assert.AreEqual(reference[i].A, written[i].A, "Color written in position:{0}; beyond array data", i);
                     }
                 }
             }
         }
-        [TestCase(4096, 0, 4096, -1, -1, 65, 65)]
+
+#if XNA
+        [TestCase(4095, 0, 4095)]
+        [TestCase(4095, 1, 4095)]
+        [TestCase(4096, 1, 4096)]
+        [TestCase(4096, 1, 4095)]
+        [TestCase(4095, 1, 4096)]
+        [TestCase(4096, 1, 4097)]
+        [TestCase(4095, 0, 4094)]
+
+        [TestCase(4097, 1, 4097)]
+        [TestCase(4098, 1, 4097)]
+        [TestCase(4097, 1, 4098)]
+        [TestCase(4097, 0, 4097)]
+        [TestCase(4096, 0, 4095)]
+#endif
+        public void SetData3ParameterExceptionTest(int arraySize, int startIndex, int elements)
+        {
+            using (System.IO.StreamReader reader = new System.IO.StreamReader("Assets/Textures/LogoOnly_64px.png"))
+            {
+                Color[] data = new Color[arraySize];
+                Color[] written = new Color[4096];
+                Color[] reference = new Color[4096];
+                for (int i = 0; i < arraySize; i++)
+                {
+                    data[i] = Color.White;
+                }
+                Texture2D t = Texture2D.FromStream(_game.GraphicsDevice, reader.BaseStream);
+                t.GetData(reference);
+                Assert.Throws(Is.InstanceOf<Exception>(), () => t.SetData(data, startIndex, elements));
+                t.GetData(written);
+                for (int i = 0; i < written.Length; i++)
+                {
+                    Assert.AreEqual(reference[i].R, written[i].R, "Bad color written in position:{0};", i);
+                    Assert.AreEqual(reference[i].G, written[i].G, "Bad color written in position:{0};", i);
+                    Assert.AreEqual(reference[i].B, written[i].B, "Bad color written in position:{0};", i);
+                    Assert.AreEqual(reference[i].A, written[i].A, "Bad color written in position:{0};", i);
+                }
+            }
+        }
+
+#if !XNA
+        //This 2 test cases I'm not sure if they should work or not in MonoGame
         [TestCase(3844, 0, 3844, 1, 1, 63, 63)]
         [TestCase(3845, 1, 3844, 1, 1, 63, 63)]
 
@@ -228,7 +300,7 @@ namespace MonoGame.Tests.Framework
         [TestCase(4097, 1, 4095, 0, 0, 64, 64)]
         [TestCase(4097, 1, 3844, 1, 1, 63, 63)]
         [TestCase(3970, 1, 4096, 1, 1, 63, 63)]
-
+#endif
         [TestCase(4096, 0, 4096, 0, 0, 64, 64)]
         [TestCase(4096, 0, 3969, 1, 1, 63, 63)]
         [TestCase(3969, 0, 3969, 1, 1, 63, 63)]
@@ -249,13 +321,10 @@ namespace MonoGame.Tests.Framework
                 {
                     data[i] = Color.White;
                 }
-                //data[66] = new Color(212, 212, 212, 212);
                 Texture2D t = Texture2D.FromStream(_game.GraphicsDevice, reader.BaseStream);
                 t.GetData(reference);
                 t.SetData(0, area, data, startIndex, elements);
-                //t.GetData(0, area, written, 0, elements);
                 t.GetData(written);
-                //Console.Error.Write("\n{0}", written[0].ToString());
                 for (int i = 0; i < written.Length; i++)
                 {
                     int rx = i % 64, ry = i / 64;
@@ -273,6 +342,46 @@ namespace MonoGame.Tests.Framework
                         Assert.AreEqual(reference[i].B, written[i].B, "Color written in position:{0}; beyond array data", i);
                         Assert.AreEqual(reference[i].A, written[i].A, "Color written in position:{0}; beyond array data", i);
                     }
+                }
+            }
+        }
+
+        [TestCase(4096, 0, 4096, -1, -1, 65, 65)]
+#if XNA
+        [TestCase(3844, 0, 3844, 1, 1, 63, 63)]
+        [TestCase(3845, 1, 3844, 1, 1, 63, 63)]
+        [TestCase(4096, 0, 4096, 1, 1, 63, 63)]
+        [TestCase(4096, 0, 4095, 0, 0, 64, 64)]
+        [TestCase(4096, 0, 3844, 1, 1, 63, 63)]
+        [TestCase(3969, 0, 4096, 1, 1, 63, 63)]
+        [TestCase(4097, 1, 4096, 1, 1, 63, 63)]
+        [TestCase(4097, 1, 4095, 0, 0, 64, 64)]
+        [TestCase(4097, 1, 3844, 1, 1, 63, 63)]
+        [TestCase(3970, 1, 4096, 1, 1, 63, 63)]
+#endif
+        public void SetData5ParameterExceptionTest(int arraySize, int startIndex, int elements, int x, int y, int w, int h)
+        {
+            using (System.IO.StreamReader reader = new System.IO.StreamReader("Assets/Textures/LogoOnly_64px.png"))
+            {
+                Rectangle area = new Rectangle(x, y, w, h);
+                int areaLength = w * h;
+                Color[] data = new Color[arraySize];
+                Color[] reference = new Color[4096];
+                Color[] written = new Color[4096];
+                for (int i = 0; i < arraySize; i++)
+                {
+                    data[i] = Color.White;
+                }
+                Texture2D t = Texture2D.FromStream(_game.GraphicsDevice, reader.BaseStream);
+                t.GetData(reference);
+                Assert.Throws(Is.InstanceOf<Exception>(), () => t.SetData(0, area, data, startIndex, elements));
+                t.GetData(written);
+                for (int i = 0; i < written.Length; i++)
+                {
+                    Assert.AreEqual(reference[i].R, written[i].R, "Bad color written in position:{0};", i);
+                    Assert.AreEqual(reference[i].G, written[i].G, "Bad color written in position:{0};", i);
+                    Assert.AreEqual(reference[i].B, written[i].B, "Bad color written in position:{0};", i);
+                    Assert.AreEqual(reference[i].A, written[i].A, "Bad color written in position:{0};", i);
                 }
             }
         }

--- a/Test/Framework/Texture2DNonVisualTest.cs
+++ b/Test/Framework/Texture2DNonVisualTest.cs
@@ -64,9 +64,9 @@ namespace MonoGame.Tests.Framework
         }
 
 #if XNA
-        [TestCase("Assets/Textures/LogoOnly_64px.bmp")]
-        [TestCase("Assets/Textures/LogoOnly_64px.dds")]
-        [TestCase("Assets/Textures/LogoOnly_64px.tif")]
+                [TestCase("Assets/Textures/LogoOnly_64px.bmp")]
+                [TestCase("Assets/Textures/LogoOnly_64px.dds")]
+                [TestCase("Assets/Textures/LogoOnly_64px.tif")]
 #endif
         [TestCase("Assets/Textures/LogoOnly_64px.tga")]
         [TestCase("Assets/Textures/SampleCube64DXT1Mips.dds")]
@@ -120,7 +120,135 @@ namespace MonoGame.Tests.Framework
                 Assert.Throws<ArgumentException>(() => t.GetData(0, toReadArea, colors, startIndex, elementsToRead));
             }
         }
-        [TestFixtureTearDown]
+
+        [TestCase(2000000)]
+        [TestCase(2000)]
+        [TestCase(4095)]
+        [TestCase(4097)]
+
+        [TestCase(4096)]
+        public void SetData1ParameterGoodTest(int arraySize)
+        {
+            using (System.IO.StreamReader reader = new System.IO.StreamReader("Assets/Textures/LogoOnly_64px.png"))
+            {
+                Color[] data = new Color[arraySize];
+                Color[] written = new Color[4096];
+                for (int i = 0; i < arraySize; i++)
+                {
+                    data[i] = Color.White;
+                }
+                Texture2D t = Texture2D.FromStream(_game.GraphicsDevice, reader.BaseStream);
+                t.SetData(data);
+                t.GetData(written);
+                for (int i = 0; i < written.Length; i++)
+                {
+
+                    if (i < arraySize)
+                    {
+                        Assert.AreEqual(255, written[i].R, "Bad color in position:{0};", i);
+                        Assert.AreEqual(255, written[i].G, "Bad color in position:{0};", i);
+                        Assert.AreEqual(255, written[i].B, "Bad color in position:{0};", i);
+                        Assert.AreEqual(255, written[i].A, "Bad color in position:{0};", i);
+                    }
+                    else
+                    {
+                        Assert.AreNotEqual(255, written[i].R, "Bad color in position:{0};", i);
+                        Assert.AreNotEqual(255, written[i].G, "Bad color in position:{0};", i);
+                        Assert.AreNotEqual(255, written[i].B, "Bad color in position:{0};", i);
+                        Assert.AreNotEqual(255, written[i].A, "Bad color in position:{0};", i);
+                    }
+                }
+            }
+        }
+        [TestCase(4200,0,4096)]
+        [TestCase(2000,0,4096)]
+
+        [TestCase(4095, 0, 4095)]
+        [TestCase(4095, 1, 4095)]
+        [TestCase(4096, 1, 4096)]
+        [TestCase(4096, 1, 4095)]
+        [TestCase(4095, 1, 4096)]
+        [TestCase(4096, 1, 4097)]
+        [TestCase(4095, 0, 4094)]
+
+        [TestCase(4097, 1, 4097)]
+        [TestCase(4098, 1, 4097)]
+        [TestCase(4097, 1, 4098)]
+        [TestCase(4097, 0, 4097)]
+        [TestCase(4096, 0, 4095)]
+
+        [TestCase(4097, 1, 4096)]
+        [TestCase(4097, 0, 4096)]
+        [TestCase(4096, 0, 4096)]
+        public void SetData3ParameterGoodTest(int arraySize, int startIndex, int elements)
+        {
+            using (System.IO.StreamReader reader = new System.IO.StreamReader("Assets/Textures/LogoOnly_64px.png"))
+            {
+                Color[] data = new Color[arraySize];
+                Color[] written = new Color[4096];
+                Color[] reference = new Color[4096];
+                for (int i = 0; i < arraySize; i++)
+                {
+                    data[i] = Color.White;
+                }
+                Texture2D t = Texture2D.FromStream(_game.GraphicsDevice, reader.BaseStream);
+                t.GetData(reference);
+                t.SetData(data, startIndex, elements);
+                t.GetData(written);
+                for (int i = 0; i < written.Length; i++)
+                {
+                    if (i < arraySize)
+                    {
+                        Assert.AreEqual(255, written[i].R, "Bad color in position:{0};", i);
+                        Assert.AreEqual(255, written[i].G, "Bad color in position:{0};", i);
+                        Assert.AreEqual(255, written[i].B, "Bad color in position:{0};", i);
+                        Assert.AreEqual(255, written[i].A, "Bad color in position:{0};", i);
+                    }
+                    else
+                    {
+                        Assert.AreEqual(reference[i].R, written[i].R, "Bad color in position:{0};", i);
+                        Assert.AreEqual(reference[i].G, written[i].G, "Bad color in position:{0};", i);
+                        Assert.AreEqual(reference[i].B, written[i].B, "Bad color in position:{0};", i);
+                        Assert.AreEqual(reference[i].A, written[i].A, "Bad color in position:{0};", i);
+                    }
+                }
+            }
+        }
+
+        //public void SetData5ParameterGoodTest(int arraySize, int startIndex, int elements)
+        //{
+        //    using (System.IO.StreamReader reader = new System.IO.StreamReader("Assets/Textures/LogoOnly_64px.png"))
+        //    {
+        //        Rectangle area = new Rectangle();
+        //        Color[] data = new Color[arraySize];
+        //        Color[] written = new Color[4096];
+        //        for (int i = 0; i < arraySize; i++)
+        //        {
+        //            data[i] = Color.White;
+        //        }
+        //        Texture2D t = Texture2D.FromStream(_game.GraphicsDevice, reader.BaseStream);
+        //        t.SetData(0, area, data, startIndex, elements);
+        //        t.GetData(0, area, written, 0, elements);
+        //        for (int i = 0; i < arraySize; i++)
+        //        {
+        //            if (i < arraySize)
+                    //{
+                    //    Assert.AreEqual(255, written[i].R, "Bad color in position:{0};", i);
+                    //    Assert.AreEqual(255, written[i].G, "Bad color in position:{0};", i);
+                    //    Assert.AreEqual(255, written[i].B, "Bad color in position:{0};", i);
+                    //    Assert.AreEqual(255, written[i].A, "Bad color in position:{0};", i);
+                    //}
+                    //else
+                    //{
+                    //    Assert.AreNotEqual(255, written[i].R, "Bad color in position:{0};", i);
+                    //    Assert.AreNotEqual(255, written[i].G, "Bad color in position:{0};", i);
+                    //    Assert.AreNotEqual(255, written[i].B, "Bad color in position:{0};", i);
+                    //    Assert.AreNotEqual(255, written[i].A, "Bad color in position:{0};", i);
+                    //}
+//        }
+//    }
+//}
+[TestFixtureTearDown]
         public void TearDown()
         {
             _game.Dispose();

--- a/Test/Framework/Texture2DNonVisualTest.cs
+++ b/Test/Framework/Texture2DNonVisualTest.cs
@@ -122,8 +122,6 @@ namespace MonoGame.Tests.Framework
         }
 #if !XNA
         [TestCase(2000000)]
-        [TestCase(2000)]
-        [TestCase(4095)]
         [TestCase(4097)]
 #endif
         [TestCase(4096)]
@@ -161,10 +159,10 @@ namespace MonoGame.Tests.Framework
                 }
             }
         }
-#if XNA
-        [TestCase(2000000)]
         [TestCase(2000)]
         [TestCase(4095)]
+#if XNA
+        [TestCase(2000000)]
         [TestCase(4097)]
 #endif
         public void SetData1ParameterExceptionTest(int arraySize)
@@ -193,18 +191,7 @@ namespace MonoGame.Tests.Framework
         }
 
 #if !XNA
-        [TestCase(2000, 0, 4096)]
-        [TestCase(4095, 0, 4095)]
-        [TestCase(4095, 1, 4095)]
-        [TestCase(4096, 1, 4096)]
-        [TestCase(4096, 1, 4095)]
-        [TestCase(4095, 1, 4096)]
-        [TestCase(4096, 1, 4097)]
-        [TestCase(4095, 0, 4094)]
-
-        [TestCase(4097, 1, 4097)]
         [TestCase(4098, 1, 4097)]
-        [TestCase(4097, 1, 4098)]
         [TestCase(4097, 0, 4097)]
         [TestCase(4096, 0, 4095)]
 #endif
@@ -247,7 +234,7 @@ namespace MonoGame.Tests.Framework
             }
         }
 
-#if XNA
+        [TestCase(2000, 0, 4096)]
         [TestCase(4095, 0, 4095)]
         [TestCase(4095, 1, 4095)]
         [TestCase(4096, 1, 4096)]
@@ -255,10 +242,10 @@ namespace MonoGame.Tests.Framework
         [TestCase(4095, 1, 4096)]
         [TestCase(4096, 1, 4097)]
         [TestCase(4095, 0, 4094)]
-
         [TestCase(4097, 1, 4097)]
-        [TestCase(4098, 1, 4097)]
         [TestCase(4097, 1, 4098)]
+#if XNA
+        [TestCase(4098, 1, 4097)]
         [TestCase(4097, 0, 4097)]
         [TestCase(4096, 0, 4095)]
 #endif
@@ -288,18 +275,12 @@ namespace MonoGame.Tests.Framework
         }
 
 #if !XNA
-        //This 2 test cases I'm not sure if they should work or not in MonoGame
-        [TestCase(3844, 0, 3844, 1, 1, 63, 63)]
-        [TestCase(3845, 1, 3844, 1, 1, 63, 63)]
-
         [TestCase(4096, 0, 4096, 1, 1, 63, 63)]
         [TestCase(4096, 0, 4095, 0, 0, 64, 64)]
         [TestCase(4096, 0, 3844, 1, 1, 63, 63)]
-        [TestCase(3969, 0, 4096, 1, 1, 63, 63)]
         [TestCase(4097, 1, 4096, 1, 1, 63, 63)]
         [TestCase(4097, 1, 4095, 0, 0, 64, 64)]
         [TestCase(4097, 1, 3844, 1, 1, 63, 63)]
-        [TestCase(3970, 1, 4096, 1, 1, 63, 63)]
 #endif
         [TestCase(4096, 0, 4096, 0, 0, 64, 64)]
         [TestCase(4096, 0, 3969, 1, 1, 63, 63)]
@@ -345,15 +326,15 @@ namespace MonoGame.Tests.Framework
                 }
             }
         }
-
-        [TestCase(4096, 0, 4096, -1, -1, 65, 65)]
-#if XNA
         [TestCase(3844, 0, 3844, 1, 1, 63, 63)]
         [TestCase(3845, 1, 3844, 1, 1, 63, 63)]
+        [TestCase(3969, 0, 4096, 1, 1, 63, 63)]
+        [TestCase(3970, 1, 4096, 1, 1, 63, 63)]
+        [TestCase(4096, 0, 4096, -1, -1, 65, 65)]
+#if XNA
         [TestCase(4096, 0, 4096, 1, 1, 63, 63)]
         [TestCase(4096, 0, 4095, 0, 0, 64, 64)]
         [TestCase(4096, 0, 3844, 1, 1, 63, 63)]
-        [TestCase(3969, 0, 4096, 1, 1, 63, 63)]
         [TestCase(4097, 1, 4096, 1, 1, 63, 63)]
         [TestCase(4097, 1, 4095, 0, 0, 64, 64)]
         [TestCase(4097, 1, 3844, 1, 1, 63, 63)]

--- a/Test/Framework/Texture2DNonVisualTest.cs
+++ b/Test/Framework/Texture2DNonVisualTest.cs
@@ -132,12 +132,14 @@ namespace MonoGame.Tests.Framework
             using (System.IO.StreamReader reader = new System.IO.StreamReader("Assets/Textures/LogoOnly_64px.png"))
             {
                 Color[] data = new Color[arraySize];
+                Color[] reference = new Color[4096];
                 Color[] written = new Color[4096];
                 for (int i = 0; i < arraySize; i++)
                 {
                     data[i] = Color.White;
                 }
                 Texture2D t = Texture2D.FromStream(_game.GraphicsDevice, reader.BaseStream);
+                t.GetData(reference);
                 t.SetData(data);
                 t.GetData(written);
                 for (int i = 0; i < written.Length; i++)
@@ -145,23 +147,23 @@ namespace MonoGame.Tests.Framework
 
                     if (i < arraySize)
                     {
-                        Assert.AreEqual(255, written[i].R, "Bad color in position:{0};", i);
-                        Assert.AreEqual(255, written[i].G, "Bad color in position:{0};", i);
-                        Assert.AreEqual(255, written[i].B, "Bad color in position:{0};", i);
-                        Assert.AreEqual(255, written[i].A, "Bad color in position:{0};", i);
+                        Assert.AreEqual(255, written[i].R, "Bad color written in position:{0};", i);
+                        Assert.AreEqual(255, written[i].G, "Bad color written in position:{0};", i);
+                        Assert.AreEqual(255, written[i].B, "Bad color written in position:{0};", i);
+                        Assert.AreEqual(255, written[i].A, "Bad color written in position:{0};", i);
                     }
                     else
                     {
-                        Assert.AreNotEqual(255, written[i].R, "Bad color in position:{0};", i);
-                        Assert.AreNotEqual(255, written[i].G, "Bad color in position:{0};", i);
-                        Assert.AreNotEqual(255, written[i].B, "Bad color in position:{0};", i);
-                        Assert.AreNotEqual(255, written[i].A, "Bad color in position:{0};", i);
+                        Assert.AreNotEqual(reference[i].R, written[i].R, "Color written in position:{0}; beyond array data", i);
+                        Assert.AreNotEqual(reference[i].G, written[i].G, "Color written in position:{0}; beyond array data", i);
+                        Assert.AreNotEqual(reference[i].B, written[i].B, "Color written in position:{0}; beyond array data", i);
+                        Assert.AreNotEqual(reference[i].A, written[i].A, "Color written in position:{0}; beyond array data", i);
                     }
                 }
             }
         }
-        [TestCase(4200,0,4096)]
-        [TestCase(2000,0,4096)]
+        [TestCase(4200, 0, 4096)]
+        [TestCase(2000, 0, 4096)]
 
         [TestCase(4095, 0, 4095)]
         [TestCase(4095, 1, 4095)]
@@ -199,56 +201,82 @@ namespace MonoGame.Tests.Framework
                 {
                     if (i < arraySize)
                     {
-                        Assert.AreEqual(255, written[i].R, "Bad color in position:{0};", i);
-                        Assert.AreEqual(255, written[i].G, "Bad color in position:{0};", i);
-                        Assert.AreEqual(255, written[i].B, "Bad color in position:{0};", i);
-                        Assert.AreEqual(255, written[i].A, "Bad color in position:{0};", i);
+                        Assert.AreEqual(255, written[i].R, "Bad color written in position:{0};", i);
+                        Assert.AreEqual(255, written[i].G, "Bad color written in position:{0};", i);
+                        Assert.AreEqual(255, written[i].B, "Bad color written in position:{0};", i);
+                        Assert.AreEqual(255, written[i].A, "Bad color written in position:{0};", i);
                     }
                     else
                     {
-                        Assert.AreEqual(reference[i].R, written[i].R, "Bad color in position:{0};", i);
-                        Assert.AreEqual(reference[i].G, written[i].G, "Bad color in position:{0};", i);
-                        Assert.AreEqual(reference[i].B, written[i].B, "Bad color in position:{0};", i);
-                        Assert.AreEqual(reference[i].A, written[i].A, "Bad color in position:{0};", i);
+                        Assert.AreNotEqual(reference[i].R, written[i].R, "Color written in position:{0}; beyond array data", i);
+                        Assert.AreNotEqual(reference[i].G, written[i].G, "Color written in position:{0}; beyond array data", i);
+                        Assert.AreNotEqual(reference[i].B, written[i].B, "Color written in position:{0}; beyond array data", i);
+                        Assert.AreNotEqual(reference[i].A, written[i].A, "Color written in position:{0}; beyond array data", i);
                     }
                 }
             }
         }
+        [TestCase(4096, 0, 4096, -1, -1, 65, 65)]
+        [TestCase(3844, 0, 3844, 1, 1, 63, 63)]
+        [TestCase(3845, 1, 3844, 1, 1, 63, 63)]
 
-        //public void SetData5ParameterGoodTest(int arraySize, int startIndex, int elements)
-        //{
-        //    using (System.IO.StreamReader reader = new System.IO.StreamReader("Assets/Textures/LogoOnly_64px.png"))
-        //    {
-        //        Rectangle area = new Rectangle();
-        //        Color[] data = new Color[arraySize];
-        //        Color[] written = new Color[4096];
-        //        for (int i = 0; i < arraySize; i++)
-        //        {
-        //            data[i] = Color.White;
-        //        }
-        //        Texture2D t = Texture2D.FromStream(_game.GraphicsDevice, reader.BaseStream);
-        //        t.SetData(0, area, data, startIndex, elements);
-        //        t.GetData(0, area, written, 0, elements);
-        //        for (int i = 0; i < arraySize; i++)
-        //        {
-        //            if (i < arraySize)
-                    //{
-                    //    Assert.AreEqual(255, written[i].R, "Bad color in position:{0};", i);
-                    //    Assert.AreEqual(255, written[i].G, "Bad color in position:{0};", i);
-                    //    Assert.AreEqual(255, written[i].B, "Bad color in position:{0};", i);
-                    //    Assert.AreEqual(255, written[i].A, "Bad color in position:{0};", i);
-                    //}
-                    //else
-                    //{
-                    //    Assert.AreNotEqual(255, written[i].R, "Bad color in position:{0};", i);
-                    //    Assert.AreNotEqual(255, written[i].G, "Bad color in position:{0};", i);
-                    //    Assert.AreNotEqual(255, written[i].B, "Bad color in position:{0};", i);
-                    //    Assert.AreNotEqual(255, written[i].A, "Bad color in position:{0};", i);
-                    //}
-//        }
-//    }
-//}
-[TestFixtureTearDown]
+        [TestCase(4096, 0, 4096, 1, 1, 63, 63)]
+        [TestCase(4096, 0, 4095, 0, 0, 64, 64)]
+        [TestCase(4096, 0, 3844, 1, 1, 63, 63)]
+        [TestCase(3969, 0, 4096, 1, 1, 63, 63)]
+        [TestCase(4097, 1, 4096, 1, 1, 63, 63)]
+        [TestCase(4097, 1, 4095, 0, 0, 64, 64)]
+        [TestCase(4097, 1, 3844, 1, 1, 63, 63)]
+        [TestCase(3970, 1, 4096, 1, 1, 63, 63)]
+
+        [TestCase(4096, 0, 4096, 0, 0, 64, 64)]
+        [TestCase(4096, 0, 3969, 1, 1, 63, 63)]
+        [TestCase(3969, 0, 3969, 1, 1, 63, 63)]
+        [TestCase(4096, 1, 3969, 1, 1, 63, 63)]
+        [TestCase(4097, 1, 3969, 1, 1, 63, 63)]
+        [TestCase(3970, 1, 3969, 1, 1, 63, 63)]
+        [TestCase(4097, 1, 4096, 0, 0, 64, 64)]
+        public void SetData5ParameterGoodTest(int arraySize, int startIndex, int elements, int x, int y, int w, int h)
+        {
+            using (System.IO.StreamReader reader = new System.IO.StreamReader("Assets/Textures/LogoOnly_64px.png"))
+            {
+                Rectangle area = new Rectangle(x, y, w, h);
+                int areaLength = w * h;
+                Color[] data = new Color[arraySize];
+                Color[] reference = new Color[4096];
+                Color[] written = new Color[4096];
+                for (int i = 0; i < arraySize; i++)
+                {
+                    data[i] = Color.White;
+                }
+                //data[66] = new Color(212, 212, 212, 212);
+                Texture2D t = Texture2D.FromStream(_game.GraphicsDevice, reader.BaseStream);
+                t.GetData(reference);
+                t.SetData(0, area, data, startIndex, elements);
+                //t.GetData(0, area, written, 0, elements);
+                t.GetData(written);
+                //Console.Error.Write("\n{0}", written[0].ToString());
+                for (int i = 0; i < written.Length; i++)
+                {
+                    int rx = i % 64, ry = i / 64;
+                    if (area.Contains(rx, ry))
+                    {
+                        Assert.AreEqual(255, written[i].R, "Bad color written in position:{0};", i);
+                        Assert.AreEqual(255, written[i].G, "Bad color written in position:{0};", i);
+                        Assert.AreEqual(255, written[i].B, "Bad color written in position:{0};", i);
+                        Assert.AreEqual(255, written[i].A, "Bad color written in position:{0};", i);
+                    }
+                    else
+                    {
+                        Assert.AreEqual(reference[i].R, written[i].R, "Color written in position:{0}; beyond array data", i);
+                        Assert.AreEqual(reference[i].G, written[i].G, "Color written in position:{0}; beyond array data", i);
+                        Assert.AreEqual(reference[i].B, written[i].B, "Color written in position:{0}; beyond array data", i);
+                        Assert.AreEqual(reference[i].A, written[i].A, "Color written in position:{0}; beyond array data", i);
+                    }
+                }
+            }
+        }
+        [TestFixtureTearDown]
         public void TearDown()
         {
             _game.Dispose();


### PR DESCRIPTION
Related to #1455.
At this time I have implemented some tests for `Texture2D.SetData()` with 1 and 3 parameters, the other overloads will come later. If someone reads the code, the testCases are grouped from bottom to top as follows: XNA and Monogame passed tests, only Monogame passed tests, and failing tests.

Things pending:

- Add tests for the remaining `SetData` overloads.
- Separate the TestCases if they should pass or fail
- Fix issues found in the Monogame implementation