### PR TITLE
Fixes logical buffer store when swapping the default framebuffer (iOS)

### DIFF
--- a/MonoGame.Framework/iOS/iOSGameView.cs
+++ b/MonoGame.Framework/iOS/iOSGameView.cs
@@ -219,12 +219,28 @@ namespace Microsoft.Xna.Framework {
 
 			_glapi.GenFramebuffers (1, ref _framebuffer);
 			_glapi.BindFramebuffer (All.Framebuffer, _framebuffer);
-			
+
 			// Create our Depth buffer. Color buffer must be the last one bound
-			GL.GenRenderbuffers(1, out _depthbuffer);
-			GL.BindRenderbuffer(RenderbufferTarget.Renderbuffer, _depthbuffer);
-            GL.RenderbufferStorage(RenderbufferTarget.Renderbuffer, RenderbufferInternalFormat.DepthComponent16, viewportWidth, viewportHeight);
-			GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferSlot.DepthAttachment, RenderbufferTarget.Renderbuffer, _depthbuffer);
+            var gdm = _platform.Game.Services.GetService(
+                typeof(IGraphicsDeviceManager)) as GraphicsDeviceManager;
+            if (gdm != null)
+            {
+                var preferredDepthFormat = gdm.PreferredDepthStencilFormat;
+                if (preferredDepthFormat != DepthFormat.None)
+                {
+                    GL.GenRenderbuffers(1, out _depthbuffer);
+                    GL.BindRenderbuffer(RenderbufferTarget.Renderbuffer, _depthbuffer);
+                    var internalFormat = All.DepthComponent16;
+                    if (preferredDepthFormat == DepthFormat.Depth24)
+                        internalFormat = All.DepthComponent24Oes;
+                    else if (preferredDepthFormat == DepthFormat.Depth24Stencil8)
+                        internalFormat = All.Depth24Stencil8Oes;
+                    GL.RenderbufferStorage(RenderbufferTarget.Renderbuffer, (RenderbufferInternalFormat)internalFormat, viewportWidth, viewportHeight);
+                    GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferSlot.DepthAttachment, RenderbufferTarget.Renderbuffer, _depthbuffer);
+                    if (preferredDepthFormat == DepthFormat.Depth24Stencil8)
+                        GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferSlot.StencilAttachment, RenderbufferTarget.Renderbuffer, _depthbuffer);
+                }
+            }
 
 			_glapi.GenRenderbuffers(1, ref _colorbuffer);
 			_glapi.BindRenderbuffer(All.Renderbuffer, _colorbuffer);
@@ -301,9 +317,14 @@ namespace Microsoft.Xna.Framework {
 			_glapi.DeleteRenderbuffers (1, ref _colorbuffer);
 			_colorbuffer = 0;
 			
-			_glapi.DeleteRenderbuffers (1, ref _depthbuffer);
-			_depthbuffer = 0;
+            if (_depthbuffer != 0)
+            {
+			    _glapi.DeleteRenderbuffers (1, ref _depthbuffer);
+			    _depthbuffer = 0;
+            }
 		}
+
+        private static readonly All[] attachements = new All[] { All.DepthAttachment, All.StencilAttachment };
 
 		// FIXME: This logic belongs in GraphicsDevice.Present, not
 		//        here.  If it can someday be moved there, then the
@@ -316,7 +337,8 @@ namespace Microsoft.Xna.Framework {
             AssertValidContext ();
 
             this.MakeCurrent();
-            GL.BindRenderbuffer (All.Renderbuffer, this._colorbuffer);
+            GL.BindRenderbuffer(RenderbufferTarget.Renderbuffer, this._colorbuffer);
+            GraphicsDevice.FramebufferHelper.GLDiscardFramebufferExt(All.Framebuffer, 2, attachements);
             __renderbuffergraphicsContext.SwapBuffers();
 		}
 

--- a/MonoGame.Framework/iOS/iOSGameView.cs
+++ b/MonoGame.Framework/iOS/iOSGameView.cs
@@ -364,7 +364,7 @@ namespace Microsoft.Xna.Framework {
             if (gds == null || gds.GraphicsDevice == null)
                 return;
 
-			if (_framebuffer + _colorbuffer + _depthbuffer != 0)
+			if (_framebuffer != 0)
 				DestroyFramebuffer ();
 			if (__renderbuffergraphicsContext == null)
 				CreateContext();
@@ -381,7 +381,7 @@ namespace Microsoft.Xna.Framework {
                 
                 if (__renderbuffergraphicsContext == null)
                     CreateContext ();
-                if (_framebuffer * _colorbuffer * _depthbuffer == 0)
+                if (_framebuffer == 0)
                     CreateFramebuffer ();
             }
 		}


### PR DESCRIPTION
Discards the depth/stencil attached to the main framebuffer (if any) to avoid a [logical buffer store](https://developer.apple.com/library/ios/documentation/3DDrawing/Conceptual/OpenGLES_ProgrammingGuide/WorkingwithEAGLContexts/WorkingwithEAGLContexts.html#//apple_ref/doc/uid/TP40008793-CH105-SW7) operation when the main framebuffer is swapped.
This also adds proper depth/stencil initialization based on the value of `GraphicsDeviceManager.PreferredDepthFormat`.