### PR TITLE
New SetRenderTargets() method which allows for variable target count.

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Xna.Framework.Graphics
         internal void OnPresentationChanged()
         {
             CreateSizeDependentResources();
-            ApplyRenderTargets(null);
+            ApplyRenderTargets(null, 0);
         }
 
 #endif
@@ -834,7 +834,7 @@ namespace Microsoft.Xna.Framework.Graphics
         internal void OnPresentationChanged()
         {
             CreateSizeDependentResources();
-            ApplyRenderTargets(null);
+            ApplyRenderTargets(null, 0);
         }
 
 #endif // WINDOWS

--- a/MonoGame.Framework/GraphicsDeviceManager.Legacy.cs
+++ b/MonoGame.Framework/GraphicsDeviceManager.Legacy.cs
@@ -222,7 +222,7 @@ namespace Microsoft.Xna.Framework
 #endif
 			// Update the back buffer.
 			_graphicsDevice.CreateSizeDependentResources();
-            _graphicsDevice.ApplyRenderTargets(null);
+            _graphicsDevice.ApplyRenderTargets(null, 0);
 
 #if WINDOWS_UAP
             ((UAPGameWindow)_game.Window).SetClientSize(_preferredBackBufferWidth, _preferredBackBufferHeight);
@@ -246,7 +246,7 @@ namespace Microsoft.Xna.Framework
 
             // Update the back buffer.
             _graphicsDevice.CreateSizeDependentResources();
-            _graphicsDevice.ApplyRenderTargets(null);
+            _graphicsDevice.ApplyRenderTargets(null, 0);
 
             ((MonoGame.Framework.WinFormsGamePlatform)_game.Platform).ResetWindowBounds();
 
@@ -270,7 +270,7 @@ namespace Microsoft.Xna.Framework
                 swapInterval = 0;
             _graphicsDevice.Context.SwapInterval = swapInterval;
 
-            _graphicsDevice.ApplyRenderTargets (null);
+            _graphicsDevice.ApplyRenderTargets(null, 0);
 
             _game.Platform.BeginScreenDeviceChange (GraphicsDevice.PresentationParameters.IsFullScreen);
             _game.Platform.EndScreenDeviceChange (displayName, GraphicsDevice.PresentationParameters.BackBufferWidth, GraphicsDevice.PresentationParameters.BackBufferHeight);

--- a/MonoGame.Framework/SharedGraphicsDeviceManager.cs
+++ b/MonoGame.Framework/SharedGraphicsDeviceManager.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Xna.Framework
             else
             {
                 GraphicsDevice.CreateSizeDependentResources();
-                GraphicsDevice.ApplyRenderTargets(null);
+                GraphicsDevice.ApplyRenderTargets(null, 0);
             }
 
             // Set the new display size on the touch panel.

--- a/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
+++ b/MonoGame.Framework/Windows/WinFormsGamePlatform.cs
@@ -102,7 +102,7 @@ namespace MonoGame.Framework
             {
                  Game.GraphicsDevice.PresentationParameters.IsFullScreen = true;
                  Game.GraphicsDevice.CreateSizeDependentResources(true);
-                 Game.GraphicsDevice.ApplyRenderTargets(null);
+                 Game.GraphicsDevice.ApplyRenderTargets(null, 0);
                 _window._form.WindowState = FormWindowState.Maximized;
             }
             else
@@ -125,7 +125,7 @@ namespace MonoGame.Framework
                 _window._form.WindowState = FormWindowState.Normal;
                 Game.GraphicsDevice.PresentationParameters.IsFullScreen = false;
                 Game.GraphicsDevice.CreateSizeDependentResources(true);
-                Game.GraphicsDevice.ApplyRenderTargets(null);
+                Game.GraphicsDevice.ApplyRenderTargets(null, 0);
             }
             else
             {

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -221,7 +221,7 @@ namespace MonoGame.Framework
                    {
                        Game.GraphicsDevice.PresentationParameters.IsFullScreen = true;
                        Game.GraphicsDevice.CreateSizeDependentResources(true);
-                        Game.GraphicsDevice.ApplyRenderTargets(null);
+                        Game.GraphicsDevice.ApplyRenderTargets(null, 0);
                    }
                 }
           }


### PR DESCRIPTION
This is a follow up to https://github.com/mono/MonoGame/pull/4853.

I've added a new render target setting call:

```
public void SetRenderTargets(RenderTargetBinding[] renderTargets, int count)
```

This allows you to specify how many targets in the array to set which lets you more easily reuse the array.  For example:

```
const int MaxTargets = 4;
RenderTargetBinding[]  targets = new RenderTargetBinding[MaxTargets];
int targetsCount;

// Get the current targets.
targetsCount = device.RenderTargetCount;
device.GetRenderTargets(targets);

// Set some new targets.
targets[0] = someTarget;
targets[1] = otherTarget;
device.SetRenderTargets(targets, 2);
```

With this I also marked old garbage generating GetRenderTargets() and SetRenderTargets() as obsolete with a comment specifying they are there only for XNA compatibility.

Thoughts?