### PR TITLE
Dispose of all SFX in tests to avoid crashing

### DIFF
--- a/Test/Framework/Audio/DynamicSoundEffectInstanceTest.cs
+++ b/Test/Framework/Audio/DynamicSoundEffectInstanceTest.cs
@@ -151,18 +151,27 @@ namespace MonoGame.Tests.Audio
         {
             // Valid sample rates
             var instance = new DynamicSoundEffectInstance(48000, AudioChannels.Stereo);
+            instance.Dispose();
             instance = new DynamicSoundEffectInstance(8000, AudioChannels.Stereo);
+            instance.Dispose();
 
             // Invalid sample rates
             Assert.Throws<ArgumentOutOfRangeException>(() => { instance = new DynamicSoundEffectInstance(7999, AudioChannels.Stereo); });
+            if (instance != null) instance.Dispose();
             Assert.Throws<ArgumentOutOfRangeException>(() => { instance = new DynamicSoundEffectInstance(48001, AudioChannels.Stereo); });
+            if (instance != null) instance.Dispose();
 
             // Valid channel counts
             instance = new DynamicSoundEffectInstance(44100, AudioChannels.Mono);
+            instance.Dispose();
+
             instance = new DynamicSoundEffectInstance(44100, AudioChannels.Stereo);
+            instance.Dispose();
 
             // Invalid channel count
             Assert.Throws<ArgumentOutOfRangeException>(() => { instance = new DynamicSoundEffectInstance(44100, (AudioChannels)123); });
+            if (instance != null) instance.Dispose();
+
         }
 
         [Test]
@@ -188,6 +197,8 @@ namespace MonoGame.Tests.Audio
             // Disposed
             monoInstance.Dispose();
             Assert.Throws<ObjectDisposedException>(() => { monoInstance.GetSampleDuration(0); });
+
+            stereoInstance.Dispose();
         }
 
         [Test]
@@ -210,6 +221,8 @@ namespace MonoGame.Tests.Audio
             // Disposed
             monoInstance.Dispose();
             Assert.Throws<ObjectDisposedException>(() => { monoInstance.GetSampleSizeInBytes(TimeSpan.Zero); });
+
+            stereoInstance.Dispose();
         }
 
         [Test]


### PR DESCRIPTION
Fixes #5042. 

Trying to dispose XAudio's MasterVoice when not all SFX are disposed caused this crash. This properly disposes of all DynamicSoundEffectInstances in the tests. Maybe dynamic sound effects also be added to some static collection so they can always be properly disposed?