### PR TITLE
Fix typo in SDL GL bindings

### DIFF
--- a/MonoGame.Framework/SDL/SDL2.cs
+++ b/MonoGame.Framework/SDL/SDL2.cs
@@ -367,7 +367,7 @@ internal static class Sdl
             BlueSize,
             AlphaSize,
             BufferSize,
-            DoubleFuffer,
+            DoubleBuffer,
             DepthSize,
             StencilSize,
             AccumRedSize,

--- a/MonoGame.Framework/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/SDL/SDLGameWindow.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Xna.Framework
                     Sdl.GL.SetAttribute (Sdl.GL.Attribute.StencilSize, 8);
                     break;
             }
-            Sdl.GL.SetAttribute (Sdl.GL.Attribute.DoubleFuffer, 1);
+            Sdl.GL.SetAttribute (Sdl.GL.Attribute.DoubleBuffer, 1);
             Sdl.GL.SetAttribute (Sdl.GL.Attribute.ContextMajorVersion, 2);
             Sdl.GL.SetAttribute (Sdl.GL.Attribute.ContextMinorVersion, 1);
             


### PR DESCRIPTION
@dellis1972 I think I can safely blame you for this one XD

This PR has nothing functional, just fixes a typo. (DoubleFuffer -> DoubleBuffer)