### PR TITLE
Make TitleContainer resolve resource paths on Windows

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -359,7 +359,10 @@
       <Platforms>iOS,tvOS,MacOS</Platforms>
     </Compile>
     <Compile Include="TitleContainer.WinRT.cs">
-      <Platforms>Windows8,WindowsPhone,WindowsPhone81,WindowsUniversal</Platforms>
+      <Platforms>Windows8,WindowsPhone81,WindowsUniversal</Platforms>
+    </Compile>
+    <Compile Include="TitleContainer.WP.cs">
+      <Platforms>WindowsPhone</Platforms>
     </Compile>
     <Compile Include="Vector2.cs" />
     <Compile Include="Vector3.cs" />

--- a/MonoGame.Framework/TitleContainer.WP.cs
+++ b/MonoGame.Framework/TitleContainer.WP.cs
@@ -1,0 +1,41 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Microsoft.Xna.Framework
+{
+    partial class TitleContainer
+    {
+        static partial void PlatformInit()
+        {
+            Location = Windows.ApplicationModel.Package.Current.InstalledLocation.Path;
+        }
+
+        private static async Task<Stream> OpenStreamAsync(string name)
+        {
+            var package = Windows.ApplicationModel.Package.Current;
+
+            try
+            {
+                var storageFile = await package.InstalledLocation.GetFileAsync(name);
+                var randomAccessStream = await storageFile.OpenReadAsync();
+                return randomAccessStream.AsStreamForRead();
+            }
+            catch (IOException)
+            {
+                // The file must not exist... return a null stream.
+                return null;
+            }
+        }
+
+        private static Stream PlatformOpenStream(string safeName)
+        {
+            return Task.Run(() => OpenStreamAsync(safeName).Result).Result;
+        }
+    }
+}
+

--- a/MonoGame.Framework/TitleContainer.WinRT.cs
+++ b/MonoGame.Framework/TitleContainer.WinRT.cs
@@ -5,29 +5,47 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using Windows.ApplicationModel.Resources.Core;
 
 namespace Microsoft.Xna.Framework
 {
     partial class TitleContainer
     {
+        static internal ResourceContext ResourceContext;
+        static internal ResourceMap FileResourceMap;
+
         static partial void PlatformInit()
         {
             Location = Windows.ApplicationModel.Package.Current.InstalledLocation.Path;
+
+            ResourceContext = new Windows.ApplicationModel.Resources.Core.ResourceContext();
+            FileResourceMap = ResourceManager.Current.MainResourceMap.GetSubtree("Files");
         }
 
         private static async Task<Stream> OpenStreamAsync(string name)
         {
             var package = Windows.ApplicationModel.Package.Current;
 
-            try
+            NamedResource result;
+
+            if (FileResourceMap != null && FileResourceMap.TryGetValue(name, out result))
             {
-                var storageFile = await package.InstalledLocation.GetFileAsync(name);
-                var randomAccessStream = await storageFile.OpenReadAsync();
-                return randomAccessStream.AsStreamForRead();
+                var resolved = result.Resolve(ResourceContext);
+
+                try
+                {
+                    var storageFile = await resolved.GetValueAsFileAsync();
+                    var randomAccessStream = await storageFile.OpenReadAsync();
+                    return randomAccessStream.AsStreamForRead();
+                }
+                catch (IOException)
+                {
+                    // The file must not exist... return a null stream.
+                    return null;
+                }
             }
-            catch (IOException)
+            else
             {
-                // The file must not exist... return a null stream.
                 return null;
             }
         }

--- a/MonoGame.Framework/TitleContainer.WinRT.cs
+++ b/MonoGame.Framework/TitleContainer.WinRT.cs
@@ -24,8 +24,6 @@ namespace Microsoft.Xna.Framework
 
         private static async Task<Stream> OpenStreamAsync(string name)
         {
-            var package = Windows.ApplicationModel.Package.Current;
-
             NamedResource result;
 
             if (FileResourceMap != null && FileResourceMap.TryGetValue(name, out result))


### PR DESCRIPTION
This is the new version of https://github.com/mono/MonoGame/pull/4132 that splits its TitleContainer code into platform specific files.

When you call the TitleContainer.OpenStream method on Windows platforms, it needs to lookup the location of the specified resource. This is because on Windows 10, resources may be stored outside of the main application folder when using an "application bundle" (now the default setting). 

This solves a problem that we had in production where our game would work fine when deploying from within Visual Studio, but it wouldn't be able to find its localized resources when bundled and deployed via a package. With this PR, localized resources are looked up using the standard Windows APIs and everything works great.

This API is available for Windows8, WindowsPhone81, and WindowsUniversal but not for WindowsPhone (8.0), so the TitleContainer was split appropriately to prevent too many #ifs.