### PR TITLE
Fixed the DisplayMode Ordering so it orders the display modes from smallest to highest.

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsAdapter.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.cs
@@ -326,6 +326,11 @@ namespace Microsoft.Xna.Framework.Graphics
                     adapter.Dispose();
                     dxgiFactory.Dispose();
 #endif
+                    modes.Sort (delegate (DisplayMode a, DisplayMode b) {
+                        if (a == b) return 0;
+                        if (a.Format <= b.Format && a.Width <= b.Width && a.Height <= b.Height) return -1;
+                        else return 1;
+                    });
                     _supportedDisplayModes = new DisplayModeCollection(modes);
                 }
 


### PR DESCRIPTION
XNA seems to report the DisplayModes in size order from small to large.
So the largest is at the end of the list. This commit makes sure that
we do the same.