### PR TITLE
Implemented GraphicsAdapter for DirectX platforms

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -604,7 +604,15 @@
 		<ExcludePlatforms>Web</ExcludePlatforms>
     </Compile>
     <Compile Include="Graphics\Effect\SpriteEffect.cs" />
-    <Compile Include="Graphics\GraphicsAdapter.cs" />
+    <Compile Include="Graphics\GraphicsAdapter.cs">
+      <ExcludePlatforms>Android,Angle,iOS,Linux,MacOS,Ouya,WindowsGL,tvOS,Web</ExcludePlatforms>
+    </Compile>
+    <Compile Include="Graphics\GraphicsAdapter.DirectX.cs">
+      <Services>DirectXGraphics</Services>
+    </Compile>
+    <Compile Include="Graphics\GraphicsAdapter.Legacy.cs">
+      <Platforms>Android,Angle,iOS,Linux,MacOS,Ouya,WindowsGL,tvOS,Web</Platforms>
+    </Compile>
     <Compile Include="Graphics\GraphicsCapabilities.cs" />
     <Compile Include="Graphics\GraphicsContext.SDL.cs">
       <Platforms>WindowsGL,Linux</Platforms>

--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -98,6 +98,7 @@
     <Compile Include="Framework\GameTest+Methods.cs" />
     <Compile Include="Framework\GameTest+Properties.cs" />
     <Compile Include="Framework\GestureRecognizerTest.cs" />
+    <Compile Include="Framework\GraphicsAdapterTest.cs" />
     <Compile Include="Framework\MathHelperTest.cs" />
 	<Compile Include="Framework\MatrixTest.cs" />
     <Compile Include="Framework\MockWindow.cs" />

--- a/MonoGame.Framework/Graphics/DisplayMode.cs
+++ b/MonoGame.Framework/Graphics/DisplayMode.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         public override string ToString()
         {
-            return "{{Width:" + this.width + " Height:" + this.height + " Format:" + this.Format + "}}";
+            return "{Width:" + this.width + " Height:" + this.height + " Format:" + this.Format + " AspectRatio:" + this.AspectRatio + "}";
         }
 
         #endregion Public Methods

--- a/MonoGame.Framework/Graphics/DisplayModeCollection.cs
+++ b/MonoGame.Framework/Graphics/DisplayModeCollection.cs
@@ -33,38 +33,49 @@ using System.Collections.Generic;
 
 namespace Microsoft.Xna.Framework.Graphics
 {
-    public class DisplayModeCollection : IEnumerable<DisplayMode>, IEnumerable
+    public class DisplayModeCollection : IEnumerable<DisplayMode>
     {
-        private readonly List<DisplayMode> modes;
+        private readonly List<DisplayMode> _modes;
 
         public IEnumerable<DisplayMode> this[SurfaceFormat format]
         {
-            get {
-                List<DisplayMode> list = new List<DisplayMode>();
-                foreach (DisplayMode mode in this.modes)
+            get 
+            {
+                var list = new List<DisplayMode>();
+                foreach (var mode in _modes)
                 {
                     if (mode.Format == format)
-                    {
                         list.Add(mode);
-                    }
                 }
                 return list;
-
             }
         }
 
         public IEnumerator<DisplayMode> GetEnumerator()
         {
-            return modes.GetEnumerator();
+            return _modes.GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return modes.GetEnumerator();
+            return _modes.GetEnumerator();
         }
         
-        public DisplayModeCollection(List<DisplayMode> setmodes) {
-            modes = setmodes;
+        internal DisplayModeCollection(List<DisplayMode> modes) 
+        {
+            // Sort the modes in a consistent way that happens
+            // to match XNA behavior on some graphics devices.
+
+            modes.Sort(delegate(DisplayMode a, DisplayMode b)
+            {
+                if (a == b) 
+                    return 0;
+                if (a.Format <= b.Format && a.Width <= b.Width && a.Height <= b.Height) 
+                    return -1;
+                return 1;
+            });
+
+            _modes = modes;
         }
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.DirectX.cs
@@ -1,0 +1,114 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    partial class GraphicsAdapter
+    {
+        private static void PlatformInitializeAdapters(out ReadOnlyCollection<GraphicsAdapter> adapters)
+        {
+            var factory = new SharpDX.DXGI.Factory1();
+
+            var adapterCount = factory.GetAdapterCount();
+            var adapterList = new List<GraphicsAdapter>(adapterCount);
+
+            for (var i = 0; i < adapterCount; i++)
+            {
+                var device = factory.GetAdapter1(i);
+
+                var monitorCount = device.GetOutputCount();
+                for (var j = 0; j < monitorCount; j++)
+                {
+                    var monitor = device.GetOutput(j);
+
+                    var adapter = CreateAdapter(device, monitor);
+                    adapterList.Add(adapter);
+
+                    monitor.Dispose();
+                }
+
+                device.Dispose();
+            }
+
+            factory.Dispose();
+
+            adapters = new ReadOnlyCollection<GraphicsAdapter>(adapterList);
+        }
+
+        private static readonly Dictionary<SharpDX.DXGI.Format, SurfaceFormat> FormatTranslations = new Dictionary<SharpDX.DXGI.Format, SurfaceFormat>
+        {
+            { SharpDX.DXGI.Format.R8G8B8A8_UNorm, SurfaceFormat.Color },
+            { SharpDX.DXGI.Format.B8G8R8A8_UNorm, SurfaceFormat.Color },
+            { SharpDX.DXGI.Format.B5G6R5_UNorm, SurfaceFormat.Bgr565 },
+        };
+
+        private static GraphicsAdapter CreateAdapter(SharpDX.DXGI.Adapter1 device, SharpDX.DXGI.Output monitor)
+        {            
+            var adapter = new GraphicsAdapter();
+
+            adapter.DeviceName = monitor.Description.DeviceName;
+            adapter.Description = device.Description1.Description;
+            adapter.DeviceId = device.Description1.DeviceId;
+            adapter.Revision = device.Description1.Revision;
+            adapter.VendorId = device.Description1.VendorId;
+            adapter.SubSystemId = device.Description1.SubsystemId;
+            adapter.MonitorHandle = monitor.Description.MonitorHandle;
+
+#if WINDOWS_UAP
+            var desktopWidth = monitor.Description.DesktopBounds.Right - monitor.Description.DesktopBounds.Left;
+            var desktopHeight = monitor.Description.DesktopBounds.Bottom - monitor.Description.DesktopBounds.Top;
+#else
+            var desktopWidth = monitor.Description.DesktopBounds.Width;
+            var desktopHeight = monitor.Description.DesktopBounds.Height;
+#endif
+
+            var modes = new List<DisplayMode>();
+
+            foreach (var formatTranslation in FormatTranslations)
+            {
+                SharpDX.DXGI.ModeDescription[] displayModes;
+
+                // This can fail on headless machines, so just assume the desktop size
+                // is a valid mode and return that... so at least our unit tests work.
+                try
+                {
+                    displayModes = monitor.GetDisplayModeList(formatTranslation.Key, 0);
+                }
+                catch (SharpDX.SharpDXException ex)
+                {
+                    var mode = new DisplayMode(desktopWidth, desktopHeight, SurfaceFormat.Color);
+                    modes.Add(mode);
+                    adapter._currentDisplayMode = mode;
+                    break;
+                }
+
+
+                foreach (var displayMode in displayModes)
+                {
+                    var mode = new DisplayMode(displayMode.Width, displayMode.Height, formatTranslation.Value);
+
+                    // Skip duplicate modes with the same width/height/formats.
+                    if (modes.Contains(mode))
+                        continue;
+
+                    modes.Add(mode);
+
+                    if (mode.Width == desktopWidth && mode.Height == desktopHeight && mode.Format == SurfaceFormat.Color)
+                    {
+                        if (adapter._currentDisplayMode == null)
+                            adapter._currentDisplayMode = mode;
+                    }
+                }
+            }
+
+            adapter._supportedDisplayModes = new DisplayModeCollection(modes);
+
+            return adapter;
+        }
+    }
+}

--- a/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
+++ b/MonoGame.Framework/Graphics/GraphicsAdapter.Legacy.cs
@@ -1,0 +1,386 @@
+// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+#if MONOMAC
+#if PLATFORM_MACOS_LEGACY
+using MonoMac.AppKit;
+using MonoMac.Foundation;
+#else
+using AppKit;
+using Foundation;
+#endif
+#elif IOS
+using UIKit;
+#elif ANDROID
+using Android.Views;
+using Android.Runtime;
+#endif
+
+// NOTE: This is the legacy graphics adapter implementation
+// which should no longer be updated.  All new development
+// should go into the new one.
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    public sealed class GraphicsAdapter : IDisposable
+    {
+        /// <summary>
+        /// Defines the driver type for graphics adapter. Usable only on DirectX platforms for now.
+        /// </summary>
+        public enum DriverType
+        {
+            /// <summary>
+            /// Hardware device been used for rendering. Maximum speed and performance.
+            /// </summary>
+            Hardware,
+            /// <summary>
+            /// Emulates the hardware device on CPU. Slowly, only for testing.
+            /// </summary>
+            Reference,
+            /// <summary>
+            /// Useful when <see cref="DriverType.Hardware"/> acceleration does not work.
+            /// </summary>
+            FastSoftware
+        }
+
+        private static ReadOnlyCollection<GraphicsAdapter> _adapters;
+
+        private DisplayModeCollection _supportedDisplayModes;
+
+
+#if MONOMAC
+		private NSScreen _screen;
+        internal GraphicsAdapter(NSScreen screen)
+        {
+            _screen = screen;
+        }
+#elif IOS
+		private UIScreen _screen;
+        internal GraphicsAdapter(UIScreen screen)
+        {
+            _screen = screen;
+        }
+#elif DESKTOPGL
+        int _displayIndex;
+#else
+        internal GraphicsAdapter()
+        {
+        }
+#endif
+
+        public void Dispose()
+        {
+        }
+
+        public DisplayMode CurrentDisplayMode
+        {
+            get
+            {
+#if MONOMAC
+                //Dummy values until MonoMac implements Quartz Display Services
+                SurfaceFormat format = SurfaceFormat.Color;
+                
+                return new DisplayMode((int)_screen.Frame.Width,
+                                       (int)_screen.Frame.Height,
+                                       format);
+#elif IOS
+                return new DisplayMode((int)(_screen.Bounds.Width * _screen.Scale),
+                       (int)(_screen.Bounds.Height * _screen.Scale),
+                       SurfaceFormat.Color);
+#elif ANDROID
+                View view = ((AndroidGameWindow)Game.Instance.Window).GameView;
+                return new DisplayMode(view.Width, view.Height, SurfaceFormat.Color);
+#elif DESKTOPGL
+                var displayIndex = Sdl.Display.GetWindowDisplayIndex(SdlGameWindow.Instance.Handle);
+
+                Sdl.Display.Mode mode;
+                Sdl.Display.GetCurrentDisplayMode(displayIndex, out mode);
+
+                return new DisplayMode(mode.Width, mode.Height, SurfaceFormat.Color);
+#elif WINDOWS
+                using (var graphics = System.Drawing.Graphics.FromHwnd(IntPtr.Zero))
+                {
+                    var dc = graphics.GetHdc();
+                    int width = GetDeviceCaps(dc, HORZRES);
+                    int height = GetDeviceCaps(dc, VERTRES);
+                    graphics.ReleaseHdc(dc);
+                    return new DisplayMode(width, height, SurfaceFormat.Color);
+                }
+#else
+                return new DisplayMode(800, 600, SurfaceFormat.Color);
+#endif
+            }
+        }
+
+        public static GraphicsAdapter DefaultAdapter
+        {
+            get { return Adapters[0]; }
+        }
+
+        public static ReadOnlyCollection<GraphicsAdapter> Adapters
+        {
+            get
+            {
+                if (_adapters == null)
+                {
+#if MONOMAC
+                    GraphicsAdapter[] tmpAdapters = new GraphicsAdapter[NSScreen.Screens.Length];
+                    for (int i=0; i<NSScreen.Screens.Length; i++) {
+                        tmpAdapters[i] = new GraphicsAdapter(NSScreen.Screens[i]);
+                    }
+                    
+                    _adapters = new ReadOnlyCollection<GraphicsAdapter>(tmpAdapters);
+#elif IOS
+					_adapters = new ReadOnlyCollection<GraphicsAdapter>(
+						new [] {new GraphicsAdapter(UIScreen.MainScreen)});
+#else
+                    _adapters = new ReadOnlyCollection<GraphicsAdapter>(new[] { new GraphicsAdapter() });
+#endif
+                }
+
+                return _adapters;
+            }
+        }
+
+        /// <summary>
+        /// Used to request creation of the reference graphics device, 
+        /// or the default hardware accelerated device (when set to false).
+        /// </summary>
+        /// <remarks>
+        /// This only works on DirectX platforms where a reference graphics
+        /// device is available and must be defined before the graphics device
+        /// is created. It defaults to false.
+        /// </remarks>
+        public static bool UseReferenceDevice
+        {
+            get { return UseDriverType == DriverType.Reference; }
+            set { UseDriverType = value ? DriverType.Reference : DriverType.Hardware; }
+        }
+
+        /// <summary>
+        /// Used to request creation of a specific kind of driver.
+        /// </summary>
+        /// <remarks>
+        /// These values only work on DirectX platforms and must be defined before the graphics device
+        /// is created. <see cref="DriverType.Hardware"/> by default.
+        /// </remarks>
+        public static DriverType UseDriverType { get; set; }
+
+        /*
+		public bool QueryRenderTargetFormat(
+			GraphicsProfile graphicsProfile,
+			SurfaceFormat format,
+			DepthFormat depthFormat,
+			int multiSampleCount,
+			out SurfaceFormat selectedFormat,
+			out DepthFormat selectedDepthFormat,
+			out int selectedMultiSampleCount)
+		{
+			throw new NotImplementedException();
+		}
+
+        public string Description
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public int DeviceId
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public Guid DeviceIdentifier
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public string DeviceName
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public string DriverDll
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public Version DriverVersion
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public bool IsDefaultAdapter
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public bool IsWideScreen
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public IntPtr MonitorHandle
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public int Revision
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public int SubSystemId
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+        */
+
+#if DIRECTX && !WINDOWS_PHONE
+        private static readonly Dictionary<SharpDX.DXGI.Format, SurfaceFormat> FormatTranslations = new Dictionary<SharpDX.DXGI.Format, SurfaceFormat>
+            {
+                { SharpDX.DXGI.Format.R8G8B8A8_UNorm, SurfaceFormat.Color },
+                { SharpDX.DXGI.Format.B8G8R8A8_UNorm, SurfaceFormat.Color },
+                { SharpDX.DXGI.Format.B5G6R5_UNorm, SurfaceFormat.Bgr565 },
+            };
+#endif
+
+        public DisplayModeCollection SupportedDisplayModes
+        {
+            get
+            {
+                bool displayChanged = false;
+#if DESKTOPGL
+                var displayIndex = Sdl.Display.GetWindowDisplayIndex (SdlGameWindow.Instance.Handle);
+                displayChanged = displayIndex != _displayIndex;
+#endif
+                if (_supportedDisplayModes == null || displayChanged)
+                {
+                    var modes = new List<DisplayMode>(new[] { CurrentDisplayMode, });
+
+#if DESKTOPGL
+                    _displayIndex = displayIndex;
+                    modes.Clear();
+                    
+                    var modeCount = Sdl.Display.GetNumDisplayModes(displayIndex);
+
+                    for (int i = 0;i < modeCount;i++)
+                    {
+                        Sdl.Display.Mode mode;
+                        Sdl.Display.GetDisplayMode(displayIndex, i, out mode);
+
+                        // We are only using one format, Color
+                        // mode.Format gets the Color format from SDL
+                        var displayMode = new DisplayMode(mode.Width, mode.Height, SurfaceFormat.Color);
+                        if (!modes.Contains(displayMode))
+                            modes.Add(displayMode);
+                    }
+#elif DIRECTX && !WINDOWS_PHONE
+                    var dxgiFactory = new SharpDX.DXGI.Factory1();
+                    var adapter = dxgiFactory.GetAdapter(0);
+                    var output = adapter.Outputs[0];
+
+                    modes.Clear();
+                    foreach (var formatTranslation in FormatTranslations)
+                    {
+                        var displayModes = output.GetDisplayModeList(formatTranslation.Key, 0);
+                        foreach (var displayMode in displayModes)
+                        {
+                            var xnaDisplayMode = new DisplayMode(displayMode.Width, displayMode.Height, formatTranslation.Value);
+                            if (!modes.Contains(xnaDisplayMode))
+                                modes.Add(xnaDisplayMode);
+                        }
+                    }
+
+                    output.Dispose();
+                    adapter.Dispose();
+                    dxgiFactory.Dispose();
+#endif
+                    modes.Sort(delegate(DisplayMode a, DisplayMode b)
+                    {
+                        if (a == b) return 0;
+                        if (a.Format <= b.Format && a.Width <= b.Width && a.Height <= b.Height) return -1;
+                        else return 1;
+                    });
+                    _supportedDisplayModes = new DisplayModeCollection(modes);
+                }
+
+                return _supportedDisplayModes;
+            }
+        }
+
+        /*
+        public int VendorId
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+        */
+
+        /// <summary>
+        /// Gets a <see cref="System.Boolean"/> indicating whether
+        /// <see cref="GraphicsAdapter.CurrentDisplayMode"/> has a
+        /// Width:Height ratio corresponding to a widescreen <see cref="DisplayMode"/>.
+        /// Common widescreen modes include 16:9, 16:10 and 2:1.
+        /// </summary>
+        public bool IsWideScreen
+        {
+            get
+            {
+                // Common non-widescreen modes: 4:3, 5:4, 1:1
+                // Common widescreen modes: 16:9, 16:10, 2:1
+                // XNA does not appear to account for rotated displays on the desktop
+                const float limit = 4.0f / 3.0f;
+                var aspect = CurrentDisplayMode.AspectRatio;
+                return aspect > limit;
+            }
+        }
+
+#if WINDOWS && !OPENGL
+        [System.Runtime.InteropServices.DllImport("gdi32.dll", CharSet = System.Runtime.InteropServices.CharSet.Auto, SetLastError = true, ExactSpelling = true)]
+        public static extern int GetDeviceCaps(IntPtr hDC, int nIndex);
+
+        private const int HORZRES = 8;
+        private const int VERTRES = 10;
+#endif
+    }
+}

--- a/Test/Framework/GraphicsAdapterTest.cs
+++ b/Test/Framework/GraphicsAdapterTest.cs
@@ -1,0 +1,96 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Linq;
+using Microsoft.Xna.Framework.Graphics;
+using NUnit.Framework;
+
+// HACK: Only enable for XNA and DirectX which are the 
+// only platforms which currently correctly implement 
+// the GraphicsAdapter API.
+#if XNA || DIRECTX
+
+namespace MonoGame.Tests.Framework
+{
+    class GraphicsAdapterTest
+    {
+        private static bool Equals(DisplayMode m1, DisplayMode m2)
+        {
+            return m1.Width == m2.Width &&
+                   m1.Height == m2.Height &&
+                   m1.Format == m2.Format &&
+                   m1.AspectRatio == m2.AspectRatio &&
+                   m1.TitleSafeArea == m2.TitleSafeArea;
+        }
+
+        [Test]
+        public static void Adapters()
+        {
+            var adapters = GraphicsAdapter.Adapters;
+            Assert.IsNotNull(adapters);
+            Assert.GreaterOrEqual(adapters.Count, 1);
+
+            var defaultAdapterCount = 0;
+
+            foreach (var adapter in adapters)
+            {
+                Assert.IsNotNull(adapter);
+
+                if (adapter.IsDefaultAdapter)
+                    defaultAdapterCount++;
+                Assert.LessOrEqual(defaultAdapterCount, 1);
+
+                Assert.IsNotNullOrEmpty(adapter.DeviceName);
+                Assert.IsNotNullOrEmpty(adapter.Description);
+                Assert.AreNotEqual(0, adapter.DeviceId);
+                Assert.AreNotEqual(IntPtr.Zero, adapter.MonitorHandle);
+                Assert.AreNotEqual(0, adapter.VendorId);
+                Assert.GreaterOrEqual(adapter.SubSystemId, 0);
+                Assert.GreaterOrEqual(adapter.Revision, 0);
+
+                Assert.IsNotNull(adapter.CurrentDisplayMode); 
+                Assert.IsNotNull(adapter.SupportedDisplayModes);
+                Assert.GreaterOrEqual(adapter.SupportedDisplayModes.Count(), 1);
+                Assert.AreEqual(1, adapter.SupportedDisplayModes.Count(m => Equals(m, adapter.CurrentDisplayMode)));
+
+                // Seems like XNA treats aspect ratios above 16:10 as wide screen.
+                const float minWideScreenAspect = 16.0f / 10.0f;
+                var isWidescreen = adapter.CurrentDisplayMode.AspectRatio >= minWideScreenAspect;
+                Assert.AreEqual(isWidescreen, adapter.IsWideScreen); 
+
+                foreach (var mode in adapter.SupportedDisplayModes)
+                {
+                    Assert.Greater(mode.Width, 0);
+                    Assert.LessOrEqual(mode.Width, 3840);
+                    Assert.Greater(mode.Height, 0);
+                    Assert.LessOrEqual(mode.Height, 3840);
+
+                    var aspect = mode.Width / (float)mode.Height;
+                    Assert.AreEqual(aspect, mode.AspectRatio);
+
+                    Assert.GreaterOrEqual((int)mode.Format, 0);
+
+                    Assert.GreaterOrEqual(mode.TitleSafeArea.Left, 0);
+                    Assert.GreaterOrEqual(mode.TitleSafeArea.Top, 0);
+                    Assert.Less(mode.TitleSafeArea.Left, mode.TitleSafeArea.Right);
+                    Assert.Less(mode.TitleSafeArea.Top, mode.TitleSafeArea.Bottom);
+                    Assert.LessOrEqual(mode.TitleSafeArea.Width, mode.Width);
+                    Assert.LessOrEqual(mode.TitleSafeArea.Height, mode.Height);
+                }
+            }
+        }
+
+        [Test]
+        public static void DefaultAdapter()
+        {
+            var adapter = GraphicsAdapter.DefaultAdapter;
+            Assert.IsNotNull(adapter);
+            Assert.IsTrue(adapter.IsDefaultAdapter);
+            Assert.Contains(adapter, GraphicsAdapter.Adapters);
+        }
+    }
+}
+
+#endif // XNA || DIRECTX

--- a/Test/MonoGame.Tests.XNA.csproj
+++ b/Test/MonoGame.Tests.XNA.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Framework\EnumConformingTest.cs" />
     <Compile Include="Framework\GamePadStateTest.cs" />
     <Compile Include="Framework\GamePadThumbSticksTest.cs" />
+    <Compile Include="Framework\GraphicsAdapterTest.cs" />
     <Compile Include="Framework\MatrixTest.cs" />
     <Compile Include="Framework\PackedVectorTest.cs" />
     <Compile Include="Framework\PlaneTest.cs" />


### PR DESCRIPTION
This PR cleans up `GraphicsAdapter` into a partial class allowing for other platforms to cleanly extend it.

Added unit tests to verify the DirectX implementation matches XNA behavior.

Left old implementation of `GraphicsAdapter` in legacy file that is used on the other public platforms.  We should start replacing these with correct partial implementations.
