### PR TITLE
Fixed DirectX backbuffer resize behaviour

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/TextureImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/TextureImporter.cs
@@ -157,8 +157,20 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
 
                 default:
                     // Bitmap and other formats are converted to 32-bit by default
+                    // Are we in the BGRA format?  If so, we need to switch R & B instead of R & G
+                    bool isBGRA =
+                        imageType == FREE_IMAGE_TYPE.FIT_BITMAP &&
+                        FreeImage.GetBlueMask(fBitmap) == 0x000000FF &&
+                        FreeImage.GetGreenMask(fBitmap) == 0x0000FF00 &&
+                        FreeImage.GetRedMask(fBitmap) == 0x00FF0000;
+
                     bgra = FreeImage.ConvertTo32Bits(fBitmap);
-                    SwitchRedAndBlueChannels(bgra);
+
+                    if (isBGRA)
+                        SwitchRedAndGreenChannels(bgra);
+                    else
+                        SwitchRedAndBlueChannels(bgra);
+                    
                     FreeImage.UnloadEx(ref fBitmap);
                     fBitmap = bgra;
                     break;
@@ -178,6 +190,19 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             FreeImage.SetChannel(fBitmap, r, FREE_IMAGE_COLOR_CHANNEL.FICC_BLUE);
             FreeImage.UnloadEx(ref r);
             FreeImage.UnloadEx(ref b);
+        }
+        /// <summary>
+        /// Switches the red and green channels
+        /// </summary>
+        /// <param name="fBitmap">image</param>
+        private static void SwitchRedAndGreenChannels(FIBITMAP fBitmap)
+        {
+            var r = FreeImage.GetChannel(fBitmap, FREE_IMAGE_COLOR_CHANNEL.FICC_RED);
+            var g = FreeImage.GetChannel(fBitmap, FREE_IMAGE_COLOR_CHANNEL.FICC_GREEN);
+            FreeImage.SetChannel(fBitmap, g, FREE_IMAGE_COLOR_CHANNEL.FICC_RED);
+            FreeImage.SetChannel(fBitmap, r, FREE_IMAGE_COLOR_CHANNEL.FICC_GREEN);
+            FreeImage.UnloadEx(ref r);
+            FreeImage.UnloadEx(ref g);
         }
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/TextureImporter.cs
+++ b/MonoGame.Framework.Content.Pipeline/TextureImporter.cs
@@ -157,20 +157,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
 
                 default:
                     // Bitmap and other formats are converted to 32-bit by default
-                    // Are we in the BGRA format?  If so, we need to switch R & B instead of R & G
-                    bool isBGRA =
-                        imageType == FREE_IMAGE_TYPE.FIT_BITMAP &&
-                        FreeImage.GetBlueMask(fBitmap) == 0x000000FF &&
-                        FreeImage.GetGreenMask(fBitmap) == 0x0000FF00 &&
-                        FreeImage.GetRedMask(fBitmap) == 0x00FF0000;
-
                     bgra = FreeImage.ConvertTo32Bits(fBitmap);
-
-                    if (isBGRA)
-                        SwitchRedAndGreenChannels(bgra);
-                    else
-                        SwitchRedAndBlueChannels(bgra);
-                    
+                    SwitchRedAndBlueChannels(bgra);
                     FreeImage.UnloadEx(ref fBitmap);
                     fBitmap = bgra;
                     break;
@@ -190,19 +178,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             FreeImage.SetChannel(fBitmap, r, FREE_IMAGE_COLOR_CHANNEL.FICC_BLUE);
             FreeImage.UnloadEx(ref r);
             FreeImage.UnloadEx(ref b);
-        }
-        /// <summary>
-        /// Switches the red and green channels
-        /// </summary>
-        /// <param name="fBitmap">image</param>
-        private static void SwitchRedAndGreenChannels(FIBITMAP fBitmap)
-        {
-            var r = FreeImage.GetChannel(fBitmap, FREE_IMAGE_COLOR_CHANNEL.FICC_RED);
-            var g = FreeImage.GetChannel(fBitmap, FREE_IMAGE_COLOR_CHANNEL.FICC_GREEN);
-            FreeImage.SetChannel(fBitmap, g, FREE_IMAGE_COLOR_CHANNEL.FICC_RED);
-            FreeImage.SetChannel(fBitmap, r, FREE_IMAGE_COLOR_CHANNEL.FICC_GREEN);
-            FreeImage.UnloadEx(ref r);
-            FreeImage.UnloadEx(ref g);
         }
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 #endif
 
-	/// <summary>
+        /// <summary>
         /// Returns a handle to internal device object. Valid only on DirectX platforms.
         /// For usage, convert this to SharpDX.Direct3D11.Device.
         /// </summary>
@@ -601,7 +601,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 supportedFeatureLevel = SharpDX.Direct3D11.Device.GetSupportedFeatureLevel();
             }
             catch (SharpDX.SharpDXException)
-            {   
+            {
                 // if GetSupportedFeatureLevel() fails, do not crash the initialization. Program can run without this.
             }
 
@@ -625,7 +625,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
 
 #if DEBUG
-            try 
+            try
             {
 #endif
                 // Create the Direct3D device.
@@ -633,7 +633,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     _d3dDevice = defaultDevice.QueryInterface<SharpDX.Direct3D11.Device>();
 #if DEBUG
             }
-            catch(SharpDXException)
+            catch (SharpDXException)
             {
                 // Try again without the debug flag.  This allows debug builds to run
                 // on machines that don't have the debug runtime installed.
@@ -647,7 +647,13 @@ namespace Microsoft.Xna.Framework.Graphics
             _d3dContext = _d3dDevice.ImmediateContext.QueryInterface<SharpDX.Direct3D11.DeviceContext>();
         }
 
-        internal void CreateSizeDependentResources(bool useFullscreenParameter = false)
+        internal void SetHardwareFullscreen()
+        {
+            // This force to switch to fullscreen mode when hardware mode enabled(working in WindowsDX mode).
+            _swapChain.SetFullscreenState(PresentationParameters.IsFullScreen, null);
+        }
+
+        internal void CreateSizeDependentResources()
         {
             _d3dContext.OutputMerger.SetTargets((SharpDX.Direct3D11.DepthStencilView)null,
                                                 (SharpDX.Direct3D11.RenderTargetView)null);
@@ -717,16 +723,10 @@ namespace Microsoft.Xna.Framework.Graphics
             if (_swapChain != null)
             {
                 _swapChain.ResizeBuffers(2,
-                                            PresentationParameters.BackBufferWidth,
-                                            PresentationParameters.BackBufferHeight,
-                                            format,
-                                            SwapChainFlags.None);
-
-                // This force to switch to fullscreen mode when hardware mode enabled(working in WindowsDX mode).
-                if (useFullscreenParameter)
-                {
-                    _swapChain.SetFullscreenState(PresentationParameters.IsFullScreen, null);
-                }
+                                        PresentationParameters.BackBufferWidth,
+                                        PresentationParameters.BackBufferHeight,
+                                        format,
+                                        SwapChainFlags.None);
 
                 // Update Vsync setting.
                 using (var dxgiDevice = _d3dDevice.QueryInterface<SharpDX.DXGI.Device1>())
@@ -755,7 +755,7 @@ namespace Microsoft.Xna.Framework.Graphics
                         Scaling = DisplayModeScaling.Unspecified,
 #endif
                         Width = PresentationParameters.BackBufferWidth,
-                        Height = PresentationParameters.BackBufferHeight,                        
+                        Height = PresentationParameters.BackBufferHeight,
                     },
 
                     OutputHandle = PresentationParameters.DeviceWindowHandle,
@@ -763,11 +763,11 @@ namespace Microsoft.Xna.Framework.Graphics
                     Usage = SharpDX.DXGI.Usage.RenderTargetOutput,
                     BufferCount = 2,
                     SwapEffect = SharpDXHelper.ToSwapEffect(PresentationParameters.PresentationInterval),
-                    IsWindowed = useFullscreenParameter ? PresentationParameters.IsFullScreen : true
+                    IsWindowed = true
                 };
 
                 // Once the desired swap chain description is configured, it must be created on the same adapter as our D3D Device
-                
+
                 // First, retrieve the underlying DXGI Device from the D3D Device.
                 // Creates the swap chain 
                 using (var dxgiDevice = _d3dDevice.QueryInterface<SharpDX.DXGI.Device1>())
@@ -864,10 +864,10 @@ namespace Microsoft.Xna.Framework.Graphics
 #if WINDOWS_UAP
 							_d3dContext.ClearRenderTargetView(view, new RawColor4(color.X, color.Y, color.Z, color.W));
 #else
-							_d3dContext.ClearRenderTargetView(view, new Color4(color.X, color.Y, color.Z, color.W));
+                            _d3dContext.ClearRenderTargetView(view, new Color4(color.X, color.Y, color.Z, color.W));
 #endif
-					}
-				}
+                    }
+                }
 
                 // Clear the depth/stencil render buffer.
                 SharpDX.Direct3D11.DepthStencilClearFlags flags = 0;
@@ -994,9 +994,9 @@ namespace Microsoft.Xna.Framework.Graphics
 					MaxDepth = _viewport.MaxDepth
 				};
 #else
-				var viewport = new SharpDX.ViewportF(_viewport.X, _viewport.Y, (float)_viewport.Width, (float)_viewport.Height, _viewport.MinDepth, _viewport.MaxDepth);
+                var viewport = new SharpDX.ViewportF(_viewport.X, _viewport.Y, (float)_viewport.Width, (float)_viewport.Height, _viewport.MinDepth, _viewport.MaxDepth);
 #endif
-				lock (_d3dContext)
+                lock (_d3dContext)
                     _d3dContext.Rasterizer.SetViewport(viewport);
             }
         }
@@ -1147,16 +1147,16 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             // NOTE: This code assumes _d3dContext has been locked by the caller.
 
-            if ( _scissorRectangleDirty )
-	        {
-	            _d3dContext.Rasterizer.SetScissorRectangle(
-                    _scissorRectangle.X, 
-                    _scissorRectangle.Y, 
-                    _scissorRectangle.Right, 
+            if (_scissorRectangleDirty)
+            {
+                _d3dContext.Rasterizer.SetScissorRectangle(
+                    _scissorRectangle.X,
+                    _scissorRectangle.Y,
+                    _scissorRectangle.Right,
                     _scissorRectangle.Bottom);
-	            _scissorRectangleDirty = false;
-	        }
-            
+                _scissorRectangleDirty = false;
+            }
+
             // If we're not applying shaders then early out now.
             if (!applyShaders)
                 return;
@@ -1167,7 +1167,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 {
                     _d3dContext.InputAssembler.SetIndexBuffer(
                         _indexBuffer.Buffer,
-                        _indexBuffer.IndexElementSize == IndexElementSize.SixteenBits ? 
+                        _indexBuffer.IndexElementSize == IndexElementSize.SixteenBits ?
                             SharpDX.DXGI.Format.R16_UInt : SharpDX.DXGI.Format.R32_UInt,
                         0);
                 }
@@ -1239,7 +1239,7 @@ namespace Microsoft.Xna.Framework.Graphics
             SamplerStates.PlatformSetSamplers(this);
         }
 
-        private int SetUserVertexBuffer<T>(T[] vertexData, int vertexOffset, int vertexCount, VertexDeclaration vertexDecl) 
+        private int SetUserVertexBuffer<T>(T[] vertexData, int vertexOffset, int vertexCount, VertexDeclaration vertexDecl)
             where T : struct
         {
             DynamicVertexBuffer buffer;
@@ -1397,27 +1397,27 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             _d3dContext.Flush();
         }
-        
+
         private static GraphicsProfile PlatformGetHighestSupportedGraphicsProfile(GraphicsDevice graphicsDevice)
         {
             FeatureLevel featureLevel;
-			try
+            try
             {
-				if (graphicsDevice == null || graphicsDevice._d3dDevice == null || graphicsDevice._d3dDevice.NativePointer == null) 
-					featureLevel = SharpDX.Direct3D11.Device.GetSupportedFeatureLevel();
-               	else
-                	featureLevel = graphicsDevice._d3dDevice.FeatureLevel;
+                if (graphicsDevice == null || graphicsDevice._d3dDevice == null || graphicsDevice._d3dDevice.NativePointer == null)
+                    featureLevel = SharpDX.Direct3D11.Device.GetSupportedFeatureLevel();
+                else
+                    featureLevel = graphicsDevice._d3dDevice.FeatureLevel;
             }
             catch (SharpDXException)
-            { 
-            	featureLevel = FeatureLevel.Level_9_1; //Minimum defined level
+            {
+                featureLevel = FeatureLevel.Level_9_1; //Minimum defined level
             }
 
             GraphicsProfile graphicsProfile;
 
             if (featureLevel >= FeatureLevel.Level_10_0 || GraphicsAdapter.UseReferenceDevice)
                 graphicsProfile = GraphicsProfile.HiDef;
-            else 
+            else
                 graphicsProfile = GraphicsProfile.Reach;
 
             return graphicsProfile;

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -100,9 +100,9 @@ namespace MonoGame.Framework
 
             if (Game.graphicsDeviceManager.HardwareModeSwitch)
             {
-                 Game.GraphicsDevice.PresentationParameters.IsFullScreen = true;
-                 Game.GraphicsDevice.CreateSizeDependentResources(true);
-                 Game.GraphicsDevice.ApplyRenderTargets(null);
+                Game.GraphicsDevice.PresentationParameters.IsFullScreen = true;
+                Game.GraphicsDevice.SetHardwareFullscreen();
+
                 _window._form.WindowState = FormWindowState.Maximized;
             }
             else
@@ -122,10 +122,16 @@ namespace MonoGame.Framework
 
             if (Game.graphicsDeviceManager.HardwareModeSwitch)
             {
-                _window._form.WindowState = FormWindowState.Normal;
+
                 Game.GraphicsDevice.PresentationParameters.IsFullScreen = false;
-                Game.GraphicsDevice.CreateSizeDependentResources(true);
-                Game.GraphicsDevice.ApplyRenderTargets(null);
+                Game.GraphicsDevice.SetHardwareFullscreen();
+
+                _window._form.WindowState = FormWindowState.Normal;
+
+                Game.GraphicsDevice.PresentationParameters.BackBufferWidth = Game.graphicsDeviceManager.PreferredBackBufferWidth;
+                Game.GraphicsDevice.PresentationParameters.BackBufferHeight = Game.graphicsDeviceManager.PreferredBackBufferHeight;
+
+                Game.GraphicsDevice.OnPresentationChanged();
             }
             else
             {

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -365,12 +365,13 @@ namespace MonoGame.Framework
                 var newWidth = _form.ClientRectangle.Width;
                 var newHeight = _form.ClientRectangle.Height;
 
-#if !(WINDOWS && DIRECTX)
                 manager.PreferredBackBufferWidth = newWidth;
                 manager.PreferredBackBufferHeight = newHeight;
-#endif
+
                 if (manager.GraphicsDevice == null)
                     return;
+
+                manager.ApplyChanges();
             }
 
             // Set the new view state which will trigger the 
@@ -460,7 +461,8 @@ namespace MonoGame.Framework
 
         internal void ChangeClientSize(Size clientBounds)
         {
-            this._form.ClientSize = clientBounds;
+            if(this._form.ClientSize != clientBounds)
+                this._form.ClientSize = clientBounds;
         }
 
         [System.Security.SuppressUnmanagedCodeSecurity] // We won't use this maliciously

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -220,7 +220,7 @@ namespace MonoGame.Framework
                     if (!_platform.IsActive && Game.GraphicsDevice.PresentationParameters.IsFullScreen)
                    {
                        Game.GraphicsDevice.PresentationParameters.IsFullScreen = true;
-                       Game.GraphicsDevice.CreateSizeDependentResources(true);
+                       Game.GraphicsDevice.CreateSizeDependentResources();
                         Game.GraphicsDevice.ApplyRenderTargets(null);
                    }
                 }
@@ -365,13 +365,12 @@ namespace MonoGame.Framework
                 var newWidth = _form.ClientRectangle.Width;
                 var newHeight = _form.ClientRectangle.Height;
 
-                manager.PreferredBackBufferWidth = newWidth;
-                manager.PreferredBackBufferHeight = newHeight;
-
                 if (manager.GraphicsDevice == null)
                     return;
 
-                manager.ApplyChanges();
+                manager.GraphicsDevice.PresentationParameters.BackBufferWidth = newWidth;
+                manager.GraphicsDevice.PresentationParameters.BackBufferHeight = newHeight;
+                manager.GraphicsDevice.OnPresentationChanged();
             }
 
             // Set the new view state which will trigger the 


### PR DESCRIPTION
Also added an if statement to stop the infinite recursion issue I found in WinFormsGameWindow.cs (directly related to backbuffer problem)

I don't think this will cause more issues, but please let me know if it does.

Fixes https://github.com/mono/MonoGame/issues/4922
Fixes https://github.com/mono/MonoGame/issues/4018
Fixes https://github.com/mono/MonoGame/issues/4841
