### PR TITLE
Reset effectMaterial.Effect to null so we do not try to serialize it.

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/MaterialProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/MaterialProcessor.cs
@@ -178,6 +178,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                 if (effectMaterial.Effect == null)
                     throw new PipelineException("EffectMaterialContent.Effect or EffectMaterialContent.CompiledEffect should be set for materials with a custom effect.");
                 effectMaterial.CompiledEffect = BuildEffect(effectMaterial.Effect, context);
+                effectMaterial.Effect = null;
                 // TODO: Docs say to validate OpaqueData for SetValue/SetValueTranspose
                 // Does that mean to match up with effect param names??
             }


### PR DESCRIPTION
There was a bug when serializing the effectMaterial.
After we had compiled the effect it was still trying
to serialize the actual Effect object as well not
just the CompiledEffect.
So we null it out after compilation to make sure
we dont serialize it.