### PR TITLE
XAudio copy audio buffers

### DIFF
--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -158,10 +158,20 @@ namespace Microsoft.Xna.Framework.Audio
             }
         }
 
+        private static DataStream ToDataStream(int offset, byte[] buffer, int length)
+        {
+            // NOTE: We make a copy here because old versions of 
+            // DataStream.Create didn't work correctly for offsets.
+            var data = new byte[length - offset];
+            Buffer.BlockCopy(buffer, offset, data, 0, length - offset);
+
+            return DataStream.Create(data, true, false);
+        }
+
         private void PlatformInitializePcm(byte[] buffer, int offset, int count, int sampleRate, AudioChannels channels, int loopStart, int loopLength)
         {
             CreateBuffers(  new WaveFormat(sampleRate, (int)channels),
-                            DataStream.Create(buffer, true, false, offset),
+                            ToDataStream(offset, buffer, count),
                             loopStart, 
                             loopLength);
         }
@@ -182,7 +192,7 @@ namespace Microsoft.Xna.Framework.Audio
                 throw new NotSupportedException("Unsupported wave format!");
 
             CreateBuffers(  waveFormat,
-                            DataStream.Create(buffer, true, false),
+                            ToDataStream(0, buffer, bufferSize),
                             loopStart,
                             loopLength);
         }
@@ -194,7 +204,7 @@ namespace Microsoft.Xna.Framework.Audio
                 duration = TimeSpan.FromSeconds((float)loopLength / sampleRate);
 
                 CreateBuffers(  new WaveFormatAdpcm(sampleRate, channels, blockAlignment),
-                                DataStream.Create(buffer, true, false),
+                                ToDataStream(0, buffer, buffer.Length),
                                 loopStart,
                                 loopLength);
 


### PR DESCRIPTION
This addresses a bug reported by @cra0zy in https://github.com/mono/MonoGame/pull/5006#issuecomment-236380478.

This also avoids what i think is a bug in SharpDX (https://github.com/sharpdx/SharpDX/issues/785).
