### PR TITLE
Fixes potential stencil state mismatch

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -631,8 +631,11 @@ namespace Microsoft.Xna.Framework.Graphics
                     this.framebufferHelper.BindFramebuffer(glResolveFramebuffer);
                 }
                 // The only fragment operations which affect the resolve are the pixel ownership test, the scissor test, and dithering.
-                GL.Disable(EnableCap.ScissorTest);
-                GraphicsExtensions.CheckGLError();
+                if (this._lastDepthStencilState.StencilEnable)
+                {
+                    GL.Disable(EnableCap.ScissorTest);
+                    GraphicsExtensions.CheckGLError();
+                }
                 var glFramebuffer = this.glFramebuffers[this._currentRenderTargetBindings];
                 this.framebufferHelper.BindReadFramebuffer(glFramebuffer);
                 for (var i = 0; i < this._currentRenderTargetCount; ++i)
@@ -643,7 +646,11 @@ namespace Microsoft.Xna.Framework.Graphics
                 }
                 if (renderTarget.RenderTargetUsage == RenderTargetUsage.DiscardContents && this.framebufferHelper.SupportsInvalidateFramebuffer)
                     this.framebufferHelper.InvalidateReadFramebuffer();
-                this._depthStencilStateDirty = true;
+                if (this._lastDepthStencilState.StencilEnable)
+                {
+                    GL.Enable(EnableCap.ScissorTest);
+                    GraphicsExtensions.CheckGLError();
+                }
             }
             for (var i = 0; i < this._currentRenderTargetCount; ++i)
             {


### PR DESCRIPTION
When resolving a multisampled rendertarget, we have to disable the stencil test to make sure everything is resolved properly.
The way it was previously done was to directly call ``GL.Disable(EnableCap.ScissorTest)`` and we set ``GraphicsDevice._depthStencilStateDirty = true`` to ensure the current stencil test value was returned to its original value during the next draw call.
Unfortunately this fails if ``GraphicsDevice._lastDepthStencilState.StencilEnable == GraphicsDevice.DepthStencilState.StencilEnable == true`` since MonoGame caches state and makes sure to not submit superfluous OpenGL calls. In that case, the stencil test would not be reset to its original state (the one before the rendertarget gets resolved).

The fix is very simple and explicit: it tests the value of the last **applied** stencil state and only disable it if necessary, and reenable it right after if it was previously enabled.

Despite being the original author of the multisampling code, I have no idea why it wasn't done this way in the first place. Apologies if this sneaky bug caused you as much pain as it did for us :)