### PR TITLE
Fix Mouse updating when moving the Window

### DIFF
--- a/MonoGame.Framework/Input/Mouse.SDL.cs
+++ b/MonoGame.Framework/Input/Mouse.SDL.cs
@@ -23,8 +23,7 @@ namespace Microsoft.Xna.Framework.Input
             var state = (Sdl.Patch > 4) ? // SDL 2.0.4 has a bug with Global Mouse
                     Sdl.Mouse.GetGlobalState(out x, out y) :
                     Sdl.Mouse.GetState(out x, out y);
-            var clientBounds = window.ClientBounds;
-
+            
             if (winFlags.HasFlag(Sdl.Window.State.MouseFocus))
             {
                 window.MouseState.LeftButton = (state.HasFlag(Sdl.Mouse.Button.Left)) ? ButtonState.Pressed : ButtonState.Released;
@@ -34,10 +33,11 @@ namespace Microsoft.Xna.Framework.Input
                 window.MouseState.XButton2 = (state.HasFlag(Sdl.Mouse.Button.X2Mask)) ? ButtonState.Pressed : ButtonState.Released;
 
                 window.MouseState.ScrollWheelValue = ScrollY;
-            }
 
-            window.MouseState.X = x - ((Sdl.Patch > 4) ? clientBounds.X : 0);
-            window.MouseState.Y = y - ((Sdl.Patch > 4) ? clientBounds.Y : 0);
+                var clientBounds = window.ClientBounds;
+                window.MouseState.X = x - ((Sdl.Patch > 4) ? clientBounds.X : 0);
+                window.MouseState.Y = y - ((Sdl.Patch > 4) ? clientBounds.Y : 0);
+            }
 
             return window.MouseState;
         }


### PR DESCRIPTION
When you click and hold the title bar of the window
and move it around we are still updating the X/Y
location of the Mouse. This does not happen in XNA
and it makes things look a bit weird as far as the
user is concerned.

This commit just moves the updating of the X/Y position
into the check that the mouse has Focus. This fixes the
issue since when we click on the Title bar the Mouse does
NOT have focus.