### PR TITLE
Silently catching haptic initialization failures

### DIFF
--- a/MonoGame.Framework/Input/GamePad.SDL.cs
+++ b/MonoGame.Framework/Input/GamePad.SDL.cs
@@ -68,8 +68,15 @@ namespace Microsoft.Xna.Framework.Input
 
             if (Sdl.Haptic.EffectSupported(gamepad.HapticDevice, ref _hapticLeftRightEffect) == 1)
             {
-                Sdl.Haptic.NewEffect(gamepad.HapticDevice, ref _hapticLeftRightEffect);
-                gamepad.HapticType = 1;
+                try // for some reason, even if a GamePad "supports" the haptic effect, it may still fail on some low-end gamepads
+                {
+                    Sdl.Haptic.NewEffect(gamepad.HapticDevice, ref _hapticLeftRightEffect);
+                    gamepad.HapticType = 1;
+                }
+                catch (Exception)
+                {
+                    Sdl.Haptic.Close(gamepad.HapticDevice);
+                }
             }
             else if (Sdl.Haptic.RumbleSupported(gamepad.HapticDevice) == 1)
             {


### PR DESCRIPTION
I have a few crash reports stating that ```Sdl.Haptic.NewEffect()``` may fail (error message = "Haptic error Unable to create effect") even though ```Sdl.Haptic.EffectSupported()``` succeed.
I can't be sure, but I believe this is due to some low-end gamepads having weird/wrong capabilities.

This PR silently catch the error and closes the haptic device to continue normally without haptic support.

cc @cra0zy @tomspilman 