### PR TITLE
Linux Installer Update

### DIFF
--- a/Installers/Linux/Main/mgcb
+++ b/Installers/Linux/Main/mgcb
@@ -1,2 +1,0 @@
-#!/bin/bash
-mono /usr/lib/mono/xbuild/MonoGame/v3.0/Tools/MGCB.exe "$@"

--- a/Installers/Linux/Main/monogame-pipeline
+++ b/Installers/Linux/Main/monogame-pipeline
@@ -1,2 +1,0 @@
-#!/bin/bash
-mono /usr/lib/mono/xbuild/MonoGame/v3.0/Tools/Pipeline.exe "$@"

--- a/Installers/Linux/RUN/uninstall.sh
+++ b/Installers/Linux/RUN/uninstall.sh
@@ -7,7 +7,8 @@ if [ "$(id -u)" != "0" ]; then
 fi
 
 #remove terminal commands for mgcb and pipeline tool
-rm -f /usr/bin/monogame-pipeline
+rm -f /usr/bin/monogame-pipeline-tool
+rm -f /usr/bin/monogame-uninstall
 rm -f /usr/bin/mgcb
 
 #remove application icon


### PR DESCRIPTION
Stuff done:
 - if any previous version is detected the installer will try to find an uninstall script and uninstall it
 - added "monogame-uninstall" command for easier uninstallation
 - MonoGame Pipeline > MonoGame Pipeline Tool name change
 - monogame-pipeline > monogame-pipeline-tool command change
 - dependencies are now getting checked like in the screenshoot bellow
 - some minor tweaking to what is shown

![deps](https://cloud.githubusercontent.com/assets/6773302/15541093/043e2c38-228b-11e6-8c56-1d0399d53cd1.png)