### PR TITLE
Remove restriction on HardwareModeSwitch

### DIFF
--- a/MonoGame.Framework/GraphicsDeviceManager.Legacy.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.Legacy.cs
@@ -487,15 +487,14 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// Gets or sets the boolean which defines how window switches from windowed to fullscreen state.
         /// "Hard" mode(true) is slow to switch, but more effecient for performance, while "soft" mode(false) is vice versa.
-        /// The default value is <c>true</c>. Can only be changed before graphics device is created (in game's constructor).
+        /// The default value is <c>true</c>.
         /// </summary>
         public bool HardwareModeSwitch
         {
             get { return _hardwareModeSwitch; }
             set
             {
-                if (_graphicsDevice == null) _hardwareModeSwitch = value;
-                else throw new InvalidOperationException("This property can only be changed before graphics device is created(in game constructor).");
+                _hardwareModeSwitch = value;
             }
         }
 

--- a/MonoGame.Framework/GraphicsDeviceManager.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.cs
@@ -332,17 +332,14 @@ namespace Microsoft.Xna.Framework
         /// <summary>
         /// Gets or sets the boolean which defines how window switches from windowed to fullscreen state.
         /// "Hard" mode(true) is slow to switch, but more effecient for performance, while "soft" mode(false) is vice versa.
-        /// The default value is <c>true</c>. Can only be changed before graphics device is created (in game's constructor).
+        /// The default value is <c>true</c>.
         /// </summary>
         public bool HardwareModeSwitch
         {
             get { return _hardwareModeSwitch;}
             set
             {
-                if (_graphicsDevice == null) 
-                    _hardwareModeSwitch = value;
-                else 
-                    throw new InvalidOperationException("This property can only be changed before graphics device is created(in game constructor).");
+                _hardwareModeSwitch = value;
             }
         }
 


### PR DESCRIPTION
The HardwareModeSwitch property controls if the game window
goes into hard full screen or into a 'soft' fullscreen (which
is basically a fullscreen borderless form).

There is a use case where the developer might want to allow
the user the ability to switch between the two. Plus I cannot
see any hardware reason why this cannot be changed at runtime.