### PR TITLE
List only the displaymodes for the current display.

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsAdapter.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.cs
@@ -61,6 +61,8 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             _screen = screen;
         }
+#elif DESKTOPGL
+        int _displayIndex;
 #else
         internal GraphicsAdapter()
         {
@@ -280,30 +282,31 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             get
             {
-
-                if (_supportedDisplayModes == null)
+                bool displayChanged = false;
+#if DESKTOPGL
+                var displayIndex = Sdl.Display.GetWindowDisplayIndex (SdlGameWindow.Instance.Handle);
+                displayChanged = displayIndex != _displayIndex;
+#endif
+                if (_supportedDisplayModes == null || displayChanged)
                 {
                     var modes = new List<DisplayMode>(new[] { CurrentDisplayMode, });
 
 #if DESKTOPGL
-                    var displayCount = Sdl.Display.GetNumVideoDisplays();
+                    _displayIndex = displayIndex;
                     modes.Clear();
                     
-                    for (int displayIndex = 0; displayIndex < displayCount;displayIndex++)
+                    var modeCount = Sdl.Display.GetNumDisplayModes(displayIndex);
+
+                    for (int i = 0;i < modeCount;i++)
                     {
-                        var modeCount = Sdl.Display.GetNumDisplayModes(displayIndex);
+                        Sdl.Display.Mode mode;
+                        Sdl.Display.GetDisplayMode(displayIndex, i, out mode);
 
-                        for (int i = 0;i < modeCount;i++)
-                        {
-                            Sdl.Display.Mode mode;
-                            Sdl.Display.GetDisplayMode(displayIndex, i, out mode);
-
-                            // We are only using one format, Color
-                            // mode.Format gets the Color format from SDL
-                            var displayMode = new DisplayMode(mode.Width, mode.Height, SurfaceFormat.Color);
-                            if (!modes.Contains(displayMode))
-                                modes.Add(displayMode);
-                        }
+                        // We are only using one format, Color
+                        // mode.Format gets the Color format from SDL
+                        var displayMode = new DisplayMode(mode.Width, mode.Height, SurfaceFormat.Color);
+                        if (!modes.Contains(displayMode))
+                            modes.Add(displayMode);
                     }
 #elif DIRECTX && !WINDOWS_PHONE
                     var dxgiFactory = new SharpDX.DXGI.Factory1();


### PR DESCRIPTION
In the current implementation of the SDL back end we list ALL
the displaymodes for evey display. I need to check with XNA but
it seems we should only list the modes for the current display. Otherwise
you might end up trying to set a mode which isn't supported.

Anyone with XNA able to confirm the DisplayMode list is for the "current" display only.