### PR TITLE
[Pipeline Tool] Fix null reference exception with Windows propertygrid dialog launching

### DIFF
--- a/Tools/Pipeline/Controls/PropertyGridTable.cs
+++ b/Tools/Pipeline/Controls/PropertyGridTable.cs
@@ -195,10 +195,10 @@ namespace MonoGame.Tools.Pipeline
             // dialog at the end of Paint event so everything gets drawn.
             if(_edit)
             {
+                _edit = false;
+
                 if (!Global.Unix)
                     _selectedCell.Edit(pixel1);
-
-                _edit = false;
             }
         }
 


### PR DESCRIPTION
The reason why null ref exception would occur is because when a new dialog is created it will pause the current drawing, and create a new redraw event to show the dialog, but the new redraw event will reset `_selectedCell` to `null` since mouse is out of focus, and since the old event didn't finish up `_edit` would still be `true`.