### PR TITLE
Fix GetBufferData for Index- and VertexBuffer on OpenGL

### DIFF
--- a/MonoGame.Framework/Graphics/Vertices/IndexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/IndexBuffer.OpenGL.cs
@@ -76,10 +76,10 @@ namespace Microsoft.Xna.Framework.Graphics
 #if !GLES
         private void GetBufferData<T>(int offsetInBytes, T[] data, int startIndex, int elementCount) where T : struct
         {
-            GL.BindBuffer(BufferTarget.ArrayBuffer, ibo);
+            GL.BindBuffer(BufferTarget.ElementArrayBuffer, ibo);
             GraphicsExtensions.CheckGLError();
             var elementSizeInByte = Marshal.SizeOf(typeof(T));
-            IntPtr ptr = GL.MapBuffer(BufferTarget.ArrayBuffer, BufferAccess.ReadOnly);
+            IntPtr ptr = GL.MapBuffer(BufferTarget.ElementArrayBuffer, BufferAccess.ReadOnly);
             // Pointer to the start of data to read in the index buffer
             ptr = new IntPtr(ptr.ToInt64() + offsetInBytes);
 			if (typeof(T) == typeof(byte))
@@ -87,7 +87,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 byte[] buffer = data as byte[];
                 // If data is already a byte[] we can skip the temporary buffer
                 // Copy from the index buffer to the destination array
-                Marshal.Copy(ptr, buffer, 0, buffer.Length);
+                Marshal.Copy(ptr, buffer, startIndex * elementSizeInByte, elementCount * elementSizeInByte);
             }
             else
             {
@@ -98,7 +98,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 // Copy from the temporary buffer to the destination array
                 Buffer.BlockCopy(buffer, 0, data, startIndex * elementSizeInByte, elementCount * elementSizeInByte);
             }
-            GL.UnmapBuffer(BufferTarget.ArrayBuffer);
+            GL.UnmapBuffer(BufferTarget.ElementArrayBuffer);
             GraphicsExtensions.CheckGLError();
         }
 #endif

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.OpenGL.cs
@@ -83,13 +83,13 @@ namespace Microsoft.Xna.Framework.Graphics
             var elementSizeInByte = Marshal.SizeOf(typeof(T));
             IntPtr ptr = GL.MapBuffer (BufferTarget.ArrayBuffer, BufferAccess.ReadOnly);
             GraphicsExtensions.CheckGLError();
-            // Pointer to the start of data to read in the index buffer
+            // Pointer to the start of data to read in the vertex buffer
             ptr = new IntPtr (ptr.ToInt64 () + offsetInBytes);
 			if (typeof(T) == typeof(byte)) {
                 byte[] buffer = data as byte[];
                 // If data is already a byte[] we can skip the temporary buffer
                 // Copy from the vertex buffer to the destination array
-                Marshal.Copy (ptr, buffer, 0, buffer.Length);
+                Marshal.Copy (ptr, buffer, startIndex * vertexStride, elementCount * vertexStride);
             } else {
                 // Temporary buffer to store the copied section of data
                 byte[] buffer = new byte[elementCount * vertexStride - offsetInBytes];
@@ -119,7 +119,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 //Buffer.BlockCopy(buffer, 0, data, startIndex * elementSizeInByte, elementCount * elementSizeInByte);
             }
             GL.UnmapBuffer(BufferTarget.ArrayBuffer);
-            }
+            GraphicsExtensions.CheckGLError();
+        }
         
 #endif
 


### PR DESCRIPTION
Binding was wrong in IndexBuffer and both did not take startIndex and elementCount into account in all cases.