### PR TITLE
Properly setting the LeftTrigger and RightTrigger buttons in UWP

### DIFF
--- a/MonoGame.Framework/Input/GamePad.UWP.cs
+++ b/MonoGame.Framework/Input/GamePad.UWP.cs
@@ -92,6 +92,14 @@ namespace Microsoft.Xna.Framework.Input
                 (state.Buttons.HasFlag(WGI.GamepadButtons.X) ? Buttons.X : 0) |
                 (state.Buttons.HasFlag(WGI.GamepadButtons.Y) ? Buttons.Y : 0) |
                 0;
+
+            // Check triggers
+            const double triggerThreshold = 0.1;
+            if (triggers.Left > triggerThreshold)
+                buttonStates |= Buttons.LeftTrigger;
+            if (triggers.Right > triggerThreshold)
+                buttonStates |= Buttons.RightTrigger;
+
             var buttons = new GamePadButtons(buttonStates);
 
             var dpad = new GamePadDPad(

--- a/MonoGame.Framework/Input/GamePad.UWP.cs
+++ b/MonoGame.Framework/Input/GamePad.UWP.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Xna.Framework.Input
     {
         /// <summary>
         /// Attempts to mimic SharpDX.XInput.Gamepad which defines the trigger threshold as 30 with a range of 0 to 255. 
-        /// We trigger here has a range of 0.0 to 1.0. So, 30 / 255 = 0.11765.
+        /// The trigger here has a range of 0.0 to 1.0. So, 30 / 255 = 0.11765.
         /// </summary>
         private const double TriggerThreshold = 0.11765;
 

--- a/MonoGame.Framework/Input/GamePad.UWP.cs
+++ b/MonoGame.Framework/Input/GamePad.UWP.cs
@@ -9,10 +9,8 @@ namespace Microsoft.Xna.Framework.Input
 {
     static partial class GamePad
     {
-        /// <summary>
-        /// Attempts to mimic SharpDX.XInput.Gamepad which defines the trigger threshold as 30 with a range of 0 to 255. 
-        /// The trigger here has a range of 0.0 to 1.0. So, 30 / 255 = 0.11765.
-        /// </summary>
+        // Attempts to mimic SharpDX.XInput.Gamepad which defines the trigger threshold as 30 with a range of 0 to 255. 
+        // The trigger here has a range of 0.0 to 1.0. So, 30 / 255 = 0.11765.
         private const double TriggerThreshold = 0.11765;
 
         internal static bool Back;

--- a/MonoGame.Framework/Input/GamePad.UWP.cs
+++ b/MonoGame.Framework/Input/GamePad.UWP.cs
@@ -9,6 +9,12 @@ namespace Microsoft.Xna.Framework.Input
 {
     static partial class GamePad
     {
+        /// <summary>
+        /// Attempts to mimic SharpDX.XInput.Gamepad which defines the trigger threshold as 30 with a range of 0 to 255. 
+        /// We trigger here has a range of 0.0 to 1.0. So, 30 / 255 = 0.11765.
+        /// </summary>
+        private const double triggerThreshold = 0.11765;
+
         internal static bool Back;
 
         private static int PlatformGetMaxNumberOfGamePads()
@@ -94,7 +100,6 @@ namespace Microsoft.Xna.Framework.Input
                 0;
 
             // Check triggers
-            const double triggerThreshold = 0.1;
             if (triggers.Left > triggerThreshold)
                 buttonStates |= Buttons.LeftTrigger;
             if (triggers.Right > triggerThreshold)

--- a/MonoGame.Framework/Input/GamePad.UWP.cs
+++ b/MonoGame.Framework/Input/GamePad.UWP.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Xna.Framework.Input
         /// Attempts to mimic SharpDX.XInput.Gamepad which defines the trigger threshold as 30 with a range of 0 to 255. 
         /// We trigger here has a range of 0.0 to 1.0. So, 30 / 255 = 0.11765.
         /// </summary>
-        private const double triggerThreshold = 0.11765;
+        private const double TriggerThreshold = 0.11765;
 
         internal static bool Back;
 
@@ -100,9 +100,9 @@ namespace Microsoft.Xna.Framework.Input
                 0;
 
             // Check triggers
-            if (triggers.Left > triggerThreshold)
+            if (triggers.Left > TriggerThreshold)
                 buttonStates |= Buttons.LeftTrigger;
-            if (triggers.Right > triggerThreshold)
+            if (triggers.Right > TriggerThreshold)
                 buttonStates |= Buttons.RightTrigger;
 
             var buttons = new GamePadButtons(buttonStates);


### PR DESCRIPTION
There's no code that could possibly set Buttons.LeftTrigger or Buttons.RightTrigger in UWP mode. This code is similar to: https://github.com/mono/MonoGame/blob/develop/MonoGame.Framework/Input/GamePad.XInput.cs#L251

I tested this in a Windows Universal app using an Xbox 360 Controller and an Xbox One Controller. 