### PR TITLE
Update Xamarin Studio addin #4917

### DIFF
--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame.addin.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame.addin.xml
@@ -61,6 +61,17 @@
     <Import file="MonoDevelop.MonoGame.Core.dll" />
     <Import file="MonoDevelop.MonoGame.iOS.dll" />
     <Import file="MonoDevelop.MonoGame.Mac.dll" />
+    <!-- Native Libraries -->
+    <Import file="templates/libs/x64/libopenal.so.1" />
+    <Import file="templates/libs/x86/libopenal.so.1" />
+    <Import file="templates/libs/libopenal.1.dylib" />
+    <Import file="templates/libs/x64/soft_oal.dll" />
+    <Import file="templates/libs/x86/soft_oal.dll" />
+    <Import file="templates/libs/x64/libSDL2-2.0.so.0" />
+    <Import file="templates/libs/x86/libSDL2-2.0.so.0" />
+    <Import file="templates/libs/libSDL2-2.0.0.dylib" />
+    <Import file="templates/libs/x64/SDL2.dll" />
+    <Import file="templates/libs/x86/SDL2.dll" />
     <!-- Nuget Packages -->
     <Import file="packages/MonoGame.Framework.Android.3.4.0.459.nupkg" />
     <Import file="packages/MonoGame.Framework.iOS.3.4.0.459.nupkg" />

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame.csproj
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/MonoDevelop.MonoGame.csproj
@@ -91,6 +91,9 @@
     <Folder Include="templates\" />
     <Folder Include="templates\Common\" />
     <Folder Include="packages\" />
+    <Folder Include="templates\libs\" />
+    <Folder Include="templates\libs\x64\" />
+    <Folder Include="templates\libs\x86\" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="templates\MonoGameWindowsProject.xpt.xml">
@@ -192,6 +195,46 @@
     </Content>
     <Content Include="..\..\..\ThirdParty\Dependencies\MonoGame.Framework.dll.config">
       <Link>templates\Common\MonoGame.Framework.dll.config</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\..\ThirdParty\Dependencies\openal-soft\MacOS\Universal\libopenal.1.dylib">
+      <Link>templates\libs\libopenal.1.dylib</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\..\ThirdParty\Dependencies\openal-soft\Linux\x64\libopenal.so.1">
+      <Link>templates\libs\x64\libopenal.so.1</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\..\ThirdParty\Dependencies\openal-soft\Windows\x64\soft_oal.dll">
+      <Link>templates\libs\x64\soft_oal.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\..\ThirdParty\Dependencies\openal-soft\Windows\x86\soft_oal.dll">
+      <Link>templates\libs\x86\soft_oal.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\..\ThirdParty\Dependencies\openal-soft\Linux\x86\libopenal.so.1">
+      <Link>templates\libs\x86\libopenal.so.1</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\..\ThirdParty\Dependencies\SDL\Linux\x64\libSDL2-2.0.so.0">
+      <Link>templates\libs\x64\libSDL2-2.0.so.0</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\..\ThirdParty\Dependencies\SDL\Windows\x64\SDL2.dll">
+      <Link>templates\libs\x64\SDL2.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\..\ThirdParty\Dependencies\SDL\Windows\x86\SDL2.dll">
+      <Link>templates\libs\x86\SDL2.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\..\ThirdParty\Dependencies\SDL\Linux\x86\libSDL2-2.0.so.0">
+      <Link>templates\libs\x86\libSDL2-2.0.so.0</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\..\ThirdParty\Dependencies\SDL\MacOS\Universal\libSDL2-2.0.0.dylib">
+      <Link>templates\libs\libSDL2-2.0.0.dylib</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/exclude.addins
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/exclude.addins
@@ -3,6 +3,10 @@
     <Exclude>nvtt.dll</Exclude>
 	<Exclude>freetype6.dll</Exclude>
 	<Exlcude>pvrtc.dll</Exlcude>
+	<Exlcude>templates/libs/x86/SDL2.dll</Exlcude>
+	<Exlcude>templates/libs/x64/SDL2.dll</Exlcude>
+	<Exclude>templates/libs/x86/soft_oal.dll</Exclude>
+	<Exclude>templates/libs/x64/soft_oal.dll</Exclude>
 	<!--
 	<Exclude>libnvtt.dylib</Exlcude>
 	<Exclude>libnvimage.dylib</Exlcude>

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/Common/Game1.cs
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/Common/Game1.cs
@@ -2,7 +2,6 @@ using System;
 
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Storage;
 using Microsoft.Xna.Framework.Input;
 
 namespace ${Namespace}

--- a/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameProject.xpt.xml
+++ b/IDE/MonoDevelop/MonoDevelop.MonoGame/templates/MonoGameProject.xpt.xml
@@ -36,8 +36,42 @@
 				<Directory name="Content">
 					<File name="Content.mgcb" src="Common/Content.mgcb" BuildAction="MonoGameContentReference" />
 				</Directory>
+				<Directory name="x64">
+					<ContentFile>
+						<RawFile name="libopenal.so.1" src="libs/x64/libopenal.so.1" CopyToOutputDirectory="PreserveNewest" />
+					</ContentFile>
+					<ContentFile>
+						<RawFile name="soft_oal.dll" src="libs/x64/soft_oal.dll" CopyToOutputDirectory="PreserveNewest" />
+					</ContentFile>
+					<ContentFile>
+						<RawFile name="libSDL2-2.0.so.0" src="libs/x64/libSDL2-2.0.so.0" CopyToOutputDirectory="PreserveNewest" />
+					</ContentFile>
+					<ContentFile>
+						<RawFile name="SDL2.dll" src="libs/x64/SDL2.dll" CopyToOutputDirectory="PreserveNewest" />
+					</ContentFile>
+				</Directory>
+				<Directory name="x86">
+					<ContentFile>
+						<RawFile name="libopenal.so.1" src="libs/x86/libopenal.so.1" CopyToOutputDirectory="PreserveNewest" />
+					</ContentFile>
+					<ContentFile>
+						<RawFile name="soft_oal.dll" src="libs/x86/soft_oal.dll" CopyToOutputDirectory="PreserveNewest" />
+					</ContentFile>
+					<ContentFile>
+						<RawFile name="libSDL2-2.0.so.0" src="libs/x86/libSDL2-2.0.so.0" CopyToOutputDirectory="PreserveNewest" />
+					</ContentFile>
+					<ContentFile>
+						<RawFile name="SDL2.dll" src="libs/x86/SDL2.dll" CopyToOutputDirectory="PreserveNewest" />
+					</ContentFile>
+				</Directory>
 				<ContentFile>
 					<File name="MonoGame.Framework.dll.config" src="Common/MonoGame.Framework.dll.config" CopyToOutputDirectory="PreserveNewest" />
+				</ContentFile>
+				<ContentFile>
+					<RawFile name="libopenal.1.dylib" src="libs/libopenal.1.dylib" CopyToOutputDirectory="PreserveNewest" />
+				</ContentFile>
+				<ContentFile>
+					<RawFile name="libSDL2-2.0.0.dylib" src="libs/libSDL2-2.0.0.dylib" CopyToOutputDirectory="PreserveNewest" />
 				</ContentFile>
 			</Files>
 		</Project>


### PR DESCRIPTION
This commit Fixes #4917 it adds the required native
libraries for the DesktopGL template. It also removes
the Storage namespace from the template.