### PR TITLE
[SDL] Fix event struct size

### DIFF
--- a/MonoGame.Framework/SDL/SDL2.cs
+++ b/MonoGame.Framework/SDL/SDL2.cs
@@ -50,7 +50,7 @@ internal static class Sdl
         MouseWheel = 0x403,
     }
 
-    [StructLayout(LayoutKind.Explicit)]
+    [StructLayout(LayoutKind.Explicit, Size = 56)]
     public struct Event
     {
         [FieldOffset(0)] public EventType Type;


### PR DESCRIPTION
Huge thanks to @RHY3756547  who noticed it in http://community.monogame.net/t/sdl2-backend-corrupts-memory-after-sdl-pollevent/7704

@dellis1972 @mrhelmut This fixes the problem of running 32 bit SDL and exe on 64 bit host :)