### PR TITLE
DynamicSoundEffectInstance is added to all platforms by default

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -378,18 +378,17 @@
     <Compile Include="Audio\AudioLoader.cs">
       <Platforms>Linux,WindowsGL,Angle,Android,Ouya</Platforms>
     </Compile>
-	<Compile Include="Audio\DynamicSoundEffectInstance.cs">
-	  <Services>OpenALAudio,XAudioAudio</Services>
-	</Compile>
+	<Compile Include="Audio\DynamicSoundEffectInstance.cs" />
 	<Compile Include="Audio\DynamicSoundEffectInstance.OpenAL.cs">
 	  <Services>OpenALAudio</Services>
 	</Compile>
 	<Compile Include="Audio\DynamicSoundEffectInstance.XAudio.cs">
 	  <Services>XAudioAudio</Services>
 	</Compile>
-	<Compile Include="Audio\DynamicSoundEffectInstanceManager.cs">
-	  <Services>OpenALAudio,XAudioAudio</Services>
-	</Compile>
+    <Compile Include="Audio\DynamicSoundEffectInstance.Web.cs">
+	  <Services>WebAudio</Services>
+    </Compile>
+	<Compile Include="Audio\DynamicSoundEffectInstanceManager.cs" />
     <Compile Include="Audio\InstancePlayLimitException.cs" />
     <Compile Include="Audio\MSADPCMToPCM.cs">
       <Platforms>Android,Angle,iOS,Linux,MacOS,Ouya,WindowsGL,Web,tvOS</Platforms>

--- a/MonoGame.Framework/Audio/DynamicSoundEffectInstance.Web.cs
+++ b/MonoGame.Framework/Audio/DynamicSoundEffectInstance.Web.cs
@@ -1,0 +1,48 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+
+namespace Microsoft.Xna.Framework.Audio
+{
+    public sealed partial class DynamicSoundEffectInstance : SoundEffectInstance
+    {
+        private void PlatformCreate()
+        {
+        }
+
+        private int PlatformGetPendingBufferCount()
+        {
+            return 0;
+        }
+
+        private void PlatformPlay()
+        {
+        }
+
+        private void PlatformPause()
+        {
+        }
+
+        private void PlatformResume()
+        {
+        }
+
+        private void PlatformStop()
+        {
+        }
+
+        private void PlatformSubmitBuffer(byte[] buffer, int offset, int count)
+        {
+        }
+
+        private void PlatformDispose(bool disposing)
+        {
+        }
+
+        private void PlatformUpdateQueue()
+        {
+        }
+    }
+}

--- a/MonoGame.Framework/Audio/DynamicSoundEffectInstanceManager.cs
+++ b/MonoGame.Framework/Audio/DynamicSoundEffectInstanceManager.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Xna.Framework.Audio
     /// </summary>
     internal static class DynamicSoundEffectInstanceManager
     {
-        private static List<WeakReference> _playingInstances;
+        private static readonly List<WeakReference> _playingInstances;
 
         static DynamicSoundEffectInstanceManager()
         {

--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -651,9 +651,8 @@ namespace Microsoft.Xna.Framework
                 // playing sounds to see if they've stopped,
                 // and return them back to the pool if so.
                 SoundEffectInstancePool.Update();
-#if DIRECTX || OPENGL
+
                 DynamicSoundEffectInstanceManager.UpdatePlayingInstances();
-#endif
 
                 Update(gameTime);
 


### PR DESCRIPTION
`DynamicSoundEffectInstance` was only set to be added on DirectX and OpenAL platforms.... this adds it by default on all platforms.