### PR TITLE
Fix for "Input string was not in a correct format."

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Graphics/VertexChannelNames.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/VertexChannelNames.cs
@@ -76,8 +76,14 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             string baseName = DecodeBaseName(encodedName);
             if (string.IsNullOrEmpty(baseName))
                 throw new InvalidOperationException("encodedName");
-            // Subtract the base name from the string and convert the remainder to an integer
-            return Int32.Parse(encodedName.Substring(baseName.Length), CultureInfo.InvariantCulture);
+
+            // Subtract the base name from the string and convert the remainder to an integer.
+            // TryParse solves the problem when name is just 'BlendIndicies' for example, in 
+            // which case we default to index 0, assuming only 1 index.
+            int index = 0;
+            int.TryParse(encodedName.Substring(baseName.Length), NumberStyles.Integer, CultureInfo.InvariantCulture, out index);
+
+            return index;
         }
 
         /// <summary>


### PR DESCRIPTION
Using `TryParse` solves the problem when name is just `BlendIndicies` for example, in which case we default to index 0, assuming only 1 index.