### PR TITLE
Add NVorbis Protobuild Module

### DIFF
--- a/Build/Module.xml
+++ b/Build/Module.xml
@@ -11,5 +11,6 @@
   <Packages>
     <Package Uri="https-git://github.com/OutOfOrder/MonoKickstart.git" Folder="ThirdParty/Kickstart" GitRef="master" />
     <Package Uri="https-git://github.com/Mono-Game/MonoGame.Dependencies.git" Folder="ThirdParty/Dependencies" GitRef="master" />
+    <Package Uri="https-git://github.com/ioctlLR/NVorbis.git" Folder="ThirdParty/NVorbis" GitRef="master" />
   </Packages>
 </Module>


### PR DESCRIPTION
Just so people don't have to run the submodule commands (tho I would still recommend them because Protobuild doesn't clone git repo the same way git command does).