### PR TITLE
[Pipeline Tool] PropertyGridTable Improvements

### DIFF
--- a/Build/Projects/Pipeline.definition
+++ b/Build/Projects/Pipeline.definition
@@ -128,6 +128,7 @@
 	<Compile Include="Controls\PropertyCells\CellBool.cs" />
 	<Compile Include="Controls\PropertyCells\CellColor.cs" />
 	<Compile Include="Controls\PropertyCells\CellCombo.cs" />
+	<Compile Include="Controls\PropertyCells\CellNumber.cs" />
 	<Compile Include="Controls\PropertyCells\CellPath.cs" />
 	<Compile Include="Controls\PropertyCells\CellRefs.cs" />
 	<Compile Include="Controls\PropertyCells\CellText.cs" />

--- a/Tools/Pipeline/Controls/PropertyCells/CellBase.cs
+++ b/Tools/Pipeline/Controls/PropertyCells/CellBase.cs
@@ -16,7 +16,8 @@ namespace MonoGame.Tools.Pipeline
         public string Text { get; set; }
         public bool Editable { get; set; }
 
-        internal EventHandler _eventHandler;
+        protected EventHandler _eventHandler;
+        protected Rectangle _lastRec;
 
         public CellBase(string category, string name, object value, EventHandler eventHandler = null)
         {
@@ -46,6 +47,10 @@ namespace MonoGame.Tools.Pipeline
 
         public virtual void DrawCell(Graphics g, Rectangle rec, int separatorPos, bool selected)
         {
+            _lastRec = rec;
+            _lastRec.X += separatorPos;
+            _lastRec.Width -= separatorPos - 1;
+
             g.DrawText(SystemFonts.Default(), PropInfo.GetTextColor(selected, !Editable), separatorPos + 5, rec.Y + (rec.Height - PropInfo.TextHeight) / 2, DisplayValue);
         }
     }

--- a/Tools/Pipeline/Controls/PropertyCells/CellCombo.cs
+++ b/Tools/Pipeline/Controls/PropertyCells/CellCombo.cs
@@ -10,10 +10,7 @@ namespace MonoGame.Tools.Pipeline
 {
     public class CellCombo : CellBase
     {
-        public static int Height;
-
         private object _type;
-        private Rectangle _lastRec;
 
         public CellCombo(string category, string name, object value, object type, EventHandler eventHandler) : base(category, name, value, eventHandler)
         {
@@ -61,9 +58,8 @@ namespace MonoGame.Tools.Pipeline
                 }
             }
 
-            Height = _lastRec.Height;
             combo.Style = "OverrideSize";
-            combo.Width = _lastRec.Width + 1;
+            combo.Width = _lastRec.Width;
             combo.Height = _lastRec.Height;
             control.Add(combo, _lastRec.X, _lastRec.Y);
 
@@ -79,17 +75,9 @@ namespace MonoGame.Tools.Pipeline
                 else
                     _eventHandler(PipelineTypes.Processors[combo.SelectedIndex], EventArgs.Empty);
 
+                combo.Enabled = true;
                 control.Add(combo, _lastRec.X, _lastRec.Y);
             };
-        }
-
-        public override void Draw(Graphics g, Rectangle rec, int separatorPos, bool selected)
-        {
-            _lastRec = rec;
-            _lastRec.X += separatorPos;
-            _lastRec.Width -= separatorPos;
-
-            base.Draw(g, rec, separatorPos, selected);
         }
     }
 }

--- a/Tools/Pipeline/Controls/PropertyCells/CellNumber.cs
+++ b/Tools/Pipeline/Controls/PropertyCells/CellNumber.cs
@@ -7,11 +7,12 @@ using Eto.Forms;
 
 namespace MonoGame.Tools.Pipeline
 {
-    public class CellText : CellBase
+    public class CellNumber : CellBase
     {
-        public CellText(string category, string name, object value, EventHandler eventHandler, bool editable) : base(category, name, value, eventHandler)
+        public CellNumber(string category, string name, object value, EventHandler eventHandler) : base(category, name, value, eventHandler)
         {
-            Editable = editable && value is string;
+            DisplayValue = ((float)value).ToString("0.00");
+            DisplayValue = (DisplayValue.Length > Value.ToString().Length) ? DisplayValue : Value.ToString();
         }
 
         public override void Edit(PixelLayout control)
@@ -20,16 +21,23 @@ namespace MonoGame.Tools.Pipeline
             editText.Style = "OverrideSize";
             editText.Width = _lastRec.Width;
             editText.Height = _lastRec.Height;
-            editText.Text = Value.ToString();
+            editText.Text = DisplayValue;
 
             control.Add(editText, _lastRec.X, _lastRec.Y);
+
+            editText.Focus();
+            editText.CaretIndex = editText.Text.Length;
 
             editText.EnabledChanged += delegate
             {
                 if (_eventHandler == null)
                     return;
-                
-                _eventHandler(editText.Text, EventArgs.Empty);
+
+                try
+                {
+                    _eventHandler(float.Parse(editText.Text), EventArgs.Empty);
+                }
+                catch { }
             };
         }
     }

--- a/Tools/Pipeline/Controls/PropertyGridTable.cs
+++ b/Tools/Pipeline/Controls/PropertyGridTable.cs
@@ -87,8 +87,13 @@ namespace MonoGame.Tools.Pipeline
             var children = pixel1.Children.ToList();
 
             foreach (var control in children)
+            {
                 if (control != drawable)
+                {
+                    control.Enabled = false;
                     pixel1.Remove(control);
+                }
+            }
         }
 
         public void AddEntry(string category, string name, object value, object type, EventHandler eventHandler = null, bool editable = true)
@@ -103,6 +108,8 @@ namespace MonoGame.Tools.Pipeline
                 _cells.Add(new CellRefs(category, name, value, eventHandler));
             else if (type is Microsoft.Xna.Framework.Color)
                 _cells.Add(new CellColor(category, name, value, eventHandler));
+            else if(type is Single)
+                _cells.Add(new CellNumber(category, name, value, eventHandler));
             else
                 _cells.Add(new CellText(category, name, value, eventHandler, editable));
         }

--- a/Tools/Pipeline/Global.Linux.cs
+++ b/Tools/Pipeline/Global.Linux.cs
@@ -51,7 +51,7 @@ namespace MonoGame.Tools.Pipeline
 
             if (Gtk.Global.MajorVersion >= 3 && Gtk.Global.MinorVersion >= 16)
             {
-                _app = new Gtk.Application("MonoGame.Pipeline.Tool", GLib.ApplicationFlags.None);
+                _app = new Gtk.Application(null, GLib.ApplicationFlags.None);
                 _app.Register(GLib.Cancellable.Current);
 
                 UseHeaderBar = Gtk3Wrapper.gtk_application_prefers_app_menu(_app.Handle);

--- a/Tools/Pipeline/Styles.Linux.cs
+++ b/Tools/Pipeline/Styles.Linux.cs
@@ -255,13 +255,11 @@ namespace MonoGame.Tools.Pipeline
             {
                 var cell = (h.Control.Child as Gtk.ComboBox).Cells[0] as Gtk.CellRendererText;
                 cell.Ellipsize = Pango.EllipsizeMode.End;
+            });
 
-                h.Control.SizeAllocated += delegate
-                {
-                    var al = h.Control.Allocation;
-                    al.Height = CellCombo.Height;
-                    h.Control.SetAllocation(al);
-                };
+            Style.Add<TextBoxHandler>("OverrideSize", h =>
+            {
+                h.Control.WidthChars = 0;
             });
         }
     }


### PR DESCRIPTION
Stuff done:
 - text editing now has a textbox inside property grid
 - numbers are now editable and have a textbox inside combobox (fixes #4905)
 - disabled height overriding of cellcombo for Gtk, it got cut off on some themes

PS. I snuck in a line of change to `Global.Linux.cs` since I noticed a bug with it while doing this PR