### PR TITLE
WinDX: Fixed crash when running from a network path

### DIFF
--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -138,10 +138,7 @@ namespace MonoGame.Framework
             _form = new WinFormsGameForm(this);
             _form.ClientSize = new Size(GraphicsDeviceManager.DefaultBackBufferWidth, GraphicsDeviceManager.DefaultBackBufferHeight);
 
-            // When running unit tests this can return null.
-            var assembly = Assembly.GetEntryAssembly();
-            if (assembly != null)
-                _form.Icon = Icon.ExtractAssociatedIcon(assembly.Location);
+            SetIcon();
             Title = Utilities.AssemblyHelper.GetDefaultWindowTitle();
 
             _form.MaximizeBox = false;
@@ -164,6 +161,20 @@ namespace MonoGame.Framework
             _form.KeyPress += OnKeyPress;
 
             RegisterToAllWindows();
+        }
+
+        [DllImport("shell32.dll", CharSet = CharSet.Auto, BestFitMapping = false)]
+        private static extern IntPtr ExtractIcon(IntPtr hInst, string exeFileName, int iconIndex);
+
+        private void SetIcon()
+        {
+            // When running unit tests this can return null.
+            var assembly = Assembly.GetEntryAssembly();
+            if (assembly == null)
+                return;
+            var handle = ExtractIcon(IntPtr.Zero, assembly.Location, 0);
+            if (handle != IntPtr.Zero)
+                _form.Icon = Icon.FromHandle(handle);
         }
 
         ~WinFormsGameWindow()


### PR DESCRIPTION
I got a crash report telling me that the `WinFormsGameWindow` constructor had thrown an `ArgumentException` when calling `Icon.ExtractAssociatedIcon`. After some investigation, I found that this same crash would occur when running my game from a UNC network path.

According to the [MSDN documenation](https://msdn.microsoft.com/en-us/library/system.drawing.icon.extractassociatedicon(v=vs.110).aspx), `Icon.ExtractAssociatedIcon` does not support UNC paths (it doesn't say why though). I found a couple of stackoverflow posts<sup>[[1](http://stackoverflow.com/questions/6819466/extractassociatedicon-returns-null)][[2](http://stackoverflow.com/questions/1842226/how-to-get-the-associated-icon-from-a-network-share-file)]</sup> suggesting to use P/Invoke to get around this. So I gave this a try and found that it did indeed work correctly for both UNC and normal file paths.

This PR uses this solution to fix the crash which would occur when running from a UNC network path.