### PR TITLE
Improve and simplify Joystick and GamePad detection

### DIFF
--- a/MonoGame.Framework/Input/GamePad.SDL.cs
+++ b/MonoGame.Framework/Input/GamePad.SDL.cs
@@ -21,9 +21,6 @@ namespace Microsoft.Xna.Framework.Input
 
         private static readonly Dictionary<int, GamePadInfo> Gamepads = new Dictionary<int, GamePadInfo>();
 
-        // we have to maintain this mapping because instance IDs are not ordered by player index (i.e. player lights on Xbox gamepads), but DeviceID are
-        private static readonly Dictionary<int, int> _deviceInstaceToId = new Dictionary<int, int>();
-
         private static Sdl.Haptic.Effect _hapticLeftRightEffect = new Sdl.Haptic.Effect
         {
             type = Sdl.Haptic.EffectId.LeftRight,
@@ -36,7 +33,7 @@ namespace Microsoft.Xna.Framework.Input
             }
         };
 
-        static GamePad()
+        public static void InitDatabase()
         {
             using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("gamecontrollerdb.txt"))
                 if (stream != null)
@@ -51,60 +48,53 @@ namespace Microsoft.Xna.Framework.Input
 
         internal static void AddDevice(int deviceId)
         {
-            var jdevice = Sdl.Joystick.Open(deviceId);
-            var instanceid = Sdl.Joystick.InstanceID(jdevice);
-
             var gamepad = new GamePadInfo();
             gamepad.Device = Sdl.GameController.Open(deviceId);
+            gamepad.HapticDevice = Sdl.Haptic.Open(deviceId);
 
-            _deviceInstaceToId.Add(instanceid, deviceId);
+            var id = 0;
+            while (Gamepads.ContainsKey(id))
+                id++;
 
-            Gamepads.Add(deviceId, gamepad);
+            Gamepads.Add(id, gamepad);
+            
+            if (gamepad.HapticDevice == IntPtr.Zero)
+                return;
 
-            if (Sdl.Haptic.IsHaptic(jdevice) == 1)
+            try
             {
-
-                gamepad.HapticDevice = Sdl.Haptic.OpenFromJoystick(jdevice);
-
-                if (gamepad.HapticDevice != IntPtr.Zero && Sdl.Haptic.EffectSupported(gamepad.HapticDevice, ref _hapticLeftRightEffect) == 1)
+                if (Sdl.Haptic.EffectSupported(gamepad.HapticDevice, ref _hapticLeftRightEffect) == 1)
                 {
-                    try // for some reason, even if a GamePad "supports" the haptic effect, it may still fail on some gamepads (Logitech F710, F310 for instance)
-                    {
-                        Sdl.Haptic.NewEffect(gamepad.HapticDevice, ref _hapticLeftRightEffect);
-                        gamepad.HapticType = 1;
-                    }
-                    catch (Exception)
-                    {
-                        Sdl.Haptic.Close(gamepad.HapticDevice);
-                    }
+                    Sdl.Haptic.NewEffect(gamepad.HapticDevice, ref _hapticLeftRightEffect);
+                    gamepad.HapticType = 1;
                 }
-                else if (gamepad.HapticDevice != IntPtr.Zero && Sdl.Haptic.RumbleSupported(gamepad.HapticDevice) == 1)
+                else if (Sdl.Haptic.RumbleSupported(gamepad.HapticDevice) == 1)
                 {
-                    try // for some reason, even if a GamePad "supports" the haptic effect, it may still fail on some gamepads (Logitech F710, F310 for instance)
-                    {
-                        Sdl.Haptic.RumbleInit(gamepad.HapticDevice);
-                        gamepad.HapticType = 2;
-                    }
-                    catch (Exception)
-                    {
-                        Sdl.Haptic.Close(gamepad.HapticDevice);
-                    }
+                    Sdl.Haptic.RumbleInit(gamepad.HapticDevice);
+                    gamepad.HapticType = 2;
                 }
                 else
-                {
                     Sdl.Haptic.Close(gamepad.HapticDevice);
-                }
             }
-
-            Sdl.ClearError(); // in case anything wrong happened with the haptic init
+            catch
+            {
+                Sdl.Haptic.Close(gamepad.HapticDevice);
+                gamepad.HapticDevice = IntPtr.Zero;
+                Sdl.ClearError();
+            }
         }
 
         internal static void RemoveDevice(int instanceid)
         {
-            int deviceId = _deviceInstaceToId[instanceid];
-            DisposeDevice(Gamepads[deviceId]);
-            Gamepads.Remove(deviceId);
-            _deviceInstaceToId.Remove(instanceid);
+            foreach (KeyValuePair<int, GamePadInfo> entry in Gamepads)
+            {
+                if (Sdl.Joystick.InstanceID(Sdl.GameController.GetJoystick(entry.Value.Device)) == instanceid)
+                {
+                    Gamepads.Remove(entry.Key);
+                    DisposeDevice(entry.Value);
+                    break;
+                }
+            }
         }
 
         private static void DisposeDevice(GamePadInfo info)

--- a/MonoGame.Framework/SDL/SDL2.cs
+++ b/MonoGame.Framework/SDL/SDL2.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Text;
 using System.Runtime.InteropServices;
+using System.Diagnostics;
 
 internal static class Sdl
 {
@@ -181,7 +182,7 @@ internal static class Sdl
     public static int GetError(int value)
     {
         if (value < 0)
-            throw new Exception(GetError());
+            Debug.WriteLine(GetError());
 
         return value;
     }
@@ -189,7 +190,7 @@ internal static class Sdl
     public static IntPtr GetError(IntPtr pointer)
     {
         if (pointer == IntPtr.Zero)
-            throw new Exception(GetError());
+            Debug.WriteLine(GetError());
 
         return pointer;
     }
@@ -652,6 +653,14 @@ internal static class Sdl
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_JoystickClose")]
         public static extern void Close(IntPtr joystick);
 
+        [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_JoystickFromInstanceID")]
+        private static extern IntPtr SDL_JoystickFromInstanceID(int joyid);
+
+        public static IntPtr FromInstanceID(int joyid)
+        {
+            return GetError(SDL_JoystickFromInstanceID(joyid));
+        }
+
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_JoystickGetAxis")]
         public static extern short GetAxis(IntPtr joystick, int axis);
 
@@ -758,8 +767,15 @@ internal static class Sdl
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_GameControllerClose")]
         public static extern void Close(IntPtr gamecontroller);
 
-        [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_GameControllerGetAxis")
-        ]
+        [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_JoystickFromInstanceID")]
+        private static extern IntPtr SDL_GameControllerFromInstanceID(int joyid);
+
+        public static IntPtr FromInstanceID(int joyid)
+        {
+            return GetError(SDL_GameControllerFromInstanceID(joyid));
+        }
+
+        [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_GameControllerGetAxis")]
         public static extern short GetAxis(IntPtr gamecontroller, Axis axis);
 
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl,
@@ -836,9 +852,17 @@ internal static class Sdl
         {
             GetError(SDL_HapticNewEffect(haptic, ref effect));
         }
+        
+        [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_HapticOpen")]
+        public static extern IntPtr Open(int device_index);
 
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_HapticOpenFromJoystick")]
-        public static extern IntPtr OpenFromJoystick(IntPtr joystick);
+        private static extern IntPtr SDL_HapticOpenFromJoystick(IntPtr joystick);
+
+        public static IntPtr OpenFromJoystick(IntPtr joystick)
+        {
+            return GetError(SDL_HapticOpenFromJoystick(joystick));
+        }
 
         [DllImport(NativeLibName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_HapticRumbleInit")]
         private static extern int SDL_HapticRumbleInit(IntPtr haptic);

--- a/MonoGame.Framework/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/SDL/SDLGamePlatform.cs
@@ -84,17 +84,9 @@ namespace Microsoft.Xna.Framework
 
         public override void BeforeInitialize ()
         {
-            var events = new Sdl.Event[1];
-            Sdl.PumpEvents ();
-            while (Sdl.PeepEvents(events, 1, Sdl.EventAction.GetEvent, Sdl.EventType.ControllerDeviceAdded, Sdl.EventType.ControllerDeviceAdded) == 1)
-            {
-                GamePad.AddDevice(events[0].ControllerDevice.Which);
-            }
-            while (Sdl.PeepEvents(events, 1, Sdl.EventAction.GetEvent, Sdl.EventType.JoyDeviceAdded, Sdl.EventType.JoyDeviceAdded) == 1)
-            {
-                Joystick.AddDevice(events[0].JoystickDevice.Which);
-            }
+            GamePad.InitDatabase();
             _view.CreateWindow();
+            SdlRunLoop();
 
             base.BeforeInitialize ();
         }


### PR DESCRIPTION
Notes:
 - Instead of trying to use instanceid/deviceid, now we are using our own ids
  - when device gets added we just use the first empty slot
  - when device gets removed we search the dictionary and remove the device with specified instanceid once found
 - GameControllerAdded event cannot be used since it doesn't always get triggered, so JoystickAdded event is used for GamePad
 - Fixes: #4948 

CC. @mrhelmut @endimilojkoski