### PR TITLE
Fixed SoundEffect crash from latest XACT changes

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffectInstance.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffectInstance.XAudio.cs
@@ -305,6 +305,9 @@ namespace Microsoft.Xna.Framework.Audio
 
         internal void PlatformClearFilter()
         {
+            if (_voice == null)
+                return;
+
             var filter = new FilterParameters { Frequency = 1.0f, OneOverQ = 1.0f, Type = FilterType.LowPassFilter };
             _voice.SetFilterParameters(filter);            
         }


### PR DESCRIPTION
Fixed issue reported on the community site:

http://community.monogame.net/t/issues-with-latest-development-build/7903
