### PR TITLE
Fixed initialization of GameComponent when created within another GameComponent

### DIFF
--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -92,6 +92,7 @@
 	<Compile Include="Framework\CurveKeyTest.cs" />
 	<Compile Include="Framework\CurveTest.cs" />
 	<Compile Include="Framework\EnumConformingTest.cs" />
+    <Compile Include="Framework\GameComponentTest.cs" />
     <Compile Include="Framework\GamePadStateTest.cs" />
     <Compile Include="Framework\GamePadThumbSticksTest.cs" />
     <Compile Include="Framework\GameTest.cs" />	
@@ -123,6 +124,7 @@
     <Compile Include="Framework\Components\FlexibleGameComponent.cs" />
     <Compile Include="Framework\Components\FrameCompareComponent.cs" />
     <Compile Include="Framework\Components\ImplicitDrawOrderComponent.cs" />
+    <Compile Include="Framework\Components\InitializeOrderComponent.cs" />
     <Compile Include="Framework\Components\PixelDeltaFrameComparer.cs" />
     <Compile Include="Framework\Components\Simple3DCubeComponent.cs" />
     <Compile Include="Framework\Components\SpaceshipModelDrawComponent.cs" />

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -719,12 +719,8 @@ namespace Microsoft.Xna.Framework
         //       Components.ComponentAdded.
         private void InitializeExistingComponents()
         {
-            // TODO: Would be nice to get rid of this copy, but since it only
-            //       happens once per game, it's fairly low priority.
-            var copy = new IGameComponent[Components.Count];
-            Components.CopyTo(copy, 0);
-            foreach (var component in copy)
-                component.Initialize();
+            for(int i = 0; i < Components.Count; ++i)
+                Components[i].Initialize();
         }
 
         private void CategorizeComponents()

--- a/Test/Framework/Components/InitializeOrderComponent.cs
+++ b/Test/Framework/Components/InitializeOrderComponent.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Xna.Framework;
+
+namespace MonoGame.Tests.Framework.Components
+{
+    class InitializeOrderComponent: GameComponent
+    {
+        static int g_initOrder = 0;
+
+        public int InitOrder { get; private set; }
+        public IGameComponent ChildComponent = null;
+
+        public InitializeOrderComponent(Game game):base(game)
+        {            
+            InitOrder = -1;
+        }
+
+        public override void Initialize()
+        {
+            if (ChildComponent != null)
+                Game.Components.Add(ChildComponent);
+
+            InitOrder = g_initOrder++;
+        }
+
+    }
+}

--- a/Test/Framework/GameComponentTest.cs
+++ b/Test/Framework/GameComponentTest.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Xna.Framework;
+using NUnit.Framework;
+using MonoGame.Tests.Framework.Components;
+
+namespace MonoGame.Tests.Framework
+{
+    public class GameComponentTest
+    {
+        [Test]
+        public void InitializeOrderTest()
+        {
+            var game = new TestGameBase();
+            var gdm = new GraphicsDeviceManager(game);
+            game.IsFixedTimeStep = false;
+            game.ExitCondition = x => x.UpdateNumber > 1;
+
+            var constructor2        = new InitializeOrderComponent(game);
+            var preBaseInitialize2  = new InitializeOrderComponent(game);
+            var postBaseInitialize2 = new InitializeOrderComponent(game);
+            var loadContent2        = new InitializeOrderComponent(game);
+            var update2             = new InitializeOrderComponent(game);
+            var constructor         = new InitializeOrderComponent(game) {ChildComponent = constructor2};
+            var preBaseInitialize   = new InitializeOrderComponent(game) {ChildComponent = preBaseInitialize2};
+            var postBaseInitialize  = new InitializeOrderComponent(game) {ChildComponent = postBaseInitialize2};
+            var loadContent         = new InitializeOrderComponent(game) {ChildComponent = loadContent2};
+            var update              = new InitializeOrderComponent(game) {ChildComponent = update2};
+            
+            game.Components.Add(constructor);
+            
+            game.PreInitializeWith += (sender, args) =>
+            {
+                game.Components.Add(preBaseInitialize);
+            };
+            game.InitializeWith += (sender, args) =>
+            {
+                game.Components.Add(postBaseInitialize);
+            };
+            game.PreLoadContentWith += (sender, args) =>
+            {
+                game.Components.Add(loadContent);
+            };
+            game.PreUpdateWith += (sender, args) =>
+            {
+                game.Components.Add(update);
+            };
+            game.Run();
+            game.Dispose();
+
+            Assert.That(constructor.InitOrder == 0);
+            Assert.That(preBaseInitialize.InitOrder == 1);
+            Assert.That(constructor2.InitOrder == 2);
+            Assert.That(preBaseInitialize2.InitOrder == 3);
+            Assert.That(update2.InitOrder == 4);
+            Assert.That(update.InitOrder == 5);
+            Assert.That(postBaseInitialize.InitOrder == -1);
+            Assert.That(postBaseInitialize2.InitOrder == -1);
+        }
+
+
+    }
+}

--- a/Test/Framework/TestGameBase.cs
+++ b/Test/Framework/TestGameBase.cs
@@ -110,6 +110,7 @@ namespace MonoGame.Tests {
 		public Predicate<FrameInfo> ExitCondition { get; set; }
 		public bool SuppressExtraUpdatesAndDraws { get; set; }
 
+		public event EventHandler<FrameInfoEventArgs> InitializeWith;
 		public event EventHandler<FrameInfoEventArgs> LoadContentWith;
 		public event EventHandler<FrameInfoEventArgs> UnloadContentWith;
 		public event EventHandler<FrameInfoEventArgs> DrawWith;
@@ -124,6 +125,7 @@ namespace MonoGame.Tests {
 
 		public void ClearActions ()
 		{
+			InitializeWith = null;
 			LoadContentWith = null;
 			UnloadContentWith = null;
 			DrawWith = null;
@@ -147,6 +149,7 @@ namespace MonoGame.Tests {
 		{
 			SafeRaise (PreInitializeWith);
 			base.Initialize ();
+			SafeRaise (InitializeWith);
 		}
 
 		protected override void LoadContent ()

--- a/Test/Framework/TestGameBase.cs
+++ b/Test/Framework/TestGameBase.cs
@@ -110,13 +110,13 @@ namespace MonoGame.Tests {
 		public Predicate<FrameInfo> ExitCondition { get; set; }
 		public bool SuppressExtraUpdatesAndDraws { get; set; }
 
-		public event EventHandler<FrameInfoEventArgs> InitializeWith;
 		public event EventHandler<FrameInfoEventArgs> LoadContentWith;
 		public event EventHandler<FrameInfoEventArgs> UnloadContentWith;
 		public event EventHandler<FrameInfoEventArgs> DrawWith;
 		public event EventHandler<FrameInfoEventArgs> UpdateWith;
 		public event EventHandler<FrameInfoEventArgs> UpdateOncePerDrawWith;
 
+		public event EventHandler<FrameInfoEventArgs> PreInitializeWith;
 		public event EventHandler<FrameInfoEventArgs> PreLoadContentWith;
 		public event EventHandler<FrameInfoEventArgs> PreUnloadContentWith;
 		public event EventHandler<FrameInfoEventArgs> PreDrawWith;
@@ -124,13 +124,13 @@ namespace MonoGame.Tests {
 
 		public void ClearActions ()
 		{
-			InitializeWith = null;
 			LoadContentWith = null;
 			UnloadContentWith = null;
 			DrawWith = null;
 			UpdateWith = null;
 			UpdateOncePerDrawWith = null;
 
+			PreInitializeWith = null;
 			PreLoadContentWith = null;
 			PreUnloadContentWith = null;
 			PreDrawWith = null;
@@ -145,7 +145,7 @@ namespace MonoGame.Tests {
 
 		protected override void Initialize ()
 		{
-			SafeRaise (InitializeWith);
+			SafeRaise (PreInitializeWith);
 			base.Initialize ();
 		}
 

--- a/Test/Framework/Visual/DepthStencilStateTest.cs
+++ b/Test/Framework/Visual/DepthStencilStateTest.cs
@@ -82,7 +82,7 @@ namespace MonoGame.Tests.Visual
         {
             var cube = new Simple3DCubeComponent(Game);
 
-            Game.InitializeWith += (sender, e) =>
+            Game.PreInitializeWith += (sender, e) =>
             {
                 cube.Initialize();
             };
@@ -112,7 +112,7 @@ namespace MonoGame.Tests.Visual
         {
             var cube = new Simple3DCubeComponent(Game);
 
-            Game.InitializeWith += (sender, e) =>
+            Game.PreInitializeWith += (sender, e) =>
             {
                 cube.Initialize();
             };

--- a/Test/Framework/Visual/GraphicsDeviceManagerTest.cs
+++ b/Test/Framework/Visual/GraphicsDeviceManagerTest.cs
@@ -94,7 +94,7 @@ namespace MonoGame.Tests.Visual
             Texture2D tex = null;
             SpriteBatch spriteBatch = null;
 
-            game.InitializeWith += (sender, args) =>
+            game.PreInitializeWith += (sender, args) =>
             {
                 tex = new Texture2D(game.GraphicsDevice, 1, 1);
                 tex.SetData(new[] { Color.White.PackedValue });

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Framework\Components\DrawFrameNumberComponent.cs" />
     <Compile Include="Framework\Components\FlexibleGameComponent.cs" />
     <Compile Include="Framework\Components\ImplicitDrawOrderComponent.cs" />
+    <Compile Include="Framework\Components\InitializeOrderComponent.cs" />
     <Compile Include="Framework\Components\Simple3DCubeComponent.cs" />
     <Compile Include="Framework\Components\VisualTestGameComponent.cs" />
     <Compile Include="Framework\Components\VisualTestDrawableGameComponent.cs" />
@@ -116,6 +117,7 @@
     <Compile Include="Framework\CurveKeyTest.cs" />
     <Compile Include="Framework\CurveTest.cs" />
     <Compile Include="Framework\EnumConformingTest.cs" />
+    <Compile Include="Framework\GameComponentTest.cs" />
     <Compile Include="Framework\GamePadStateTest.cs" />
     <Compile Include="Framework\GamePadThumbSticksTest.cs" />
     <Compile Include="Framework\MatrixTest.cs" />


### PR DESCRIPTION
Fixes https://github.com/mono/MonoGame/issues/2943

Test file 
[ComponentTest.zip](https://github.com/mono/MonoGame/files/376393/ComponentTest.zip)
based on 
http://pastebin.com/bDG4yZUG

output: 
    Constructor - Initialize
    Initialize (pre-base.Initialize) - Initialize
    Constructor- 2 - Initialize
    Initialize (pre-base.Initialize)- 2 - Initialize
    BeginRun- 2 - Initialize
    BeginRun - Initialize
    Update- 2 - Initialize
    Update - Initialize
    Draw- 2 - Initialize
    Draw - Initialize

Note: removing a component during .Initialize() will have unpredictable results.