### PR TITLE
Threading and GL resource loading

### DIFF
--- a/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture2DReader.cs
@@ -65,99 +65,105 @@ namespace Microsoft.Xna.Framework.Content
 			}
 			
             texture = existingInstance ?? new Texture2D(reader.GraphicsDevice, width, height, levelCountOutput > 1, convertedFormat);
-			
-			for (int level = 0; level < levelCount; level++)
-			{
-				var levelDataSizeInBytes = reader.ReadInt32();
-                var levelData = reader.ContentManager.GetScratchBuffer(levelDataSizeInBytes);
-                reader.Read(levelData, 0, levelDataSizeInBytes);
-                int levelWidth = width >> level;
-                int levelHeight = height >> level;
-
-                if (level >= levelCountOutput)
-                    continue;
-
-				//Convert the image data if required
-				switch (surfaceFormat)
-				{
-					case SurfaceFormat.Dxt1:
-                    case SurfaceFormat.Dxt1SRgb:
-                    case SurfaceFormat.Dxt1a:
-                        if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsDxt1 && convertedFormat == SurfaceFormat.Color)
-						    levelData = DxtUtil.DecompressDxt1(levelData, levelWidth, levelHeight);
-						break;
-					case SurfaceFormat.Dxt3:
-					case SurfaceFormat.Dxt3SRgb:
-                        if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc)
-                        if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc && convertedFormat == SurfaceFormat.Color)
-						    levelData = DxtUtil.DecompressDxt3(levelData, levelWidth, levelHeight);
-						break;
-					case SurfaceFormat.Dxt5:
-					case SurfaceFormat.Dxt5SRgb:
-                        if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc)
-                        if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc && convertedFormat == SurfaceFormat.Color)
-    						levelData = DxtUtil.DecompressDxt5(levelData, levelWidth, levelHeight);
-						break;
-                    case SurfaceFormat.Bgra5551:
-                        {
 #if OPENGL
-                            // Shift the channels to suit OpenGL
-                            int offset = 0;
-                            for (int y = 0; y < levelHeight; y++)
+            Threading.BlockOnUIThread(() =>
+            {
+#endif
+                for (int level = 0; level < levelCount; level++)
+			    {
+				    var levelDataSizeInBytes = reader.ReadInt32();
+                    var levelData = reader.ContentManager.GetScratchBuffer(levelDataSizeInBytes);
+                    reader.Read(levelData, 0, levelDataSizeInBytes);
+                    int levelWidth = width >> level;
+                    int levelHeight = height >> level;
+
+                    if (level >= levelCountOutput)
+                        continue;
+
+				    //Convert the image data if required
+				    switch (surfaceFormat)
+				    {
+					    case SurfaceFormat.Dxt1:
+                        case SurfaceFormat.Dxt1SRgb:
+                        case SurfaceFormat.Dxt1a:
+                            if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsDxt1 && convertedFormat == SurfaceFormat.Color)
+						        levelData = DxtUtil.DecompressDxt1(levelData, levelWidth, levelHeight);
+						    break;
+					    case SurfaceFormat.Dxt3:
+					    case SurfaceFormat.Dxt3SRgb:
+                            if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc)
+                            if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc && convertedFormat == SurfaceFormat.Color)
+						        levelData = DxtUtil.DecompressDxt3(levelData, levelWidth, levelHeight);
+						    break;
+					    case SurfaceFormat.Dxt5:
+					    case SurfaceFormat.Dxt5SRgb:
+                            if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc)
+                            if (!reader.GraphicsDevice.GraphicsCapabilities.SupportsS3tc && convertedFormat == SurfaceFormat.Color)
+    						    levelData = DxtUtil.DecompressDxt5(levelData, levelWidth, levelHeight);
+						    break;
+                        case SurfaceFormat.Bgra5551:
                             {
-                                for (int x = 0; x < levelWidth; x++)
-                                {
-                                    ushort pixel = BitConverter.ToUInt16(levelData, offset);
-                                    pixel = (ushort)(((pixel & 0x7FFF) << 1) | ((pixel & 0x8000) >> 15));
-                                    levelData[offset] = (byte)(pixel);
-                                    levelData[offset + 1] = (byte)(pixel >> 8);
-                                    offset += 2;
-                                }
-                            }
-#endif
-                        }
-                        break;
-					case SurfaceFormat.Bgra4444:
-						{
 #if OPENGL
-                            // Shift the channels to suit OpenGL
-							int offset = 0;
-							for (int y = 0; y < levelHeight; y++)
-							{
-								for (int x = 0; x < levelWidth; x++)
-								{
-									ushort pixel = BitConverter.ToUInt16(levelData, offset);
-									pixel = (ushort)(((pixel & 0x0FFF) << 4) | ((pixel & 0xF000) >> 12));
-									levelData[offset] = (byte)(pixel);
-									levelData[offset + 1] = (byte)(pixel >> 8);
-									offset += 2;
-								}
-							}
+                                // Shift the channels to suit OpenGL
+                                int offset = 0;
+                                for (int y = 0; y < levelHeight; y++)
+                                {
+                                    for (int x = 0; x < levelWidth; x++)
+                                    {
+                                        ushort pixel = BitConverter.ToUInt16(levelData, offset);
+                                        pixel = (ushort)(((pixel & 0x7FFF) << 1) | ((pixel & 0x8000) >> 15));
+                                        levelData[offset] = (byte)(pixel);
+                                        levelData[offset + 1] = (byte)(pixel >> 8);
+                                        offset += 2;
+                                    }
+                                }
 #endif
-						}
-						break;
-					case SurfaceFormat.NormalizedByte4:
-						{
-							int bytesPerPixel = surfaceFormat.GetSize();
-							int pitch = levelWidth * bytesPerPixel;
-							for (int y = 0; y < levelHeight; y++)
-							{
-								for (int x = 0; x < levelWidth; x++)
-								{
-									int color = BitConverter.ToInt32(levelData, y * pitch + x * bytesPerPixel);
-									levelData[y * pitch + x * 4] = (byte)(((color >> 16) & 0xff)); //R:=W
-									levelData[y * pitch + x * 4 + 1] = (byte)(((color >> 8) & 0xff)); //G:=V
-									levelData[y * pitch + x * 4 + 2] = (byte)(((color) & 0xff)); //B:=U
-									levelData[y * pitch + x * 4 + 3] = (byte)(((color >> 24) & 0xff)); //A:=Q
-								}
-							}
-						}
-						break;
-				}
+                            }
+                            break;
+					    case SurfaceFormat.Bgra4444:
+						    {
+#if OPENGL
+                                // Shift the channels to suit OpenGL
+							    int offset = 0;
+							    for (int y = 0; y < levelHeight; y++)
+							    {
+								    for (int x = 0; x < levelWidth; x++)
+								    {
+									    ushort pixel = BitConverter.ToUInt16(levelData, offset);
+									    pixel = (ushort)(((pixel & 0x0FFF) << 4) | ((pixel & 0xF000) >> 12));
+									    levelData[offset] = (byte)(pixel);
+									    levelData[offset + 1] = (byte)(pixel >> 8);
+									    offset += 2;
+								    }
+							    }
+#endif
+						    }
+						    break;
+					    case SurfaceFormat.NormalizedByte4:
+						    {
+							    int bytesPerPixel = surfaceFormat.GetSize();
+							    int pitch = levelWidth * bytesPerPixel;
+							    for (int y = 0; y < levelHeight; y++)
+							    {
+								    for (int x = 0; x < levelWidth; x++)
+								    {
+									    int color = BitConverter.ToInt32(levelData, y * pitch + x * bytesPerPixel);
+									    levelData[y * pitch + x * 4] = (byte)(((color >> 16) & 0xff)); //R:=W
+									    levelData[y * pitch + x * 4 + 1] = (byte)(((color >> 8) & 0xff)); //G:=V
+									    levelData[y * pitch + x * 4 + 2] = (byte)(((color) & 0xff)); //B:=U
+									    levelData[y * pitch + x * 4 + 3] = (byte)(((color >> 24) & 0xff)); //A:=Q
+								    }
+							    }
+						    }
+						    break;
+				    }
 				
-                texture.SetData(level, null, levelData, 0, levelDataSizeInBytes);
-			}
-			
+                    texture.SetData(level, null, levelData, 0, levelDataSizeInBytes);
+			    }
+#if OPENGL
+            });
+#endif
+        			
 			return texture;
 		}
     }

--- a/MonoGame.Framework/Content/ContentReaders/Texture3DReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/Texture3DReader.cs
@@ -23,19 +23,26 @@ namespace Microsoft.Xna.Framework.Content
                 texture = new Texture3D(reader.GraphicsDevice, width, height, depth, levelCount > 1, format);
             else
                 texture = existingInstance;
-            
-            for (int i = 0; i < levelCount; i++)
-            {
-                int dataSize = reader.ReadInt32();
-                byte[] data = reader.ContentManager.GetScratchBuffer(dataSize);
-                reader.Read(data, 0, dataSize);
-                texture.SetData(i, 0, 0, width, height, 0, depth, data, 0, dataSize);
 
-                // Calculate dimensions of next mip level.
-                width = Math.Max(width >> 1, 1);
-                height = Math.Max(height >> 1, 1);
-                depth = Math.Max(depth >> 1, 1);
-            }
+#if OPENGL
+            Threading.BlockOnUIThread(() =>
+            {
+#endif
+                for (int i = 0; i < levelCount; i++)
+                {
+                    int dataSize = reader.ReadInt32();
+                    byte[] data = reader.ContentManager.GetScratchBuffer(dataSize);
+                    reader.Read(data, 0, dataSize);
+                    texture.SetData(i, 0, 0, width, height, 0, depth, data, 0, dataSize);
+
+                    // Calculate dimensions of next mip level.
+                    width = Math.Max(width >> 1, 1);
+                    height = Math.Max(height >> 1, 1);
+                    depth = Math.Max(depth >> 1, 1);
+                }
+#if OPENGL
+            });
+#endif
 
             return texture;
         }

--- a/MonoGame.Framework/Content/ContentReaders/TextureCubeReader.cs
+++ b/MonoGame.Framework/Content/ContentReaders/TextureCubeReader.cs
@@ -23,18 +23,25 @@ namespace Microsoft.Xna.Framework.Content
             else
                 textureCube = existingInstance;
 
-            for (int face = 0; face < 6; face++) 
+#if OPENGL
+            Threading.BlockOnUIThread(() =>
             {
-                for (int i=0; i<levels; i++) 
+#endif
+                for (int face = 0; face < 6; face++)
                 {
-                    int faceSize = reader.ReadInt32();
-                    byte[] faceData = reader.ContentManager.GetScratchBuffer(faceSize);
-                    reader.Read(faceData, 0, faceSize);
-                    textureCube.SetData<byte>((CubeMapFace)face, i, null, faceData, 0, faceSize);
+                    for (int i = 0; i < levels; i++)
+                    {
+                        int faceSize = reader.ReadInt32();
+                        byte[] faceData = reader.ContentManager.GetScratchBuffer(faceSize);
+                        reader.Read(faceData, 0, faceSize);
+                        textureCube.SetData<byte>((CubeMapFace)face, i, null, faceData, 0, faceSize);
+                    }
                 }
-            }
-            
-            return textureCube;
+#if OPENGL
+            });
+#endif
+
+             return textureCube;
         }
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsContext.SDL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsContext.SDL.cs
@@ -3,7 +3,6 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using Microsoft.Xna.Framework;
 
 namespace OpenGL
 {
@@ -36,7 +35,6 @@ namespace OpenGL
                 return;
             
             SetWindowHandle(info);
-            Threading.BackgroundContext = Sdl.GL.CreateContext (_winHandle);
             _context = Sdl.GL.CreateContext(_winHandle);
 
             // GL entry points must be loaded after the GL context creation, otherwise some Windows drivers will return only GL 1.3 compatible functions

--- a/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
@@ -218,6 +218,10 @@ namespace Microsoft.Xna.Framework.Graphics
                         GL.PixelStore(PixelStoreParameter.UnpackAlignment, 4);
                     }
 
+#if !ANDROID
+                    GL.Finish();
+                    GraphicsExtensions.CheckGLError();
+#endif
                     // Restore the bound texture.
                     GL.BindTexture(TextureTarget.Texture2D, prevTexture);
                     GraphicsExtensions.CheckGLError();

--- a/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.OpenGL.cs
@@ -129,52 +129,52 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             Threading.BlockOnUIThread(() =>
             {
-            var elementSizeInByte = Marshal.SizeOf(typeof(T));
-            var dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
-            // Use try..finally to make sure dataHandle is freed in case of an error
-            try
-            {
-                var startBytes = startIndex * elementSizeInByte;
-                var dataPtr = (IntPtr)(dataHandle.AddrOfPinnedObject().ToInt64() + startBytes);
-                int x, y, w, h;
-                if (rect.HasValue)
+                var elementSizeInByte = Marshal.SizeOf(typeof(T));
+                var dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
+                // Use try..finally to make sure dataHandle is freed in case of an error
+                try
                 {
-                    x = rect.Value.X;
-                    y = rect.Value.Y;
-                    w = rect.Value.Width;
-                    h = rect.Value.Height;
-                }
-                else
-                {
-                    x = 0;
-                    y = 0;
-                    w = Math.Max(width >> level, 1);
-                    h = Math.Max(height >> level, 1);
-
-                    // For DXT textures the width and height of each level is a multiple of 4.
-                    // OpenGL only: The last two mip levels require the width and height to be 
-                    // passed as 2x2 and 1x1, but there needs to be enough data passed to occupy 
-                    // a 4x4 block. 
-                    // Ref: http://www.mentby.com/Group/mac-opengl/issue-with-dxt-mipmapped-textures.html 
-                    if (_format == SurfaceFormat.Dxt1
-                        || _format == SurfaceFormat.Dxt1a
-                        || _format == SurfaceFormat.Dxt3
-                        || _format == SurfaceFormat.Dxt5
-                        || _format == SurfaceFormat.RgbaAtcExplicitAlpha
-                        || _format == SurfaceFormat.RgbaAtcInterpolatedAlpha
-                        || _format == SurfaceFormat.RgbPvrtc2Bpp
-                        || _format == SurfaceFormat.RgbPvrtc4Bpp
-                        || _format == SurfaceFormat.RgbaPvrtc2Bpp
-                        || _format == SurfaceFormat.RgbaPvrtc4Bpp
-                        || _format == SurfaceFormat.RgbEtc1
-                        )
+                    var startBytes = startIndex * elementSizeInByte;
+                    var dataPtr = (IntPtr)(dataHandle.AddrOfPinnedObject().ToInt64() + startBytes);
+                    int x, y, w, h;
+                    if (rect.HasValue)
                     {
-                            if (w > 4)
-                                w = (w + 3) & ~3;
-                            if (h > 4)
-                                h = (h + 3) & ~3;
+                        x = rect.Value.X;
+                        y = rect.Value.Y;
+                        w = rect.Value.Width;
+                        h = rect.Value.Height;
                     }
-                }
+                    else
+                    {
+                        x = 0;
+                        y = 0;
+                        w = Math.Max(width >> level, 1);
+                        h = Math.Max(height >> level, 1);
+
+                        // For DXT textures the width and height of each level is a multiple of 4.
+                        // OpenGL only: The last two mip levels require the width and height to be 
+                        // passed as 2x2 and 1x1, but there needs to be enough data passed to occupy 
+                        // a 4x4 block. 
+                        // Ref: http://www.mentby.com/Group/mac-opengl/issue-with-dxt-mipmapped-textures.html 
+                        if (_format == SurfaceFormat.Dxt1
+                            || _format == SurfaceFormat.Dxt1a
+                            || _format == SurfaceFormat.Dxt3
+                            || _format == SurfaceFormat.Dxt5
+                            || _format == SurfaceFormat.RgbaAtcExplicitAlpha
+                            || _format == SurfaceFormat.RgbaAtcInterpolatedAlpha
+                            || _format == SurfaceFormat.RgbPvrtc2Bpp
+                            || _format == SurfaceFormat.RgbPvrtc4Bpp
+                            || _format == SurfaceFormat.RgbaPvrtc2Bpp
+                            || _format == SurfaceFormat.RgbaPvrtc4Bpp
+                            || _format == SurfaceFormat.RgbEtc1
+                            )
+                        {
+                                if (w > 4)
+                                    w = (w + 3) & ~3;
+                                if (h > 4)
+                                    h = (h + 3) & ~3;
+                        }
+                    }
 
                     // Store the current bound texture.
                     var prevTexture = GraphicsExtensions.GetBoundTexture2D();
@@ -225,11 +225,11 @@ namespace Microsoft.Xna.Framework.Graphics
                     // Restore the bound texture.
                     GL.BindTexture(TextureTarget.Texture2D, prevTexture);
                     GraphicsExtensions.CheckGLError();
-            }
-            finally
-            {
-                dataHandle.Free();
-            }
+                }
+                finally
+                {
+                    dataHandle.Free();
+                }
 
 #if !ANDROID
                 // Required to make sure that any texture uploads on a thread are completed

--- a/MonoGame.Framework/Graphics/Texture3D.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/Texture3D.OpenGL.cs
@@ -28,16 +28,19 @@ namespace Microsoft.Xna.Framework.Graphics
 #else
             this.glTarget = TextureTarget.Texture3D;
 
-            GL.GenTextures(1, out this.glTexture);
-            GraphicsExtensions.CheckGLError();
+            Threading.BlockOnUIThread(() =>
+            {
+                GL.GenTextures(1, out this.glTexture);
+                GraphicsExtensions.CheckGLError();
 
-            GL.BindTexture(glTarget, glTexture);
-            GraphicsExtensions.CheckGLError();
+                GL.BindTexture(glTarget, glTexture);
+                GraphicsExtensions.CheckGLError();
 
-            format.GetGLFormat(GraphicsDevice, out glInternalFormat, out glFormat, out glType);
+                format.GetGLFormat(GraphicsDevice, out glInternalFormat, out glFormat, out glType);
 
-            GL.TexImage3D(glTarget, 0, glInternalFormat, width, height, depth, 0, glFormat, glType, IntPtr.Zero);
-            GraphicsExtensions.CheckGLError();
+                GL.TexImage3D(glTarget, 0, glInternalFormat, width, height, depth, 0, glFormat, glType, IntPtr.Zero);
+                GraphicsExtensions.CheckGLError();
+            });
 
             if (mipMap)
                 throw new NotImplementedException("Texture3D does not yet support mipmaps.");
@@ -51,16 +54,19 @@ namespace Microsoft.Xna.Framework.Graphics
 #if GLES
             throw new NotSupportedException("OpenGL ES 2.0 doesn't support 3D textures.");
 #else
-            var elementSizeInByte = Marshal.SizeOf(typeof(T));
-            var dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
-            var dataPtr = (IntPtr)(dataHandle.AddrOfPinnedObject().ToInt64() + startIndex * elementSizeInByte);
+            Threading.BlockOnUIThread(() =>
+            {
+                var elementSizeInByte = Marshal.SizeOf(typeof(T));
+                var dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
+                var dataPtr = (IntPtr)(dataHandle.AddrOfPinnedObject().ToInt64() + startIndex * elementSizeInByte);
 
-            GL.BindTexture(glTarget, glTexture);
-            GraphicsExtensions.CheckGLError();
-            GL.TexSubImage3D(glTarget, level, left, top, front, width, height, depth, glFormat, glType, dataPtr);
-            GraphicsExtensions.CheckGLError();
+                GL.BindTexture(glTarget, glTexture);
+                GraphicsExtensions.CheckGLError();
+                GL.TexSubImage3D(glTarget, level, left, top, front, width, height, depth, glFormat, glType, dataPtr);
+                GraphicsExtensions.CheckGLError();
 
-            dataHandle.Free();
+                dataHandle.Free();
+            });
 #endif
         }
 

--- a/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.OpenGL.cs
@@ -35,50 +35,50 @@ namespace Microsoft.Xna.Framework.Graphics
 
             Threading.BlockOnUIThread(() =>
             {
-			GL.GenTextures(1, out this.glTexture);
-            GraphicsExtensions.CheckGLError();
-            GL.BindTexture(TextureTarget.TextureCubeMap, this.glTexture);
-            GraphicsExtensions.CheckGLError();
-            GL.TexParameter(TextureTarget.TextureCubeMap, TextureParameterName.TextureMinFilter,
-                            mipMap ? (int)TextureMinFilter.LinearMipmapLinear : (int)TextureMinFilter.Linear);
-            GraphicsExtensions.CheckGLError();
-            GL.TexParameter(TextureTarget.TextureCubeMap, TextureParameterName.TextureMagFilter,
-                            (int)TextureMagFilter.Linear);
-            GraphicsExtensions.CheckGLError();
-            GL.TexParameter(TextureTarget.TextureCubeMap, TextureParameterName.TextureWrapS,
-                            (int)TextureWrapMode.ClampToEdge);
-            GraphicsExtensions.CheckGLError();
-            GL.TexParameter(TextureTarget.TextureCubeMap, TextureParameterName.TextureWrapT,
-                            (int)TextureWrapMode.ClampToEdge);
-            GraphicsExtensions.CheckGLError();
+			    GL.GenTextures(1, out this.glTexture);
+                GraphicsExtensions.CheckGLError();
+                GL.BindTexture(TextureTarget.TextureCubeMap, this.glTexture);
+                GraphicsExtensions.CheckGLError();
+                GL.TexParameter(TextureTarget.TextureCubeMap, TextureParameterName.TextureMinFilter,
+                                mipMap ? (int)TextureMinFilter.LinearMipmapLinear : (int)TextureMinFilter.Linear);
+                GraphicsExtensions.CheckGLError();
+                GL.TexParameter(TextureTarget.TextureCubeMap, TextureParameterName.TextureMagFilter,
+                                (int)TextureMagFilter.Linear);
+                GraphicsExtensions.CheckGLError();
+                GL.TexParameter(TextureTarget.TextureCubeMap, TextureParameterName.TextureWrapS,
+                                (int)TextureWrapMode.ClampToEdge);
+                GraphicsExtensions.CheckGLError();
+                GL.TexParameter(TextureTarget.TextureCubeMap, TextureParameterName.TextureWrapT,
+                                (int)TextureWrapMode.ClampToEdge);
+                GraphicsExtensions.CheckGLError();
 
 
-            format.GetGLFormat(GraphicsDevice, out glInternalFormat, out glFormat, out glType);
+                format.GetGLFormat(GraphicsDevice, out glInternalFormat, out glFormat, out glType);
 
-            for (int i = 0; i < 6; i++)
-            {
-                TextureTarget target = GetGLCubeFace((CubeMapFace)i);
-
-                if (glFormat == (PixelFormat)GLPixelFormat.CompressedTextureFormats)
+                for (int i = 0; i < 6; i++)
                 {
-                    throw new NotImplementedException();
+                    TextureTarget target = GetGLCubeFace((CubeMapFace)i);
+
+                    if (glFormat == (PixelFormat)GLPixelFormat.CompressedTextureFormats)
+                    {
+                        throw new NotImplementedException();
+                    }
+                    else
+                    {
+                        GL.TexImage2D(target, 0, glInternalFormat, size, size, 0, glFormat, glType, IntPtr.Zero);
+                        GraphicsExtensions.CheckGLError();
+                    }
                 }
-                else
+
+                if (mipMap)
                 {
-                    GL.TexImage2D(target, 0, glInternalFormat, size, size, 0, glFormat, glType, IntPtr.Zero);
+#if IOS || ANDROID
+				    GL.GenerateMipmap(TextureTarget.TextureCubeMap);
+#else
+                    GL.TexParameter(TextureTarget.TextureCubeMap, TextureParameterName.GenerateMipmap, (int)Bool.True);
+#endif
                     GraphicsExtensions.CheckGLError();
                 }
-            }
-
-            if (mipMap)
-            {
-#if IOS || ANDROID
-				GL.GenerateMipmap(TextureTarget.TextureCubeMap);
-#else
-                GL.TexParameter(TextureTarget.TextureCubeMap, TextureParameterName.GenerateMipmap, (int)Bool.True);
-#endif
-                GraphicsExtensions.CheckGLError();
-            }
             });
         }
 
@@ -99,19 +99,19 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             Threading.BlockOnUIThread(() =>
             {
-            GL.BindTexture(TextureTarget.TextureCubeMap, this.glTexture);
-            GraphicsExtensions.CheckGLError();
-
-            TextureTarget target = GetGLCubeFace(face);
-            if (glFormat == (PixelFormat)GLPixelFormat.CompressedTextureFormats)
-            {
-                throw new NotImplementedException();
-            }
-            else
-            {
-                GL.TexSubImage2D(target, level, xOffset, yOffset, width, height, glFormat, glType, dataPtr);
+                GL.BindTexture(TextureTarget.TextureCubeMap, this.glTexture);
                 GraphicsExtensions.CheckGLError();
-            }
+
+                TextureTarget target = GetGLCubeFace(face);
+                if (glFormat == (PixelFormat)GLPixelFormat.CompressedTextureFormats)
+                {
+                    throw new NotImplementedException();
+                }
+                else
+                {
+                    GL.TexSubImage2D(target, level, xOffset, yOffset, width, height, glFormat, glType, dataPtr);
+                    GraphicsExtensions.CheckGLError();
+                }
             });
         }
 

--- a/MonoGame.Framework/SDL/SDLGamePlatform.cs
+++ b/MonoGame.Framework/SDL/SDLGamePlatform.cs
@@ -102,6 +102,7 @@ namespace Microsoft.Xna.Framework
 
             while (true)
             {
+                Threading.Run();
                 SdlRunLoop();
                 Game.Tick();
 
@@ -150,8 +151,8 @@ namespace Microsoft.Xna.Framework
                         continue;
                     foreach (var c in text)
                     {
-                        var key = KeyboardUtil.ToXna ((int)c);
-                        _view.CallTextInput (c, key);
+                        var key = KeyboardUtil.ToXna((int)c);
+                        _view.CallTextInput(c, key);
                     }
                 }
                 else if (ev.Type == Sdl.EventType.WindowEvent)

--- a/MonoGame.Framework/SDL/SDLGameWindow.cs
+++ b/MonoGame.Framework/SDL/SDLGameWindow.cs
@@ -160,7 +160,6 @@ namespace Microsoft.Xna.Framework
             Sdl.GL.SetAttribute (Sdl.GL.Attribute.DoubleBuffer, 1);
             Sdl.GL.SetAttribute (Sdl.GL.Attribute.ContextMajorVersion, 2);
             Sdl.GL.SetAttribute (Sdl.GL.Attribute.ContextMinorVersion, 1);
-            Sdl.GL.SetAttribute (Sdl.GL.Attribute.ShareWithCurrentContext, 1);
             
             _handle = Sdl.Window.Create (title,
                 _winx - _width / 2, _winy - _height / 2,

--- a/MonoGame.Framework/Threading.cs
+++ b/MonoGame.Framework/Threading.cs
@@ -68,11 +68,9 @@ namespace Microsoft.Xna.Framework
         static int mainThreadId;
 #endif
 
-#if ANDROID || (WINDOWS && !DESKTOPGL) || ANGLE
+#if ANDROID || WINDOWS || DESKTOPGL || ANGLE
         static List<Action> actions = new List<Action>();
         //static Mutex actionsMutex = new Mutex();
-#elif DESKTOPGL
-        public static IntPtr BackgroundContext;
 #elif IOS
         public static EAGLContext BackgroundContext;
 #endif
@@ -187,11 +185,6 @@ namespace Microsoft.Xna.Framework
                 GL.Flush();
                 GraphicsExtensions.CheckGLError();
             }
-#elif DESKTOPGL
-            Sdl.GL.MakeCurrent (SdlGameWindow.Instance.Handle, BackgroundContext);
-            action ();
-            GL.Finish ();
-            GraphicsExtensions.CheckGLError ();
 #elif WINDOWS_PHONE
             BlockOnContainerThread(Deployment.Current.Dispatcher, action);
 #else
@@ -218,7 +211,7 @@ namespace Microsoft.Xna.Framework
 #endif
         }
 
-#if ANDROID || (WINDOWS && !DESKTOPGL) || ANGLE
+#if ANDROID || WINDOWS || DESKTOPGL || ANGLE
         static void Add(Action action)
         {
             lock (actions)


### PR DESCRIPTION
This PR is a follow up to #4927 discussion.

It reverts the use of a background context for loading OpenGL assets (which may expose uncontrollable GL driver issues if threaded), and adds thread blocking to texture reader so that all mipmap levels are loading during a single frame (instead of having to wait for the next frame to load the next mipmap level).

@KonajuGames Does this look good to you following the discussion?